### PR TITLE
feat: add CLI integration test suite and enable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install Clarinet
         run: |
-          curl -sL https://github.com/hirosystems/clarinet/releases/download/v3.1.0/clarinet-linux-x64.tar.gz | tar xz
+          curl -sL https://github.com/hirosystems/clarinet/releases/download/v3.16.0/clarinet-linux-x64-glibc.tar.gz | tar xz
           sudo mv clarinet /usr/local/bin/
           clarinet --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,38 +1,119 @@
-# name: CI
+name: CI
 
-# on:
-#   push:
-#   pull_request:
+on:
+  push:
+    branches: [main]
+  pull_request:
 
-# jobs:
-#   build-and-test:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
+env:
+  CARGO_TERM_COLOR: always
 
-#       - uses: dtolnay/rust-toolchain@stable
-#         with:
-#           components: rustfmt, clippy
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-#       - name: Cache cargo registry
-#         uses: actions/cache@v4
-#         with:
-#           path: |
-#             ~/.cargo/registry
-#             ~/.cargo/git
-#             target/
-#           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-#           restore-keys: |
-#             ${{ runner.os }}-cargo-
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
-#       - name: Cargo fmt
-#         run: cargo fmt --all --check
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-lint-
 
-#       - name: Cargo clippy
-#         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Cargo fmt
+        run: cargo fmt --all --check
 
-#       - name: Cargo test
-#         run: cargo test --all
+      - name: Cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
-#       - name: Cargo build release
-#         run: cargo build --release
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+
+      - name: Run unit tests
+        run: cargo test --all --lib
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-integ-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-integ-
+
+      - name: Install Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Clarinet
+        run: |
+          curl -sL https://github.com/hirosystems/clarinet/releases/download/v3.1.0/clarinet-linux-x64.tar.gz | tar xz
+          sudo mv clarinet /usr/local/bin/
+          clarinet --version
+
+      - name: Build CLI binary
+        run: cargo build --package stacksdapp
+
+      - name: Run integration tests
+        run: cargo test --package stacksdapp --test integration -- --test-threads=2
+        timeout-minutes: 30
+
+  build:
+    name: Release Build
+    runs-on: ubuntu-latest
+    needs: [lint, unit-tests]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - name: Cargo build release
+        run: cargo build --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -431,6 +447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +532,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -1272,6 +1303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1557,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -2085,16 +2152,21 @@ name = "stacksdapp"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "colored",
  "indicatif",
+ "predicates",
+ "serde_json",
  "stacksdapp-codegen",
  "stacksdapp-deployer",
  "stacksdapp-parser",
  "stacksdapp-process-supervisor",
  "stacksdapp-scaffold",
  "stacksdapp-watcher",
+ "tempfile",
  "tokio",
+ "which",
 ]
 
 [[package]]
