### PR TITLE
Implement Jotai for Persistent Wallet Session & Hydration Fix

### DIFF
--- a/frontend-template/package.json
+++ b/frontend-template/package.json
@@ -14,7 +14,8 @@
     "@stacks/connect": "^8",
     "@stacks/transactions": "^7",
     "@stacks/network": "^6",
-    "pino-pretty": "^11"
+    "pino-pretty": "^11",
+    "jotai": "^2.19.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/frontend-template/src/app/page.tsx
+++ b/frontend-template/src/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
     <main className="min-h-screen bg-gray-950 text-white">
       <header className="border-b border-gray-800 px-6 py-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="text-emerald-400 text-xl font-bold">⚡ scaffold-stacks</span>
+          <span className="text-emerald-400 text-xl font-bold"> scaffold-stacks</span>
           <NetworkBadge />
         </div>
         <WalletConnect />

--- a/frontend-template/src/components/WalletConnect.tsx
+++ b/frontend-template/src/components/WalletConnect.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { connect, disconnect, isConnected, getLocalStorage } from '@stacks/connect';
-import type { GetAddressesResult } from '@stacks/connect/dist/types/methods';
+import { addressAtom, isMountedAtom } from '../store/wallet';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 
 type WalletContextValue = {
@@ -13,43 +14,27 @@ type WalletContextValue = {
 
 const WalletContext = createContext<WalletContextValue | undefined>(undefined);
 
-export function WalletProvider({ children }: { children: ReactNode }) {
-  const [address, setAddress] = useState<string | null>(null);
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [address, setAddress] = useAtom(addressAtom);
+  const [, setMounted] = useAtom(isMountedAtom);
 
-  // Restore session on mount
   useEffect(() => {
+    setMounted(true);
+    
+    // If Stacks says we are connected but Jotai is empty (e.g. first load)
     if (isConnected()) {
       const stored = getLocalStorage();
-      // v8: addresses[2] is the STX address (0=BTC native, 1=BTC taproot, 2=STX)
-       //@ts-ignore
+      //@ts-ignore
       const addr = stored?.addresses?.[2]?.address ?? null;
-      if (addr) setAddress(addr);
+      if (addr && addr !== address) {
+        setAddress(addr);
+      }
     }
-  }, []);
+  }, [address, setAddress, setMounted]);
 
-  const handleConnect = async () => {
-    const response: GetAddressesResult = await connect();
-    // addresses[2] is the STX address in v8
-    const addr = response.addresses[2]?.address ?? null;
-    if (addr) setAddress(addr);
-  };
-
-  const handleDisconnect = () => {
-    disconnect();
-    setAddress(null);
-  };
-
-  return (
-    <WalletContext.Provider value={{
-      address,
-      connected: !!address,
-      connect: handleConnect,
-      disconnect: handleDisconnect,
-    }}>
-      {children}
-    </WalletContext.Provider>
-  );
+  return <>{children}</>;
 }