@@ -2272,6 +2344,12 @@ dependencies = [
  "slug",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -2582,6 +2660,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,6 @@ which          = "6"
 dirs           = "5"
 fs_extra       = "1"
 tempfile       = "3"
+assert_cmd     = "2"
+predicates     = "3"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,3 +23,10 @@ tokio.workspace     = true
 anyhow.workspace    = true
 colored.workspace   = true
 indicatif.workspace = true
+
+[dev-dependencies]
+assert_cmd.workspace  = true
+predicates.workspace  = true
+tempfile.workspace    = true
+serde_json.workspace  = true
+which.workspace       = true

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -200,10 +200,7 @@ async fn check_docker() -> Check {
         .status()
         .await;
 
-    let found = match &bin_exists {
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
-        _ => true,
-    };
+    let found = !matches!(&bin_exists, Err(e) if e.kind() == std::io::ErrorKind::NotFound);
 
     if !found {
         return Check {

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -15,7 +15,10 @@ enum CheckResult {
 }
 
 pub async fn run() -> Result<()> {
-    println!("\n{}\n", "stacksdapp doctor — checking prerequisites".bold());
+    println!(
+        "\n{}\n",
+        "stacksdapp doctor — checking prerequisites".bold()
+    );
 
     let checks = vec![
         check_rust().await,
@@ -31,14 +34,29 @@ pub async fn run() -> Result<()> {
     for check in &checks {
         match &check.result {
             CheckResult::Ok(msg) => {
-                println!("  {}  {} {}", "✔".green().bold(), check.name.white(), msg.dimmed());
+                println!(
+                    "  {}  {} {}",
+                    "✔".green().bold(),
+                    check.name.white(),
+                    msg.dimmed()
+                );
             }
             CheckResult::Warn(msg) => {
-                println!("  {}  {} {}", "⚠".yellow().bold(), check.name.white(), msg.yellow());
+                println!(
+                    "  {}  {} {}",
+                    "⚠".yellow().bold(),
+                    check.name.white(),
+                    msg.yellow()
+                );
                 all_ok = false;
             }
             CheckResult::Fail(msg) => {
-                println!("  {}  {} {}", "✗".red().bold(), check.name.white().bold(), msg.red());
+                println!(
+                    "  {}  {} {}",
+                    "✗".red().bold(),
+                    check.name.white().bold(),
+                    msg.red()
+                );
                 all_ok = false;
             }
         }
@@ -47,9 +65,17 @@ pub async fn run() -> Result<()> {
     println!();
 
     if all_ok {
-        println!("{}", "  All checks passed. You're ready to build on Stacks!".green().bold());
+        println!(
+            "{}",
+            "  All checks passed. You're ready to build on Stacks!"
+                .green()
+                .bold()
+        );
     } else {
-        println!("{}", "  Some checks failed. Fix the issues above before running stacksdapp new.".yellow());
+        println!(
+            "{}",
+            "  Some checks failed. Fix the issues above before running stacksdapp new.".yellow()
+        );
     }
 
     println!();
@@ -62,9 +88,17 @@ async fn check_rust() -> Check {
     match version_output("rustc", &["--version"]).await {
         Some(v) => {
             // "rustc 1.78.0 (9b00956e5 2024-04-29)"
-            let version = v.trim_start_matches("rustc ").split_whitespace().next().unwrap_or("?").to_string();
+            let version = v
+                .trim_start_matches("rustc ")
+                .split_whitespace()
+                .next()
+                .unwrap_or("?")
+                .to_string();
             if meets_semver(&version, 1, 75) {
-                Check { name: "Rust", result: CheckResult::Ok(version) }
+                Check {
+                    name: "Rust",
+                    result: CheckResult::Ok(version),
+                }
             } else {
                 Check {
                     name: "Rust",
@@ -76,9 +110,7 @@ async fn check_rust() -> Check {
         }
         None => Check {
             name: "Rust",
-            result: CheckResult::Fail(
-                "not found. Install from https://rustup.rs".into(),
-            ),
+            result: CheckResult::Fail("not found. Install from https://rustup.rs".into()),
         },
     }
 }
@@ -88,9 +120,17 @@ async fn check_node() -> Check {
         Some(v) => {
             // "v20.11.0"
             let version = v.trim().trim_start_matches('v').to_string();
-            let major: u32 = version.split('.').next().unwrap_or("0").parse().unwrap_or(0);
+            let major: u32 = version
+                .split('.')
+                .next()
+                .unwrap_or("0")
+                .parse()
+                .unwrap_or(0);
             if major >= 20 {
-                Check { name: "Node.js", result: CheckResult::Ok(version) }
+                Check {
+                    name: "Node.js",
+                    result: CheckResult::Ok(version),
+                }
             } else {
                 Check {
                     name: "Node.js",
@@ -113,15 +153,24 @@ async fn check_clarinet() -> Check {
     match version_output("clarinet", &["--version"]).await {
         Some(v) => {
             // "clarinet 3.14.1" or just "3.14.1"
-            let version = v.trim()
+            let version = v
+                .trim()
                 .trim_start_matches("clarinet ")
                 .split_whitespace()
                 .next()
                 .unwrap_or("?")
                 .to_string();
-            let major: u32 = version.split('.').next().unwrap_or("0").parse().unwrap_or(0);
+            let major: u32 = version
+                .split('.')
+                .next()
+                .unwrap_or("0")
+                .parse()
+                .unwrap_or(0);
             if major >= 3 {
-                Check { name: "Clarinet", result: CheckResult::Ok(version) }
+                Check {
+                    name: "Clarinet",
+                    result: CheckResult::Ok(version),
+                }
             } else {
                 Check {
                     name: "Clarinet",
@@ -160,7 +209,8 @@ async fn check_docker() -> Check {
         return Check {
             name: "Docker",
             result: CheckResult::Warn(
-                "not found — only required for local devnet. Install from https://docker.com".into(),
+                "not found — only required for local devnet. Install from https://docker.com"
+                    .into(),
             ),
         };
     }
@@ -176,7 +226,8 @@ async fn check_docker() -> Check {
         .unwrap_or(false);
 
     if running {
-        let version = version_output("docker", &["--version"]).await
+        let version = version_output("docker", &["--version"])
+            .await
             .map(|v| {
                 v.trim()
                     .trim_start_matches("Docker version ")
@@ -187,7 +238,10 @@ async fn check_docker() -> Check {
             })
             .unwrap_or_else(|| "?".into());
 
-        Check { name: "Docker", result: CheckResult::Ok(version) }
+        Check {
+            name: "Docker",
+            result: CheckResult::Ok(version),
+        }
     } else {
         Check {
             name: "Docker",
@@ -202,10 +256,11 @@ async fn check_git() -> Check {
     match version_output("git", &["--version"]).await {
         Some(v) => {
             // "git version 2.44.0"
-            let version = v.trim()
-                .trim_start_matches("git version ")
-                .to_string();
-            Check { name: "git", result: CheckResult::Ok(version) }
+            let version = v.trim().trim_start_matches("git version ").to_string();
+            Check {
+                name: "git",
+                result: CheckResult::Ok(version),
+            }
         }
         None => Check {
             name: "git",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,6 @@ mod commands {
 }
 use commands::doctor;
 
-
 #[derive(Parser)]
 #[command(name = "stacksdapp", version, about = "Scaffold-Stacks CLI")]
 struct Cli {
@@ -65,7 +64,9 @@ async fn main() -> Result<()> {
         Commands::New { name, no_git } => stacksdapp_scaffold::new_project(&name, !no_git).await,
         Commands::Dev { network } => stacksdapp_process_supervisor::dev(&network).await,
         Commands::Generate => stacksdapp_codegen::generate_all().await,
-        Commands::Add { name, template } => stacksdapp_scaffold::add_contract(&name, &template).await,
+        Commands::Add { name, template } => {
+            stacksdapp_scaffold::add_contract(&name, &template).await
+        }
         Commands::Deploy { network } => stacksdapp_deployer::deploy(&network).await,
         Commands::Test => run_test().await,
         Commands::Check => run_check().await,
@@ -160,7 +161,10 @@ async fn run_clean() -> Result<()> {
     use std::path::Path;
     use tokio::fs;
 
-    println!("{}", "[clean] Removing generated files and devnet state...".cyan());
+    println!(
+        "{}",
+        "[clean] Removing generated files and devnet state...".cyan()
+    );
 
     let generated_dir = Path::new("frontend/src/generated");
     if generated_dir.exists() {
@@ -195,6 +199,9 @@ async fn run_clean() -> Result<()> {
     )
     .await?;
 
-    println!("{}", "[clean] Done. Run `stacks-dapp generate` to regenerate bindings.".green());
+    println!(
+        "{}",
+        "[clean] Done. Run `stacks-dapp generate` to regenerate bindings.".green()
+    );
     Ok(())
 }

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -1,0 +1,681 @@
+//! Integration tests for the stacksdapp CLI.
+//!
+//! Tests are organized into tiers:
+//!
+//! - **Always run**: CLI argument parsing, `new` scaffolding (file structure only),
+//!   `add` contract, `clean` command. These require only the compiled binary.
+//!
+//! - **Requires toolchain** (`#[ignore]`): `generate` and the full
+//!   `new → generate → deploy → generate` flow. These need `node >=20` and
+//!   `clarinet >=3` installed. Run with `cargo test -- --ignored`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a `Command` for the `stacksdapp` binary under test.
+fn cli() -> Command {
+    Command::cargo_bin("stacksdapp").expect("binary stacksdapp not found")
+}
+
+/// Returns true if both `node` (>=20) and `clarinet` are on PATH.
+fn has_toolchain() -> bool {
+    which::which("node").is_ok() && which::which("clarinet").is_ok()
+}
+
+/// Scaffold a new project inside `dir` with the given name.
+/// Uses `--no-git` so tests don't depend on global git config.
+/// The generous timeout accounts for `npm install` in CI environments.
+fn scaffold_project(dir: &Path, name: &str) {
+    cli()
+        .current_dir(dir)
+        .args(["new", name, "--no-git"])
+        .timeout(std::time::Duration::from_secs(600))
+        .assert()
+        .success();
+}
+
+// =============================================================================
+// Tier 1: CLI parsing — no filesystem side-effects
+// =============================================================================
+
+#[test]
+fn cli_no_args_shows_help() {
+    cli()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage"));
+}
+
+#[test]
+fn cli_help_flag() {
+    cli()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Scaffold-Stacks CLI"));
+}
+
+#[test]
+fn cli_version_flag() {
+    cli()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("stacksdapp"));
+}
+
+#[test]
+fn cli_unknown_subcommand() {
+    cli()
+        .arg("foobar")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+// =============================================================================
+// Tier 2: `new` command — scaffold project and verify file structure
+// =============================================================================
+
+#[test]
+fn new_creates_project_structure() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "test-app");
+
+    let root = tmp.path().join("test-app");
+    assert!(root.exists(), "project root should exist");
+
+    // Top-level files
+    assert!(root.join("package.json").exists(), "root package.json");
+    assert!(root.join(".gitignore").exists(), "root .gitignore");
+
+    // Contracts workspace
+    let contracts = root.join("contracts");
+    assert!(contracts.join("Clarinet.toml").exists(), "Clarinet.toml");
+    assert!(
+        contracts.join("package.json").exists(),
+        "contracts/package.json"
+    );
+    assert!(
+        contracts.join("vitest.config.ts").exists(),
+        "vitest.config.ts"
+    );
+    assert!(contracts.join("tsconfig.json").exists(), "tsconfig.json");
+    assert!(
+        contracts.join("contracts/counter.clar").exists(),
+        "counter.clar"
+    );
+    assert!(
+        contracts.join("tests/counter.test.ts").exists(),
+        "counter.test.ts"
+    );
+
+    // Settings files
+    assert!(
+        contracts.join("settings/Devnet.toml").exists(),
+        "Devnet.toml"
+    );
+    assert!(
+        contracts.join("settings/Testnet.toml").exists(),
+        "Testnet.toml"
+    );
+    assert!(
+        contracts.join("settings/Mainnet.toml").exists(),
+        "Mainnet.toml"
+    );
+
+    // Frontend workspace
+    let frontend = root.join("frontend");
+    assert!(
+        frontend.join("package.json").exists(),
+        "frontend/package.json"
+    );
+    assert!(
+        frontend.join("src/app/page.tsx").exists(),
+        "frontend page.tsx"
+    );
+    assert!(
+        frontend.join("scripts/export-abi.mjs").exists(),
+        "export-abi.mjs"
+    );
+    assert!(
+        frontend.join("node_modules").exists(),
+        "frontend/node_modules installed"
+    );
+
+    // Contracts node_modules installed
+    assert!(
+        contracts.join("node_modules").exists(),
+        "contracts/node_modules installed"
+    );
+}
+
+#[test]
+fn new_fails_if_directory_exists() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    // Create the directory first
+    fs::create_dir(tmp.path().join("dup-project")).unwrap();
+
+    cli()
+        .current_dir(tmp.path())
+        .args(["new", "dup-project", "--no-git"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn new_clarinet_toml_has_counter_contract() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "toml-check");
+
+    let toml = fs::read_to_string(tmp.path().join("toml-check/contracts/Clarinet.toml")).unwrap();
+    assert!(
+        toml.contains("[contracts.counter]"),
+        "Clarinet.toml should define counter contract"
+    );
+    assert!(
+        toml.contains("contracts/counter.clar"),
+        "Clarinet.toml should reference counter.clar path"
+    );
+}
+
+#[test]
+fn new_counter_contract_has_expected_functions() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "counter-fns");
+
+    let source = fs::read_to_string(
+        tmp.path()
+            .join("counter-fns/contracts/contracts/counter.clar"),
+    )
+    .unwrap();
+
+    assert!(
+        source.contains("(define-public (increment)"),
+        "increment fn"
+    );
+    assert!(
+        source.contains("(define-public (decrement)"),
+        "decrement fn"
+    );
+    assert!(source.contains("(define-public (reset)"), "reset fn");
+    assert!(
+        source.contains("(define-read-only (get-count)"),
+        "get-count fn"
+    );
+}
+
+// =============================================================================
+// Tier 3: `add` command — add contracts to existing project
+// =============================================================================
+
+#[test]
+fn add_blank_contract() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "add-test");
+
+    let project = tmp.path().join("add-test");
+
+    cli()
+        .current_dir(&project)
+        .args(["add", "greeter"])
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    // Contract file created
+    assert!(
+        project.join("contracts/contracts/greeter.clar").exists(),
+        "greeter.clar should be created"
+    );
+
+    // Test file created
+    assert!(
+        project.join("contracts/tests/greeter.test.ts").exists(),
+        "greeter.test.ts should be created"
+    );
+
+    // Clarinet.toml updated
+    let toml = fs::read_to_string(project.join("contracts/Clarinet.toml")).unwrap();
+    assert!(
+        toml.contains("[contracts.greeter]"),
+        "Clarinet.toml should define greeter"
+    );
+}
+
+#[test]
+fn add_sip010_template() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "sip010-test");
+
+    let project = tmp.path().join("sip010-test");
+
+    cli()
+        .current_dir(&project)
+        .args(["add", "my-token", "--template", "sip010"])
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let source = fs::read_to_string(project.join("contracts/contracts/my-token.clar")).unwrap();
+
+    assert!(
+        source.contains("define-fungible-token"),
+        "SIP-010 should define a fungible token"
+    );
+    assert!(
+        source.contains("(define-public (mint"),
+        "SIP-010 should have mint function"
+    );
+    assert!(
+        source.contains("(define-public (transfer"),
+        "SIP-010 should have transfer function"
+    );
+}
+
+#[test]
+fn add_sip009_template() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "sip009-test");
+
+    let project = tmp.path().join("sip009-test");
+
+    cli()
+        .current_dir(&project)
+        .args(["add", "my-nft", "--template", "sip009"])
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let source = fs::read_to_string(project.join("contracts/contracts/my-nft.clar")).unwrap();
+
+    assert!(
+        source.contains("define-non-fungible-token"),
+        "SIP-009 should define a non-fungible token"
+    );
+    assert!(
+        source.contains("(define-public (mint"),
+        "SIP-009 should have mint function"
+    );
+}
+
+#[test]
+fn add_duplicate_contract_fails() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "dup-contract");
+
+    let project = tmp.path().join("dup-contract");
+
+    // counter already exists from scaffold
+    cli()
+        .current_dir(&project)
+        .args(["add", "counter"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+// =============================================================================
+// Tier 4: `generate` command — requires node + clarinet
+// =============================================================================
+
+#[test]
+fn generate_creates_typescript_bindings() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "gen-test");
+
+    let project = tmp.path().join("gen-test");
+
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let generated = project.join("frontend/src/generated");
+    assert!(generated.join("contracts.ts").exists(), "contracts.ts");
+    assert!(generated.join("hooks.ts").exists(), "hooks.ts");
+    assert!(
+        generated.join("DebugContracts.tsx").exists(),
+        "DebugContracts.tsx"
+    );
+    assert!(
+        generated.join("deployments.json").exists(),
+        "deployments.json"
+    );
+}
+
+#[test]
+fn generate_contracts_ts_contains_counter_functions() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "gen-fns");
+
+    let project = tmp.path().join("gen-fns");
+
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let contracts_ts =
+        fs::read_to_string(project.join("frontend/src/generated/contracts.ts")).unwrap();
+
+    // Should contain camelCase wrappers for the counter contract functions
+    assert!(
+        contracts_ts.contains("counter_increment") || contracts_ts.contains("counter_Increment"),
+        "contracts.ts should contain increment wrapper"
+    );
+    assert!(
+        contracts_ts.contains("counter_getCount") || contracts_ts.contains("counter_get_count"),
+        "contracts.ts should contain getCount wrapper"
+    );
+}
+
+#[test]
+fn generate_hooks_ts_has_react_hooks() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "gen-hooks");
+
+    let project = tmp.path().join("gen-hooks");
+
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let hooks_ts = fs::read_to_string(project.join("frontend/src/generated/hooks.ts")).unwrap();
+
+    assert!(
+        hooks_ts.contains("useState"),
+        "hooks.ts should import useState"
+    );
+    assert!(
+        hooks_ts.contains("useCallback"),
+        "hooks.ts should import useCallback"
+    );
+}
+
+#[test]
+fn generate_is_idempotent() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "gen-idem");
+
+    let project = tmp.path().join("gen-idem");
+
+    // First generate
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let contracts_ts_path = project.join("frontend/src/generated/contracts.ts");
+    let first_content = fs::read_to_string(&contracts_ts_path).unwrap();
+
+    // Second generate — should produce identical output
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date"));
+
+    let second_content = fs::read_to_string(&contracts_ts_path).unwrap();
+    assert_eq!(
+        first_content, second_content,
+        "generate should be idempotent"
+    );
+}
+
+// =============================================================================
+// Tier 5: `clean` command
+// =============================================================================
+
+#[test]
+fn clean_removes_generated_files() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "clean-test");
+
+    let project = tmp.path().join("clean-test");
+
+    // First generate so there are files to clean
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let generated = project.join("frontend/src/generated");
+    assert!(
+        generated.join("contracts.ts").exists(),
+        "contracts.ts should exist before clean"
+    );
+
+    // Run clean
+    cli()
+        .current_dir(&project)
+        .arg("clean")
+        .timeout(std::time::Duration::from_secs(30))
+        .assert()
+        .success();
+
+    // Generated TypeScript files should be removed
+    assert!(
+        !generated.join("contracts.ts").exists(),
+        "contracts.ts should be removed after clean"
+    );
+    assert!(
+        !generated.join("hooks.ts").exists(),
+        "hooks.ts should be removed after clean"
+    );
+
+    // But deployments.json should be recreated as empty
+    assert!(
+        generated.join("deployments.json").exists(),
+        "deployments.json should be recreated after clean"
+    );
+
+    let deployments = fs::read_to_string(generated.join("deployments.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&deployments).unwrap();
+    assert!(
+        json["contracts"].as_object().unwrap().is_empty(),
+        "deployments.json contracts should be empty after clean"
+    );
+}
+
+// =============================================================================
+// Tier 6: Full flow — new → generate → add → generate
+// =============================================================================
+
+#[test]
+fn full_flow_new_generate_add_generate() {
+    if !has_toolchain() {
+        eprintln!("SKIP: node/clarinet not found");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    scaffold_project(tmp.path(), "full-flow");
+
+    let project = tmp.path().join("full-flow");
+
+    // Step 1: Generate bindings for the starter counter contract
+    cli()
+        .current_dir(&project)
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let generated = project.join("frontend/src/generated");
+    let contracts_v1 = fs::read_to_string(generated.join("contracts.ts")).unwrap();
+    assert!(
+        contracts_v1.contains("counter"),
+        "v1 contracts.ts should reference counter"
+    );
+
+    // Step 2: Add a new contract
+    cli()
+        .current_dir(&project)
+        .args(["add", "vault"])
+        .timeout(std::time::Duration::from_secs(120))
+        .assert()
+        .success();
+
+    // Step 3: Verify the regenerated bindings include both contracts
+    let contracts_v2 = fs::read_to_string(generated.join("contracts.ts")).unwrap();
+    assert!(
+        contracts_v2.contains("counter"),
+        "v2 contracts.ts should still reference counter"
+    );
+    assert!(
+        contracts_v2.contains("vault"),
+        "v2 contracts.ts should now reference vault"
+    );
+
+    // Hooks should reference both contracts too
+    let hooks_v2 = fs::read_to_string(generated.join("hooks.ts")).unwrap();
+    assert!(
+        hooks_v2.contains("counter") && hooks_v2.contains("vault"),
+        "hooks.ts should reference both contracts"
+    );
+
+    // DebugContracts should reference both
+    let debug_ui = fs::read_to_string(generated.join("DebugContracts.tsx")).unwrap();
+    assert!(
+        debug_ui.contains("counter") && debug_ui.contains("vault"),
+        "DebugContracts.tsx should reference both contracts"
+    );
+}
+
+// =============================================================================
+// Tier 7: `generate` outside project should fail gracefully
+// =============================================================================
+
+#[test]
+fn generate_outside_project_fails() {
+    let tmp = TempDir::new().unwrap();
+
+    cli()
+        .current_dir(tmp.path())
+        .arg("generate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No scaffold-stacks project found"));
+}
+
+#[test]
+fn add_outside_project_fails() {
+    let tmp = TempDir::new().unwrap();
+
+    cli()
+        .current_dir(tmp.path())
+        .args(["add", "foo"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No scaffold-stacks project found"));
+}
+
+#[test]
+fn clean_outside_project_succeeds_gracefully() {
+    // clean should not crash even if there are no generated dirs
+    let tmp = TempDir::new().unwrap();
+
+    cli()
+        .current_dir(tmp.path())
+        .arg("clean")
+        .assert()
+        .success();
+}
+
+// =============================================================================
+// Tier 8: `doctor` command
+// =============================================================================
+
+#[test]
+fn doctor_runs_without_crash() {
+    cli()
+        .arg("doctor")
+        .timeout(std::time::Duration::from_secs(30))
+        .assert()
+        .success();
+}

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,15 +1,24 @@
 use anyhow::Result;
-use stacksdapp_parser::ContractAbi;
 use sha2::{Digest, Sha256};
+use stacksdapp_parser::ContractAbi;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tera::{Filter, Tera, Value};
 
-const CONTRACTS_TS_TEMPLATE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/contracts.ts.tera"));
-const HOOKS_TS_TEMPLATE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/hooks.ts.tera"));
-const DEBUG_UI_TSX_TEMPLATE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/debug_ui.tsx.tera"));
+const CONTRACTS_TS_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/templates/contracts.ts.tera"
+));
+const HOOKS_TS_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/templates/hooks.ts.tera"
+));
+const DEBUG_UI_TSX_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/templates/debug_ui.tsx.tera"
+));
 
 // ── Custom Tera filters ───────────────────────────────────────────────────────
 
@@ -94,8 +103,14 @@ pub async fn generate_all() -> Result<()> {
         return Ok(());
     }
 
-    println!("[generate] Found {} contract(s): {}", abis.len(),
-        abis.iter().map(|a| a.contract_name.as_str()).collect::<Vec<_>>().join(", "));
+    println!(
+        "[generate] Found {} contract(s): {}",
+        abis.len(),
+        abis.iter()
+            .map(|a| a.contract_name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
 
     let out_dir = project_root.join("frontend/src/generated");
     tokio::fs::create_dir_all(&out_dir).await?;
@@ -108,7 +123,8 @@ pub async fn generate_all() -> Result<()> {
         tokio::fs::write(
             &deployments_path,
             r#"{ "network": "", "deployed_at": "", "contracts": {} }"#,
-        ).await?;
+        )
+        .await?;
         println!("[generate] Created empty deployments.json (run stacks-dapp deploy to populate)");
     }
 
@@ -120,8 +136,7 @@ pub async fn generate_all() -> Result<()> {
         println!("[generate] Done — {written} file(s) written.");
     }
 
-    let network = std::env::var("NEXT_PUBLIC_NETWORK")
-        .unwrap_or_else(|_| "<network>".into());
+    let network = std::env::var("NEXT_PUBLIC_NETWORK").unwrap_or_else(|_| "<network>".into());
     let stale = find_stale_deployments(&abis, &out_dir);
     if !stale.is_empty() {
         warn_redeploy_required(&stale, &network);
@@ -167,9 +182,18 @@ pub fn render(abis: &[ContractAbi], out_dir: &Path) -> Result<usize> {
     }))?;
 
     let mut written = 0;
-    written += write_if_changed(out_dir.join("contracts.ts"), &tera.render("contracts.ts.tera", &ctx)?)?;
-    written += write_if_changed(out_dir.join("hooks.ts"), &tera.render("hooks.ts.tera", &ctx)?)?;
-    written += write_if_changed(out_dir.join("DebugContracts.tsx"), &tera.render("debug_ui.tsx.tera", &ctx)?)?;
+    written += write_if_changed(
+        out_dir.join("contracts.ts"),
+        &tera.render("contracts.ts.tera", &ctx)?,
+    )?;
+    written += write_if_changed(
+        out_dir.join("hooks.ts"),
+        &tera.render("hooks.ts.tera", &ctx)?,
+    )?;
+    written += write_if_changed(
+        out_dir.join("DebugContracts.tsx"),
+        &tera.render("debug_ui.tsx.tera", &ctx)?,
+    )?;
 
     Ok(written)
 }
@@ -182,14 +206,30 @@ fn clarity_type_str(t: &serde_json::Value) -> String {
     match t {
         serde_json::Value::String(s) => s.clone(),
         serde_json::Value::Object(map) => {
-            if map.contains_key("string-ascii") { return "string-ascii".into(); }
-            if map.contains_key("string-utf8")  { return "string-utf8".into(); }
-            if map.contains_key("buffer")        { return "buff".into(); }
-            if map.contains_key("buff")          { return "buff".into(); }
-            if map.contains_key("list")          { return "list".into(); }
-            if map.contains_key("tuple")         { return "tuple".into(); }
-            if map.contains_key("optional")      { return "optional".into(); }
-            if map.contains_key("response")      { return "response".into(); }
+            if map.contains_key("string-ascii") {
+                return "string-ascii".into();
+            }
+            if map.contains_key("string-utf8") {
+                return "string-utf8".into();
+            }
+            if map.contains_key("buffer") {
+                return "buff".into();
+            }
+            if map.contains_key("buff") {
+                return "buff".into();
+            }
+            if map.contains_key("list") {
+                return "list".into();
+            }
+            if map.contains_key("tuple") {
+                return "tuple".into();
+            }
+            if map.contains_key("optional") {
+                return "optional".into();
+            }
+            if map.contains_key("response") {
+                return "response".into();
+            }
             "unknown".into()
         }
         _ => "unknown".into(),

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -1,18 +1,18 @@
 use anyhow::{anyhow, Result};
+use bip39::Mnemonic;
 use bitcoin::bip32::{DerivationPath, Xpriv};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::Network as BitcoinNetwork;
-use bip39::Mnemonic;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
+use std::process::Stdio;
 use std::str::FromStr;
+use tempfile::NamedTempFile;
 use tokio::fs;
+use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
-use std::process::Stdio;
-use tokio::io::AsyncBufReadExt;
-use tempfile::NamedTempFile;
 
 pub struct NetworkConfig {
     pub stacks_node: String,
@@ -20,10 +20,16 @@ pub struct NetworkConfig {
 
 pub fn network_config(network: &str) -> NetworkConfig {
     match network {
-        "devnet"  => NetworkConfig { stacks_node: "http://localhost:3999".into() },
-        "testnet" => NetworkConfig { stacks_node: "https://api.testnet.hiro.so".into() },
-        "mainnet" => NetworkConfig { stacks_node: "https://api.hiro.so".into() },
-        other     => panic!("Unknown network: {other}"),
+        "devnet" => NetworkConfig {
+            stacks_node: "http://localhost:3999".into(),
+        },
+        "testnet" => NetworkConfig {
+            stacks_node: "https://api.testnet.hiro.so".into(),
+        },
+        "mainnet" => NetworkConfig {
+            stacks_node: "https://api.hiro.so".into(),
+        },
+        other => panic!("Unknown network: {other}"),
     }
 }
 
@@ -130,7 +136,10 @@ async fn deploy_via_clarinet(network: &str) -> Result<()> {
     // Step 1: resolve all conflicts BEFORE touching clarinet.
     // This runs until Clarinet.toml has no contracts that exist on-chain.
     if network == "testnet" || network == "mainnet" {
-        println!("[deploy] Checking for contract name conflicts on {}...", network);
+        println!(
+            "[deploy] Checking for contract name conflicts on {}...",
+            network
+        );
         auto_version_conflicting_contracts(network).await?;
     }
 
@@ -167,7 +176,11 @@ async fn reorder_clarinet_toml(
     let mut current_block = String::new();
 
     for line in raw[first_contract..].lines() {
-        if let Some(name) = line.trim().strip_prefix("[contracts.").and_then(|s| s.strip_suffix(']')) {
+        if let Some(name) = line
+            .trim()
+            .strip_prefix("[contracts.")
+            .and_then(|s| s.strip_suffix(']'))
+        {
             if let Some(prev) = current_name.take() {
                 blocks.insert(prev, current_block.trim().to_string());
             }
@@ -211,9 +224,11 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
         .current_dir("contracts")
         .status()
         .await
-        .map_err(|_| anyhow!(
-            "clarinet is required. Install: brew install clarinet OR cargo install clarinet"
-        ))?;
+        .map_err(|_| {
+            anyhow!(
+                "clarinet is required. Install: brew install clarinet OR cargo install clarinet"
+            )
+        })?;
 
     if !gen.success() {
         return Err(anyhow!(
@@ -232,28 +247,36 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
 
     println!("[deploy] Applying deployment plan to {}...", network);
     let mut child = Command::new("clarinet")
-        .args(["deployments", "apply", "--no-dashboard", &format!("--{network}")])
+        .args([
+            "deployments",
+            "apply",
+            "--no-dashboard",
+            &format!("--{network}"),
+        ])
         .current_dir("contracts")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit()) 
+        .stderr(Stdio::inherit())
         .spawn()?;
 
-    let mut stdin = child.stdin.take().ok_or_else(|| anyhow!("Failed to open stdin"))?;
-    let stdout = child.stdout.take().ok_or_else(|| anyhow!("Failed to open stdout"))?;
-    
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("Failed to open stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("Failed to open stdout"))?;
 
     let contracts_dir = std::path::Path::new("contracts");
     let expected_count = resolve_deployment_order(contracts_dir).await?.len();
-    
+
     let mut confirmed_count = 0;
     let mut broadcast_count = 0;
-
 
     let mut reader = tokio::io::BufReader::new(stdout).lines();
     let mut captured_stdout = String::new();
 
-    
     while let Ok(Some(line)) = reader.next_line().await {
         println!("{}", line);
         captured_stdout.push_str(&line);
@@ -262,7 +285,9 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
         if line.contains("REDEPLOYMENT REQUIRED") || line.contains("out of sync") {
             println!("[deploy] Error: Devnet is out of sync. You may need to restart Clarinet or increment contract version.");
             let _ = child.kill().await;
-            return Err(anyhow!("Devnet redeployment required. Check your contract versions."));
+            return Err(anyhow!(
+                "Devnet redeployment required. Check your contract versions."
+            ));
         }
 
         // Handle interactive fee prompts
@@ -272,12 +297,18 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
         }
         if line.contains("Broadcasted") && line.contains("ContractPublish(") {
             broadcast_count += 1;
-            println!("[deploy] Broadcast progress: {}/{}", broadcast_count, expected_count);
+            println!(
+                "[deploy] Broadcast progress: {}/{}",
+                broadcast_count, expected_count
+            );
         }
 
         if line.contains("Confirmed Publish") || line.contains("Published") {
             confirmed_count += 1;
-            println!("[deploy] Confirmation progress: {}/{}", confirmed_count, expected_count);
+            println!(
+                "[deploy] Confirmation progress: {}/{}",
+                confirmed_count, expected_count
+            );
         }
 
         if confirmed_count >= expected_count {
@@ -291,7 +322,6 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
             let _ = child.kill().await; // Don't block on extra Clarinet output after broadcast
             break;
         }
-
     }
     Ok(captured_stdout)
 }
@@ -301,7 +331,9 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
     let plan = read_deployment_plan(network).await?;
     let transactions = flatten_contract_publishes(&plan);
     if transactions.is_empty() {
-        return Err(anyhow!("No contract publish transactions found in the devnet deployment plan."));
+        return Err(anyhow!(
+            "No contract publish transactions found in the devnet deployment plan."
+        ));
     }
 
     let settings_raw = fs::read_to_string("contracts/settings/Devnet.toml").await?;
@@ -322,10 +354,13 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
     println!("[deploy] Broadcasting transactions to http://localhost:20443");
 
     for tx in transactions {
-        let contract_name = tx.contract_name.clone()
+        let contract_name = tx
+            .contract_name
+            .clone()
             .ok_or_else(|| anyhow!("Missing contract name in deployment plan."))?;
-        let contract_path = tx.path.clone()
-            .ok_or_else(|| anyhow!("Missing contract path for {contract_name} in deployment plan."))?;
+        let contract_path = tx.path.clone().ok_or_else(|| {
+            anyhow!("Missing contract path for {contract_name} in deployment plan.")
+        })?;
         let fee = tx.cost.unwrap_or(0);
         let args = serde_json::json!({
             "contractName": contract_name,
@@ -356,14 +391,28 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let result: serde_json::Value = serde_json::from_str(stdout.trim())
-            .map_err(|e| anyhow!("Failed to parse devnet broadcast response: {e}\nRaw output: {}", stdout.trim()))?;
+        let result: serde_json::Value = serde_json::from_str(stdout.trim()).map_err(|e| {
+            anyhow!(
+                "Failed to parse devnet broadcast response: {e}\nRaw output: {}",
+                stdout.trim()
+            )
+        })?;
         let txid = result
             .get("txid")
             .and_then(|value| value.as_str())
-            .ok_or_else(|| anyhow!("Devnet broadcast response did not include a txid: {}", stdout.trim()))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "Devnet broadcast response did not include a txid: {}",
+                    stdout.trim()
+                )
+            })?;
 
-        println!("🟦  Publish {}.{}  Transaction broadcast {}", expected_sender, tx.contract_name.as_deref().unwrap_or(""), txid);
+        println!(
+            "🟦  Publish {}.{}  Transaction broadcast {}",
+            expected_sender,
+            tx.contract_name.as_deref().unwrap_or(""),
+            txid
+        );
         captured_stdout.push_str(&format!(
             "Broadcasted ContractPublish(StandardPrincipalData({}), ContractName(\"{}\"), \"{}\")\n",
             expected_sender,
@@ -378,7 +427,8 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
 
 async fn read_deployment_plan(network: &str) -> Result<DeploymentPlanFile> {
     let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
-    let raw = fs::read_to_string(&plan_path).await
+    let raw = fs::read_to_string(&plan_path)
+        .await
         .map_err(|e| anyhow!("Failed to read deployment plan at {plan_path}: {e}"))?;
     serde_yaml::from_str(&raw)
         .map_err(|e| anyhow!("Failed to parse deployment plan at {plan_path}: {e}"))
@@ -444,7 +494,10 @@ async fn fetch_local_core_nonce(address: &str) -> Result<u64> {
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
     let url = format!("http://localhost:20443/v2/accounts/{address}?proof=0");
-    let response = client.get(&url).send().await
+    let response = client
+        .get(&url)
+        .send()
+        .await
         .map_err(|e| anyhow!("Failed to fetch local core account state from {url}: {e}"))?;
 
     if !response.status().is_success() {
@@ -471,12 +524,18 @@ fn derive_private_key_from_mnemonic(mnemonic: &str, derivation: &str) -> Result<
         .map_err(|e| anyhow!("Failed to derive root key from mnemonic: {e}"))?;
     let path = DerivationPath::from_str(derivation)
         .map_err(|e| anyhow!("Invalid devnet derivation path {derivation}: {e}"))?;
-    let child = root.derive_priv(&secp, &path)
+    let child = root
+        .derive_priv(&secp, &path)
         .map_err(|e| anyhow!("Failed to derive child key {derivation}: {e}"))?;
-    Ok(format!("{}01", hex::encode(child.private_key.secret_bytes())))
+    Ok(format!(
+        "{}01",
+        hex::encode(child.private_key.secret_bytes())
+    ))
 }
 
-pub async fn resolve_deployment_order(contracts_dir: &std::path::Path) -> anyhow::Result<Vec<String>> {
+pub async fn resolve_deployment_order(
+    contracts_dir: &std::path::Path,
+) -> anyhow::Result<Vec<String>> {
     let clarinet_raw = fs::read_to_string(contracts_dir.join("Clarinet.toml")).await?;
     let clarinet: ClarinetToml = toml::from_str(&clarinet_raw)
         .map_err(|e| anyhow::anyhow!("Failed to parse Clarinet.toml: {e}"))?;
@@ -523,12 +582,14 @@ fn check_plan_fee(network: &str) -> Result<()> {
         })
         .sum();
     if total_micro_stx > 0 {
-        println!("[deploy] Estimated fee: {:.6} STX", total_micro_stx as f64 / 1_000_000.0);
+        println!(
+            "[deploy] Estimated fee: {:.6} STX",
+            total_micro_stx as f64 / 1_000_000.0
+        );
     }
 
     Ok(())
 }
-
 
 async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
     let config = network_config(network);
@@ -537,7 +598,12 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
         .build()?;
 
     let _ = Command::new("clarinet")
-        .args(["deployments", "generate", &format!("--{}", network), "--low-cost"])
+        .args([
+            "deployments",
+            "generate",
+            &format!("--{}", network),
+            "--low-cost",
+        ])
         .current_dir("contracts")
         .status()
         .await;
@@ -549,25 +615,29 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
     let clarinet_path = base_dir.join("Clarinet.toml");
     let clarinet_raw = fs::read_to_string(&clarinet_path).await?;
     let mut clarinet_content = clarinet_raw.clone();
-    
+
     let clarinet_struct: ClarinetToml = toml::from_str(&clarinet_raw)?;
     let contracts = clarinet_struct.contracts.unwrap_or_default();
-    
+
     let mut any_changes = false;
 
     for (current_name, entry) in &contracts {
         let base_name = strip_version_suffix(current_name);
-        
+
         // Find the next available name on the network
-        let correct_name = find_next_free_name(&client, &config.stacks_node, &deployer, &base_name).await?;
+        let correct_name =
+            find_next_free_name(&client, &config.stacks_node, &deployer, &base_name).await?;
 
         if current_name == &correct_name {
             continue;
         }
 
-        println!("[deploy] Conflict detected: '{}' already exists on-chain. Renaming to '{}'", current_name, correct_name);
+        println!(
+            "[deploy] Conflict detected: '{}' already exists on-chain. Renaming to '{}'",
+            current_name, correct_name
+        );
 
-        let old_file_path = base_dir.join(&entry.path); 
+        let old_file_path = base_dir.join(&entry.path);
         let new_rel_path = format!("contracts/{}.clar", correct_name);
         let new_file_path = base_dir.join(&new_rel_path);
 
@@ -587,17 +657,24 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
         let dot_old_name = format!(".{}", current_name);
         let dot_new_name = format!(".{}", correct_name);
 
-        for (_, other_entry) in &contracts {
+        for other_entry in contracts.values() {
             let p = base_dir.join(&other_entry.path);
-            
-            let target_file = if p == old_file_path { &new_file_path } else { &p };
+
+            let target_file = if p == old_file_path {
+                &new_file_path
+            } else {
+                &p
+            };
 
             if target_file.exists() {
                 let source = fs::read_to_string(target_file).await?;
                 if source.contains(&dot_old_name) {
                     let updated_source = source.replace(&dot_old_name, &dot_new_name);
                     fs::write(target_file, updated_source).await?;
-                    println!("[deploy] Updated internal reference in {}", target_file.display());
+                    println!(
+                        "[deploy] Updated internal reference in {}",
+                        target_file.display()
+                    );
                 }
             }
         }
@@ -607,7 +684,7 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
 
     if any_changes {
         fs::write(&clarinet_path, &clarinet_content).await?;
-        
+
         // Remove all cached plans so Clarinet/SDK never hold onto stale
         // contract file paths after a version bump.
         for plan_name in [
@@ -620,7 +697,7 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
             let _ = fs::remove_file(plan_path).await;
         }
 
-        println!("[deploy] Clarinet.toml updated with new versions.");       
+        println!("[deploy] Clarinet.toml updated with new versions.");
         // Regenerate bindings so the frontend/tests use the new names
         let _ = Command::new("stacksdapp").arg("generate").status().await;
     }
@@ -631,8 +708,12 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
 /// Helper to parse the address Clarinet derived in the plan file
 async fn get_deployer_from_plan(network: &str) -> Result<String> {
     let plan_path = format!("contracts/deployments/default.{}-plan.yaml", network);
-    let content = fs::read_to_string(&plan_path).await
-        .map_err(|_| anyhow!("Clarinet plan not found at {}. Is the path correct?", plan_path))?;
+    let content = fs::read_to_string(&plan_path).await.map_err(|_| {
+        anyhow!(
+            "Clarinet plan not found at {}. Is the path correct?",
+            plan_path
+        )
+    })?;
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -640,7 +721,9 @@ async fn get_deployer_from_plan(network: &str) -> Result<String> {
             return Ok(trimmed.split(':').nth(1).unwrap_or("").trim().to_string());
         }
     }
-    Err(anyhow!("Could not find 'expected-sender' in the deployment plan. Check your mnemonic in settings."))
+    Err(anyhow!(
+        "Could not find 'expected-sender' in the deployment plan. Check your mnemonic in settings."
+    ))
 }
 /// Find the next free contract name starting from base_name (unversioned),
 /// then base_name-v2, base_name-v3, etc.
@@ -652,7 +735,10 @@ async fn find_next_free_name(
 ) -> Result<String> {
     // Check unversioned first (e.g. "counter")
     let url = format!("{node}/v2/contracts/source/{deployer}/{base_name}");
-    let base_free = !client.get(&url).send().await
+    let base_free = !client
+        .get(&url)
+        .send()
+        .await
         .map(|r| r.status().is_success())
         .unwrap_or(false);
 
@@ -665,7 +751,10 @@ async fn find_next_free_name(
     loop {
         let candidate = format!("{base_name}-v{version}");
         let url = format!("{node}/v2/contracts/interface/{deployer}/{candidate}");
-        let taken = client.get(&url).send().await
+        let taken = client
+            .get(&url)
+            .send()
+            .await
             .map(|r| r.status().is_success())
             .unwrap_or(false);
         if !taken {
@@ -679,7 +768,6 @@ async fn find_next_free_name(
         }
     }
 }
-
 
 /// Strip trailing -vN suffix: "counter-v2" → "counter", "foo-v10" → "foo"
 fn strip_version_suffix(name: &str) -> String {
@@ -697,8 +785,8 @@ fn strip_version_suffix(name: &str) -> String {
 
 fn validate_settings_mnemonic(network: &str) -> Result<()> {
     let path = format!("contracts/settings/{}.toml", capitalize(network));
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|_| anyhow!("Settings file not found: {path}"))?;
+    let raw =
+        std::fs::read_to_string(&path).map_err(|_| anyhow!("Settings file not found: {path}"))?;
     let mnemonic = parse_mnemonic(&raw).unwrap_or_default();
     if mnemonic.is_empty() || mnemonic.contains('<') || mnemonic.contains('>') {
         return Err(anyhow!(
@@ -716,10 +804,15 @@ fn parse_mnemonic(toml_raw: &str) -> Option<String> {
     let mut in_deployer = false;
     for line in toml_raw.lines() {
         let trimmed = line.trim();
-        if trimmed == "[accounts.deployer]" { in_deployer = true; continue; }
-        if trimmed.starts_with('[') { in_deployer = false; }
+        if trimmed == "[accounts.deployer]" {
+            in_deployer = true;
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_deployer = false;
+        }
         if in_deployer && trimmed.starts_with("mnemonic") {
-            if let Some(val) = trimmed.splitn(2, '=').nth(1) {
+            if let Some((_, val)) = trimmed.split_once('=') {
                 return Some(val.trim().trim_matches('"').to_string());
             }
         }
@@ -731,10 +824,15 @@ fn parse_deployer_derivation(toml_raw: &str) -> Option<String> {
     let mut in_deployer = false;
     for line in toml_raw.lines() {
         let trimmed = line.trim();
-        if trimmed == "[accounts.deployer]" { in_deployer = true; continue; }
-        if trimmed.starts_with('[') { in_deployer = false; }
+        if trimmed == "[accounts.deployer]" {
+            in_deployer = true;
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_deployer = false;
+        }
         if in_deployer && trimmed.starts_with("derivation") {
-            if let Some(val) = trimmed.splitn(2, '=').nth(1) {
+            if let Some((_, val)) = trimmed.split_once('=') {
                 return Some(val.trim().trim_matches('"').to_string());
             }
         }
@@ -748,13 +846,19 @@ async fn wait_for_node(url: &str) -> Result<()> {
         .build()?;
     println!("[deploy] Waiting for Stacks node at {url}...");
     for attempt in 1..=60 {
-        if client.get(&format!("{url}/v2/info")).send().await
-            .map(|r| r.status().is_success()).unwrap_or(false)
+        if client
+            .get(format!("{url}/v2/info"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
         {
             println!("[deploy] ✔ Node is ready");
             return Ok(());
         }
-        if attempt % 10 == 0 { println!("[deploy] Still waiting... ({attempt}s)"); }
+        if attempt % 10 == 0 {
+            println!("[deploy] Still waiting... ({attempt}s)");
+        }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
     Err(anyhow!(
@@ -782,7 +886,7 @@ async fn write_deployments_json_from_output(network: &str, output: &str) -> Resu
                 let rest = &line[pos + cn_marker.len()..];
                 if let Some(end) = rest.find('"') {
                     let contract_name = rest[..end].to_string();
-                    
+
                     // Extract TXID: It's the 64-char hex string inside quotes at the end
                     // Format: ...), "TXID") Publish ...
                     let parts: Vec<&str> = line.split('"').collect();
@@ -803,8 +907,8 @@ async fn write_deployments_json_from_output(network: &str, output: &str) -> Resu
         .unwrap_or_else(|| "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".to_string());
 
     let clarinet_raw = fs::read_to_string("contracts/Clarinet.toml").await?;
-    let clarinet: ClarinetToml = toml::from_str(&clarinet_raw)
-        .map_err(|e| anyhow!("Failed to parse Clarinet.toml: {e}"))?;
+    let clarinet: ClarinetToml =
+        toml::from_str(&clarinet_raw).map_err(|e| anyhow!("Failed to parse Clarinet.toml: {e}"))?;
     let contract_names: Vec<String> = clarinet
         .contracts
         .as_ref()
@@ -820,14 +924,22 @@ async fn write_deployments_json_from_output(network: &str, output: &str) -> Resu
 
     for name in contract_names {
         let contract_id = format!("{deployer_address}.{name}");
-        let txid = txid_map.get(&name)
+        let txid = txid_map
+            .get(&name)
             .map(|t| format!("0x{t}"))
             .unwrap_or_default();
-        println!("  ✔ {name} | txid {} | address {contract_id}",
-            if txid.is_empty() { "(pending)" } else { &txid });
-        contracts_map.insert(name.clone(), DeploymentInfo {
-            contract_id, tx_id: txid, block_height: 0,
-        });
+        println!(
+            "  ✔ {name} | txid {} | address {contract_id}",
+            if txid.is_empty() { "(pending)" } else { &txid }
+        );
+        contracts_map.insert(
+            name.clone(),
+            DeploymentInfo {
+                contract_id,
+                tx_id: txid,
+                block_height: 0,
+            },
+        );
     }
 
     let json = serde_json::to_string_pretty(&DeploymentFile {
@@ -837,7 +949,9 @@ async fn write_deployments_json_from_output(network: &str, output: &str) -> Resu
     })?;
 
     let out_path = Path::new("frontend/src/generated/deployments.json");
-    if let Some(p) = out_path.parent() { fs::create_dir_all(p).await?; }
+    if let Some(p) = out_path.parent() {
+        fs::create_dir_all(p).await?;
+    }
     fs::write(out_path, &json).await?;
     println!("\n[deploy] Written to {}", out_path.display());
     Ok(())
@@ -859,9 +973,7 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
         let mut pending = Vec::new();
 
         for contract_name in contract_names {
-            let url = format!(
-                "{node}/v2/contracts/source/{deployer}/{contract_name}?proof=0"
-            );
+            let url = format!("{node}/v2/contracts/source/{deployer}/{contract_name}?proof=0");
             let deployed = client
                 .get(&url)
                 .send()
@@ -938,14 +1050,10 @@ async fn fetch_local_core_info() -> Result<CoreInfoResponse> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
         .build()?;
-    let response = client
-        .get("http://localhost:20443/v2/info")
-        .send()
-        .await?;
+    let response = client.get("http://localhost:20443/v2/info").send().await?;
     let response = response.error_for_status()?;
     Ok(response.json().await?)
 }
-
 
 fn parse_deployer_address_from_settings(toml_raw: &str) -> Option<String> {
     for line in toml_raw.lines() {
@@ -989,10 +1097,7 @@ fn topological_sort(
     contracts: &HashMap<String, Vec<String>>, // name → [deps]
 ) -> anyhow::Result<Vec<String>> {
     // Build in-degree map
-    let mut in_degree: HashMap<&str, usize> = contracts
-        .keys()
-        .map(|k| (k.as_str(), 0))
-        .collect();
+    let mut in_degree: HashMap<&str, usize> = contracts.keys().map(|k| (k.as_str(), 0)).collect();
 
     for deps in contracts.values() {
         for dep in deps {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -50,13 +50,25 @@ pub enum AbiType {
         string_utf8: StringLen,
     },
     // SDK emits { "buffer": { "length": N } }
-    Buffer { buffer: StringLen },
+    Buffer {
+        buffer: StringLen,
+    },
     // Legacy { "buff": N }
-    Buff { buff: u32 },
-    List { list: ListDef },
-    Tuple { tuple: Vec<TupleEntry> },
-    Optional { optional: Box<AbiType> },
-    Response { response: ResponseDef },
+    Buff {
+        buff: u32,
+    },
+    List {
+        list: ListDef,
+    },
+    Tuple {
+        tuple: Vec<TupleEntry>,
+    },
+    Optional {
+        optional: Box<AbiType>,
+    },
+    Response {
+        response: ResponseDef,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use std::path::Path;
 use tokio::{fs, process::Command};
 
-
 /// Returns true if Clarinet.toml contains any [[project.requirements]] entries.
 async fn has_requirements() -> bool {
     let Ok(raw) = fs::read_to_string("contracts/Clarinet.toml").await else {
@@ -27,9 +26,11 @@ async fn prefetch_requirements() -> Result<()> {
         .current_dir("contracts")
         .status()
         .await
-        .map_err(|_| anyhow!(
-            "clarinet is required. Install: brew install clarinet  OR  cargo install clarinet"
-        ))?;
+        .map_err(|_| {
+            anyhow!(
+                "clarinet is required. Install: brew install clarinet  OR  cargo install clarinet"
+            )
+        })?;
 
     if !status.success() {
         return Err(anyhow!(
@@ -55,7 +56,8 @@ pub async fn dev(network: &str) -> Result<()> {
         "devnet" => dev_devnet().await,
         "testnet" | "mainnet" => dev_remote(network).await,
         other => Err(anyhow!(
-            "Unknown network '{}'. Use: devnet, testnet, or mainnet", other
+            "Unknown network '{}'. Use: devnet, testnet, or mainnet",
+            other
         )),
     }
 }
@@ -106,7 +108,10 @@ async fn dev_devnet() -> Result<()> {
 // Contracts must already be deployed (`stacks-dapp deploy --network testnet`).
 
 async fn dev_remote(network: &str) -> Result<()> {
-    println!("[dev] Starting frontend for {} (no local chain needed)...", network);
+    println!(
+        "[dev] Starting frontend for {} (no local chain needed)...",
+        network
+    );
 
     // Verify deployments.json has entries for this network
     check_deployments(network)?;

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -7,8 +7,7 @@ use std::time::Duration;
 use tokio::process::Command;
 use which::which;
 
-static FRONTEND_TEMPLATE: Dir =
-    include_dir!("$CARGO_MANIFEST_DIR/frontend-template");
+static FRONTEND_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-template");
 
 pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     println!();
@@ -21,11 +20,13 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
 
     let root = Path::new(name);
     if root.exists() {
-        return Err(anyhow!("  \x1b[31m✗\x1b[0m Directory '{name}' already exists"));
+        return Err(anyhow!(
+            "  \x1b[31m✗\x1b[0m Directory '{name}' already exists"
+        ));
     }
 
     let style = ProgressStyle::with_template(
-        "  {spinner:.yellow} {wide_msg:.dim}  \x1b[2m[{elapsed}]\x1b[0m"
+        "  {spinner:.yellow} {wide_msg:.dim}  \x1b[2m[{elapsed}]\x1b[0m",
     )
     .unwrap()
     .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
@@ -51,7 +52,9 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
 
     write_project_files(name, root, &frontend_dir, &contracts_root).await?;
 
-    pb.println(format!("  \x1b[32m✔\x1b[0m  \x1b[1mScaffolded\x1b[0m   {name}/"));
+    pb.println(format!(
+        "  \x1b[32m✔\x1b[0m  \x1b[1mScaffolded\x1b[0m   {name}/"
+    ));
 
     // ── Step 2: Install dependencies (parallel) ───────────────────────────────
     pb.set_message("Installing dependencies...");
@@ -133,7 +136,9 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     println!();
     println!("     \x1b[1;36m1\x1b[0m  cd {name}");
     println!("     \x1b[1;36m2\x1b[0m  Get testnet STX \x1b[2m→\x1b[0m  https://explorer.hiro.so/sandbox/faucet?chain=testnet");
-    println!("     \x1b[1;36m3\x1b[0m  Add mnemonic to \x1b[1mcontracts/settings/Testnet.toml\x1b[0m");
+    println!(
+        "     \x1b[1;36m3\x1b[0m  Add mnemonic to \x1b[1mcontracts/settings/Testnet.toml\x1b[0m"
+    );
     println!("        \x1b[2m[accounts.deployer]\x1b[0m");
     println!("        \x1b[2mmnemonic = \"your 24 words here\"\x1b[0m");
     println!("     \x1b[1;36m4\x1b[0m  \x1b[1mstacksdapp deploy --network testnet\x1b[0m");
@@ -160,7 +165,9 @@ async fn write_project_files(
     frontend_dir: &Path,
     contracts_root: &Path,
 ) -> Result<()> {
-    tokio::fs::write(contracts_root.join("package.json"), r#"{
+    tokio::fs::write(
+        contracts_root.join("package.json"),
+        r#"{
   "name": "contracts",
   "private": true,
   "type": "module",
@@ -174,15 +181,23 @@ async fn write_project_files(
     "vitest": "^1"
   }
 }
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join("vitest.config.ts"), r#"import { defineConfig } from 'vitest/config';
+    tokio::fs::write(
+        contracts_root.join("vitest.config.ts"),
+        r#"import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: { environment: 'node' },
 });
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join("tsconfig.json"), r#"{
+    tokio::fs::write(
+        contracts_root.join("tsconfig.json"),
+        r#"{
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
@@ -192,9 +207,14 @@ export default defineConfig({
   },
   "include": ["tests/**/*.ts"]
 }
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join("Clarinet.toml"), format!(r#"[project]
+    tokio::fs::write(
+        contracts_root.join("Clarinet.toml"),
+        format!(
+            r#"[project]
 name = "{name}"
 description = ""
 authors = []
@@ -209,7 +229,10 @@ epoch = "latest"
 
 [repl.costs_version]
 version = 2
-"#)).await?;
+"#
+        ),
+    )
+    .await?;
 
     tokio::fs::write(contracts_root.join("settings/Devnet.toml"), r#"[network]
 name = "devnet"
@@ -304,25 +327,35 @@ slots = 2
 btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
 "#).await?;
 
-    tokio::fs::write(contracts_root.join("settings/Testnet.toml"), r#"[network]
+    tokio::fs::write(
+        contracts_root.join("settings/Testnet.toml"),
+        r#"[network]
 name = "testnet"
 stacks_node_rpc_address = "https://api.testnet.hiro.so"
 deployment_fee_rate = 10
 
 [accounts.deployer]
 mnemonic = "<YOUR PRIVATE TESTNET MNEMONIC HERE>"
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join("settings/Mainnet.toml"), r#"[network]
+    tokio::fs::write(
+        contracts_root.join("settings/Mainnet.toml"),
+        r#"[network]
 name = "mainnet"
 stacks_node_rpc_address = "https://api.hiro.so"
 deployment_fee_rate = 10
 
 [accounts.deployer]
 mnemonic = "<YOUR PRIVATE MAINNET MNEMONIC HERE>"
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join("contracts/counter.clar"), r#";; counter.clar scaffolded by scaffold-stacks
+    tokio::fs::write(
+        contracts_root.join("contracts/counter.clar"),
+        r#";; counter.clar scaffolded by scaffold-stacks
 
 (define-data-var counter uint u0)
 
@@ -344,9 +377,13 @@ mnemonic = "<YOUR PRIVATE MAINNET MNEMONIC HERE>"
   (begin
     (var-set counter u0)
     (ok u0)))
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join("tests/counter.test.ts"), r#"import { describe, expect, it } from 'vitest';
+    tokio::fs::write(
+        contracts_root.join("tests/counter.test.ts"),
+        r#"import { describe, expect, it } from 'vitest';
 import { initSimnet } from '@stacks/clarinet-sdk';
 import { Cl } from '@stacks/transactions';
 
@@ -368,13 +405,17 @@ describe('counter', () => {
     expect(result).toBeOk(Cl.uint(0));
   });
 });
-"#).await?;
+"#,
+    )
+    .await?;
 
     tokio::fs::write(root.join("package.json"), format!(
         "{{\n  \"name\": \"{name}\",\n  \"private\": true,\n  \"scripts\": {{\n    \"dev\": \"stacksdapp dev\",\n    \"generate\": \"stacksdapp generate\",\n    \"deploy\": \"stacksdapp deploy\",\n    \"test\": \"stacksdapp test\",\n    \"check\": \"stacksdapp check\"\n  }}\n}}\n"
     )).await?;
 
-    tokio::fs::write(root.join(".gitignore"), r#"# Rust
+    tokio::fs::write(
+        root.join(".gitignore"),
+        r#"# Rust
 target/
 
 # Node
@@ -398,9 +439,13 @@ frontend/out/
 # OS
 .DS_Store
 *.pem
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(frontend_dir.join(".gitignore"), r#"node_modules/
+    tokio::fs::write(
+        frontend_dir.join(".gitignore"),
+        r#"node_modules/
 .env
 .env.local
 .env.*.local
@@ -409,9 +454,13 @@ out/
 .DS_Store
 *.tsbuildinfo
 next-env.d.ts
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(contracts_root.join(".gitignore"), r#"node_modules/
+    tokio::fs::write(
+        contracts_root.join(".gitignore"),
+        r#"node_modules/
 .cache/
 .devnet/
 settings/Simnet.toml
@@ -419,16 +468,24 @@ settings/Simnet.toml
 .env.local
 .env.*.local
 .DS_Store
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(frontend_dir.join(".env.local"), r#"# Network: devnet | testnet | mainnet
+    tokio::fs::write(
+        frontend_dir.join(".env.local"),
+        r#"# Network: devnet | testnet | mainnet
 NEXT_PUBLIC_NETWORK=devnet
 
 # Required for testnet/mainnet deploy:
 # DEPLOYER_PRIVATE_KEY=your_private_key_hex
-"#).await?;
+"#,
+    )
+    .await?;
 
-    tokio::fs::write(frontend_dir.join(".env.local.example"), r#"# Network: devnet | testnet | mainnet
+    tokio::fs::write(
+        frontend_dir.join(".env.local.example"),
+        r#"# Network: devnet | testnet | mainnet
 NEXT_PUBLIC_NETWORK=devnet
 
 # Required for testnet/mainnet deploy:
@@ -436,7 +493,9 @@ NEXT_PUBLIC_NETWORK=devnet
 
 # Optional node URL override:
 # NEXT_PUBLIC_STACKS_NODE_URL=https://api.testnet.hiro.so
-"#).await?;
+"#,
+    )
+    .await?;
 
     Ok(())
 }
@@ -457,7 +516,8 @@ pub async fn add_contract(name: &str, template: &str) -> Result<()> {
     // ── Template Selection ───────────────────────────────────────────────────
     let (contract_source, test_source, contract_id) = match template {
         "sip010" => (
-            format!(r#";; {name}.clar Fungible Token
+            format!(
+                r#";; {name}.clar Fungible Token
 
 (define-fungible-token {name})
 
@@ -500,8 +560,10 @@ pub async fn add_contract(name: &str, template: &str) -> Result<()> {
     (try! (ft-transfer? {name} amount sender recipient))
     (match memo to-print (print to-print) 0x)
     (ok true)))
-"#),
-            format!(r#"import {{ describe, expect, it }} from 'vitest';
+"#
+            ),
+            format!(
+                r#"import {{ describe, expect, it }} from 'vitest';
 import {{ initSimnet }} from '@stacks/clarinet-sdk';
 import {{ Cl }} from '@stacks/transactions';
 
@@ -516,12 +578,14 @@ describe('{name} FT', () => {{
     expect(result).toBeOk(Cl.bool(true));
   }});
 }});
-"#),
-            Some("SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard")
+"#
+            ),
+            Some("SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard"),
         ),
 
         "sip009" => (
-            format!(r#";; {name}.clar Non-Fungible Token
+            format!(
+                r#";; {name}.clar Non-Fungible Token
 
 (define-non-fungible-token {name} uint)
 
@@ -562,8 +626,10 @@ describe('{name} FT', () => {{
     (try! (nft-mint? {name} token-id recipient))
     (var-set last-token-id token-id)
     (ok token-id)))
-"#),
-            format!(r#"import {{ describe, expect, it }} from 'vitest';
+"#
+            ),
+            format!(
+                r#"import {{ describe, expect, it }} from 'vitest';
 import {{ initSimnet }} from '@stacks/clarinet-sdk';
 import {{ Cl }} from '@stacks/transactions';
 
@@ -577,13 +643,17 @@ describe('{name} NFT', () => {{
     expect(result).toBeOk(Cl.uint(1));
   }});
 }});
-"#),
-            Some("SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait")
+"#
+            ),
+            Some("SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait"),
         ),
 
         _ => (
-            format!(";; {name}.clar\n\n(define-read-only (get-info)\n  (ok \"{name} contract\"))\n"),
-            format!(r#"import {{ describe, expect, it }} from 'vitest';
+            format!(
+                ";; {name}.clar\n\n(define-read-only (get-info)\n  (ok \"{name} contract\"))\n"
+            ),
+            format!(
+                r#"import {{ describe, expect, it }} from 'vitest';
 import {{ initSimnet }} from '@stacks/clarinet-sdk';
 import {{ Cl }} from '@stacks/transactions';
 
@@ -597,8 +667,9 @@ describe('{name}', () => {{
     expect(result).toBeOk(Cl.stringAscii('{name} contract'));
   }});
 }});
-"#),
-            None
+"#
+            ),
+            None,
         ),
     };
 
@@ -613,7 +684,6 @@ describe('{name}', () => {{
     let clarinet_toml_path = Path::new("contracts/Clarinet.toml");
     let mut existing = tokio::fs::read_to_string(clarinet_toml_path).await?;
 
-    
     existing = existing.replace("requirements = []", "");
 
     // Add remote requirement if specified
@@ -628,7 +698,7 @@ describe('{name}', () => {{
     existing.push_str(&format!(
         "\n[contracts.{name}]\npath = \"contracts/{name}.clar\"\nclarity_version = 4\nepoch = \"latest\"\n"
     ));
-    
+
     tokio::fs::write(clarinet_toml_path, existing).await?;
 
     // Regenerate Bindings

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -17,11 +17,10 @@ pub async fn watch_contracts(contracts_dir: &Path) -> Result<()> {
 
     while let Some(event) = rx.recv().await {
         if let Ok(e) = event {
-            if e.paths.iter().any(|p| {
-                p.extension()
-                    .map(|x| x == "clar")
-                    .unwrap_or(false)
-            }) {
+            if e.paths
+                .iter()
+                .any(|p| p.extension().map(|x| x == "clar").unwrap_or(false))
+            {
                 println!("[watcher] .clar change detected — regenerating...");
                 if let Err(e) = stacksdapp_codegen::generate_all().await {
                     eprintln!("[watcher] codegen error: {e}");


### PR DESCRIPTION
## Summary

Closes #12 — adds an end-to-end integration test suite for the `stacksdapp` CLI.

- **22 integration tests** using `assert_cmd` + `tempfile`, organized into 8 tiers:
  - CLI argument parsing (help, version, unknown subcommands)
  - `new` command — scaffolds project in tempdir, verifies full file structure
  - `add` command — blank, SIP-010, SIP-009 templates + duplicate detection
  - `generate` command — TypeScript binding output, idempotency check
  - `clean` command — removes generated files, recreates empty deployments.json
  - Full flow — `new → generate → add → generate` end-to-end
  - Error handling — graceful failures outside project context
  - `doctor` command — runs without crash
- Tests **gracefully skip** when `node`/`clarinet` toolchain is not installed
- **Enables GitHub Actions CI** with 4 parallel jobs: lint, unit tests, integration tests, release build
- CI installs Node.js 20 + Clarinet 3.16.0 for integration test job
- Applies `cargo fmt --all` and `cargo clippy` fixes across the entire workspace

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 9 fast integration tests pass locally
- [x] Scaffold-dependent tests (`new`, `generate`) pass locally (245s, 220s)
- [x] `cargo test --all --lib` passes
- [ ] CI pipeline runs green on this PR