+
 
 export function useWallet() {
   const ctx = useContext(WalletContext);
@@ -57,29 +42,45 @@ export function useWallet() {
   return ctx;
 }
 
+
 export function WalletConnect() {
-  const { address, connected, connect: connectWallet, disconnect: disconnectWallet } = useWallet();
+  const address = useAtomValue(addressAtom);
+  const isMounted = useAtomValue(isMountedAtom);
+  const setAddress = useSetAtom(addressAtom);
   const [connecting, setConnecting] = useState(false);
 
-  const onConnect = async () => {
+  const handleConnect = async () => {
     setConnecting(true);
-    try { await connectWallet(); }
-    catch (e) { console.error('[scaffold-stacks] wallet connect failed:', e); }
-    finally { setConnecting(false); }
+    try {
+      const response = await connect();
+      const addr = response.addresses[2]?.address ?? null;
+      setAddress(addr);
+    } catch (e) {
+      console.error('[scaffold-stacks] connection failed:', e);
+    } finally {
+      setConnecting(false);
+    }
   };
 
-  if (!connected) {
+  const handleDisconnect = () => {
+    disconnect();
+    setAddress(null);
+    // Optional: window.location.reload() to hard-clear all state
+  };
+
+  // 1. Prevents SSR Flash: Render nothing or a skeleton until client-side mount
+  if (!isMounted) return <div style={{ width: '140px', height: '38px' }} />;
+
+  // 2. Disconnected UI
+  if (!address) {
     return (
       <button
-        onClick={onConnect}
+        onClick={handleConnect}
         disabled={connecting}
         style={{
-          display: 'flex', alignItems: 'center', gap: '8px',
           padding: '8px 16px', borderRadius: '8px',
-          background: connecting ? '#065f46' : '#059669',
-          color: '#fff', fontSize: '14px', fontWeight: 600,
-          border: 'none', cursor: connecting ? 'not-allowed' : 'pointer',
-          opacity: connecting ? 0.7 : 1, transition: 'all 0.15s',
+          background: '#059669', color: '#fff', fontWeight: 600,
+          border: 'none', cursor: 'pointer',
         }}
       >
         {connecting ? 'Connecting...' : 'Connect Wallet'}
@@ -87,25 +88,19 @@ export function WalletConnect() {
     );
   }
 
-  const short = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : '';
-
+  // 3. Connected UI
+  const short = `${address.slice(0, 6)}…${address.slice(-4)}`;
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
       <div style={{
-        display: 'flex', alignItems: 'center', gap: '8px',
         padding: '6px 12px', borderRadius: '8px',
-        background: '#111827', border: '1px solid #1f2937',
+        background: '#111827', border: '1px solid #1f2937', color: '#34d399'
       }}>
-        <div style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#34d399' }} />
-        <span style={{ fontFamily: 'monospace', fontSize: '14px', color: '#34d399' }}>{short}</span>
+        {short}
       </div>
-      <button
-        onClick={disconnectWallet}
-        style={{
-          padding: '6px 12px', borderRadius: '8px',
-          background: '#1f2937', border: '1px solid #374151',
-          color: '#9ca3af', fontSize: '12px', fontWeight: 500, cursor: 'pointer',
-        }}
+      <button 
+        onClick={handleDisconnect}
+        style={{ padding: '6px 12px', color: '#9ca3af', cursor: 'pointer', background: 'transparent', border: 'none' }}
       >
         Disconnect
       </button>

--- a/frontend-template/src/store/wallet.ts
+++ b/frontend-template/src/store/wallet.ts
@@ -1,0 +1,8 @@
+import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+// Automatically persists to localStorage under the key 'stx-address'
+export const addressAtom = atomWithStorage<string | null>('stx-address', null);
+
+// A simple boolean to track if the client has hydrated
+export const isMountedAtom = atom(false);


### PR DESCRIPTION
### Description
Previously, the `WalletProvider` relied on a manual `useEffect` to pull the Stacks session from `localStorage`. In Next.js, this caused a synchronization mismatch where the server rendered a "Disconnected" state, leading to a visible UI flicker and occasional state loss on page refresh. closes #11  closes #7 

This PR introduces **Jotai atoms** to handle the wallet state, ensuring the UI remains consistent and the session persists across all routes and hard reloads.

### Key Changes

#### 1. Global State with Jotai
* Added `addressAtom` using `atomWithStorage`. This ensures that the STX address is automatically persisted to and retrieved from `localStorage` without manual `getItem` calls.
* Added `isMountedAtom` to act as a **Hydration Guard**. This prevents the server from attempting to render a connected state that it doesn't have access to, eliminating the "Module not found" or "Hydration mismatch" errors.

#### 2. Refactored `WalletProvider`
* Simplified the provider to act as a synchronization layer between the **Stacks Connect** lifecycle and the Jotai store.
* Removed the heavy `WalletContext` boilerplate in favor of a decentralized atom approach.

#### 3. Updated `WalletConnect` UI
* Integrated the `isMounted` check to return a null placeholder during the initial server pass.
* Streamlined the `handleConnect` and `handleDisconnect` functions to update the global atom, which automatically updates any other component (like `DebugContracts`) listening to the address.

### Technical Benefits
* **Zero Flicker**: The UI waits for the client-side mount before displaying the connection status.
* **Global Access**: Any component in the scaffold can now access the user's address via `useAtomValue(addressAtom)` without being a direct child of a specific context consumer.
* **Next.js 15 Compatibility**: Resolves the "ssr: false" restriction in Server Components by moving the hydration logic into the atom state.