### PR TITLE
feat(cli): add deploy dry-run and single-contract deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacksdapp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-codegen"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-process-supervisor"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-scaffold"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-deployer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bip39",

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ mnemonic = "your 24 words here"
 stacksdapp deploy --network testnet
 # deploy a single contract only
 stacksdapp deploy --network testnet --contract counter
+# preview deployment without broadcasting
+stacksdapp deploy --network testnet --dry-run
 ```
 
 ```
@@ -218,6 +220,7 @@ my-app/
 | `stacksdapp dev` | Start local devnet + frontend + watcher (Docker required) |
 | `stacksdapp deploy --network testnet` | Deploy to testnet |
 | `stacksdapp deploy --network testnet --contract <name>` | Deploy only one contract by name |
+| `stacksdapp deploy --network testnet --dry-run` | Generate plan + estimated fee without broadcasting |
 | `stacksdapp deploy --network mainnet` | Deploy to mainnet |
 | `stacksdapp deploy --network devnet` | Deploy to local devnet |
 | `stacksdapp generate` | Parse ABIs → regenerate TS bindings + debug UI |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ mnemonic = "your 24 words here"
 
 ```bash
 stacksdapp deploy --network testnet
+# deploy a single contract only
+stacksdapp deploy --network testnet --contract counter
 ```
 
 ```
@@ -215,6 +217,7 @@ my-app/
 | `stacksdapp dev --network mainnet` | Run frontend against mainnet (no Docker) |
 | `stacksdapp dev` | Start local devnet + frontend + watcher (Docker required) |
 | `stacksdapp deploy --network testnet` | Deploy to testnet |
+| `stacksdapp deploy --network testnet --contract <name>` | Deploy only one contract by name |
 | `stacksdapp deploy --network mainnet` | Deploy to mainnet |
 | `stacksdapp deploy --network devnet` | Deploy to local devnet |
 | `stacksdapp generate` | Parse ABIs → regenerate TS bindings + debug UI |

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "stacksdapp"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "The official stacksdapp CLI: A complete toolkit to scaffold, build, and deploy full-stack Bitcoin applications on Stacks."
 license     = "MIT"
@@ -12,12 +12,12 @@ name = "stacksdapp"
 path = "src/main.rs"
 
 [dependencies]
-stacksdapp-scaffold           = {version = "0.1.3", path = "../crates/scaffold" }
+stacksdapp-scaffold           = {version = "0.1.4", path = "../crates/scaffold" }
 stacksdapp-parser             = {version = "0.1.1", path = "../crates/parser" }
-stacksdapp-codegen            = {version = "0.1.1", path = "../crates/codegen" }
+stacksdapp-codegen            = {version = "0.1.2", path = "../crates/codegen" }
 stacksdapp-watcher            = {version = "0.1.1", path = "../crates/watcher" }
 stacksdapp-deployer           = {version = "0.1.1", path = "../crates/deployer" }
-stacksdapp-process-supervisor = {version = "0.1.1", path = "../crates/process_supervisor" }
+stacksdapp-process-supervisor = {version = "0.1.2", path = "../crates/process_supervisor" }
 clap.workspace      = true
 tokio.workspace     = true
 anyhow.workspace    = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ stacksdapp-scaffold           = {version = "0.1.4", path = "../crates/scaffold" 
 stacksdapp-parser             = {version = "0.1.1", path = "../crates/parser" }
 stacksdapp-codegen            = {version = "0.1.2", path = "../crates/codegen" }
 stacksdapp-watcher            = {version = "0.1.1", path = "../crates/watcher" }
-stacksdapp-deployer           = {version = "0.1.1", path = "../crates/deployer" }
+stacksdapp-deployer           = {version = "0.1.2", path = "../crates/deployer" }
 stacksdapp-process-supervisor = {version = "0.1.2", path = "../crates/process_supervisor" }
 clap.workspace      = true
 tokio.workspace     = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,6 +49,9 @@ enum Commands {
         /// Deploy a single contract by name (must exist in contracts/Clarinet.toml)
         #[arg(long)]
         contract: Option<String>,
+        /// Generate plan and fee estimate without broadcasting transactions
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Run contract tests (vitest)
     Test,
@@ -70,8 +73,12 @@ async fn main() -> Result<()> {
         Commands::Add { name, template } => {
             stacksdapp_scaffold::add_contract(&name, &template).await
         }
-        Commands::Deploy { network, contract } => {
-            stacksdapp_deployer::deploy(&network, contract.as_deref()).await
+        Commands::Deploy {
+            network,
+            contract,
+            dry_run,
+        } => {
+            stacksdapp_deployer::deploy(&network, contract.as_deref(), dry_run).await
         }
         Commands::Test => run_test().await,
         Commands::Check => run_check().await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -46,6 +46,9 @@ enum Commands {
     Deploy {
         #[arg(long, default_value = "devnet")]
         network: String,
+        /// Deploy a single contract by name (must exist in contracts/Clarinet.toml)
+        #[arg(long)]
+        contract: Option<String>,
     },
     /// Run contract tests (vitest)
     Test,
@@ -67,7 +70,9 @@ async fn main() -> Result<()> {
         Commands::Add { name, template } => {
             stacksdapp_scaffold::add_contract(&name, &template).await
         }
-        Commands::Deploy { network } => stacksdapp_deployer::deploy(&network).await,
+        Commands::Deploy { network, contract } => {
+            stacksdapp_deployer::deploy(&network, contract.as_deref()).await
+        }
         Commands::Test => run_test().await,
         Commands::Check => run_check().await,
         Commands::Clean => run_clean().await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -77,9 +77,7 @@ async fn main() -> Result<()> {
             network,
             contract,
             dry_run,
-        } => {
-            stacksdapp_deployer::deploy(&network, contract.as_deref(), dry_run).await
-        }
+        } => stacksdapp_deployer::deploy(&network, contract.as_deref(), dry_run).await,
         Commands::Test => run_test().await,
         Commands::Check => run_check().await,
         Commands::Clean => run_clean().await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -82,7 +82,14 @@ async fn run_test() -> Result<()> {
     if tokio::fs::metadata("contracts/node_modules").await.is_err() {
         println!("{}", "[test] Installing contract dependencies...".cyan());
         let install = Command::new("npm")
-            .arg("install")
+            .args([
+                "install",
+                "--no-audit",
+                "--no-fund",
+                "--prefer-offline",
+                "--progress=false",
+                "--loglevel=error",
+            ])
             .current_dir("contracts")
             .status()
             .await;

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-codegen"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "TypeScript code generation engine for Stacks dApps, using Tera templates to create type-safe contract hooks."
 license     = "MIT"

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -84,9 +84,16 @@ pub async fn generate_all() -> Result<()> {
 
     let frontend_dir = project_root.join("frontend");
     if !frontend_dir.join("node_modules").exists() {
-        println!("Installing frontend dependencies (npm install)...");
+        println!("[generate] Installing frontend dependencies...");
         let status = tokio::process::Command::new("npm")
-            .arg("install")
+            .args([
+                "install",
+                "--no-audit",
+                "--no-fund",
+                "--prefer-offline",
+                "--progress=false",
+                "--loglevel=error",
+            ])
             .current_dir(&frontend_dir)
             .status()
             .await?;

--- a/crates/deployer/Cargo.toml
+++ b/crates/deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-deployer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "A specialized deployment utility for broadcasting Clarity smart contracts to Stacks devnet, testnet, and mainnet."
 license     = "MIT"

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -126,10 +126,6 @@ pub async fn deploy(network: &str, contract: Option<&str>) -> Result<()> {
 // ── Core deploy ───────────────────────────────────────────────────────────────
 
 async fn deploy_via_clarinet(network: &str, contract: Option<&str>) -> Result<()> {
-    // Always use --low-cost for fee estimation.
-    // Testnet fee estimation is unreliable (low tx volume → extreme outliers).
-    // Mainnet fees are set conservatively — increase to "--medium-cost" if
-    // transactions are not confirming within a reasonable time.
     let fee_flag = "--low-cost";
 
     let contracts_dir = std::path::Path::new("contracts");
@@ -139,8 +135,7 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>) -> Result<()
     }
     reorder_clarinet_toml(contracts_dir, &ordered).await?;
 
-    // Step 1: resolve all conflicts BEFORE touching clarinet.
-    // This runs until Clarinet.toml has no contracts that exist on-chain.
+   
     if network == "testnet" || network == "mainnet" {
         println!(
             "[deploy] Checking for contract name conflicts on {}...",
@@ -149,11 +144,8 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>) -> Result<()
         auto_version_conflicting_contracts(network, contract).await?;
     }
 
-    // Step 2: generate + apply
+ 
     let clarinet_output = run_generate_and_apply(network, fee_flag, contract).await?;
-
-    // Step 3: if clarinet still reports ContractAlreadyExists (race condition
-    // or something we missed), resolve again and retry once more.
     if clarinet_output.contains("ContractAlreadyExists") {
         println!("[deploy] Unexpected conflict after versioning — re-resolving and retrying...");
         auto_version_conflicting_contracts(network, contract).await?;
@@ -171,8 +163,7 @@ async fn reorder_clarinet_toml(
     let path = contracts_dir.join("Clarinet.toml");
     let raw = fs::read_to_string(&path).await?;
 
-    // Split into the project header (everything before the first [contracts.])
-    // and the individual contract blocks
+   
     let first_contract = raw.find("\n[contracts.").unwrap_or(raw.len());
     let header = raw[..first_contract].to_string();
 
@@ -302,9 +293,7 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str, contract: Option<
 
         // Handle interactive fee prompts
         if line.contains("Overwrite?") {
-            // For single-contract deploys we explicitly filtered the on-disk plan.
-            // Answer "n" to preserve that file instead of letting Clarinet recompute
-            // from Clarinet.toml (which would re-include all contracts).
+
             let answer = if contract.is_some() { b"n\n" } else { b"y\n" };
             let _ = stdin.write_all(answer).await;
             let _ = stdin.flush().await;
@@ -617,8 +606,6 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
 
-    // Prevent Clarinet from prompting "Overwrite? [Y/n]" during the
-    // conflict-check prepass. This command must stay non-interactive.
     let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
     if Path::new(&plan_path).exists() {
         let _ = fs::remove_file(&plan_path).await;
@@ -715,8 +702,6 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
     if any_changes {
         fs::write(&clarinet_path, &clarinet_content).await?;
 
-        // Remove all cached plans so Clarinet/SDK never hold onto stale
-        // contract file paths after a version bump.
         for plan_name in [
             "default.devnet-plan.yaml",
             "default.simnet-plan.yaml",
@@ -755,8 +740,7 @@ async fn get_deployer_from_plan(network: &str) -> Result<String> {
         "Could not find 'expected-sender' in the deployment plan. Check your mnemonic in settings."
     ))
 }
-/// Find the next free contract name starting from base_name (unversioned),
-/// then base_name-v2, base_name-v3, etc.
+
 async fn find_next_free_name(
     client: &reqwest::Client,
     node: &str,

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -99,7 +99,7 @@ struct DeploymentFile {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
-pub async fn deploy(network: &str, contract: Option<&str>) -> Result<()> {
+pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool) -> Result<()> {
     if !Path::new("contracts/Clarinet.toml").exists() {
         return Err(anyhow!(
             "No scaffold-stacks project found. Run from the directory created by stacksdapp new"
@@ -115,17 +115,20 @@ pub async fn deploy(network: &str, contract: Option<&str>) -> Result<()> {
     if let Some(name) = contract {
         println!("[deploy] Contract filter enabled: {name}");
     }
+    if dry_run {
+        println!("[deploy] Dry run enabled: plan will not be applied.");
+    }
 
     if network == "devnet" {
         wait_for_node(&config.stacks_node).await?;
     }
 
-    deploy_via_clarinet(network, contract).await
+    deploy_via_clarinet(network, contract, dry_run).await
 }
 
 // ── Core deploy ───────────────────────────────────────────────────────────────
 
-async fn deploy_via_clarinet(network: &str, contract: Option<&str>) -> Result<()> {
+async fn deploy_via_clarinet(network: &str, contract: Option<&str>, dry_run: bool) -> Result<()> {
     let fee_flag = "--low-cost";
 
     let contracts_dir = std::path::Path::new("contracts");
@@ -145,11 +148,15 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>) -> Result<()
     }
 
  
-    let clarinet_output = run_generate_and_apply(network, fee_flag, contract).await?;
+    let clarinet_output = run_generate_and_apply(network, fee_flag, contract, dry_run).await?;
+
+    if dry_run {
+        return Ok(());
+    }
     if clarinet_output.contains("ContractAlreadyExists") {
         println!("[deploy] Unexpected conflict after versioning — re-resolving and retrying...");
         auto_version_conflicting_contracts(network, contract).await?;
-        let clarinet_output2 = run_generate_and_apply(network, fee_flag, contract).await?;
+        let clarinet_output2 = run_generate_and_apply(network, fee_flag, contract, dry_run).await?;
         return write_deployments_json_from_output(network, &clarinet_output2, contract).await;
     }
 
@@ -208,7 +215,12 @@ async fn reorder_clarinet_toml(
 }
 
 /// Run `clarinet deployments generate` then `apply`, returning stdout.
-async fn run_generate_and_apply(network: &str, fee_flag: &str, contract: Option<&str>) -> Result<String> {
+async fn run_generate_and_apply(
+    network: &str,
+    fee_flag: &str,
+    contract: Option<&str>,
+    dry_run: bool,
+) -> Result<String> {
     // Delete stale plan so clarinet never prompts "Overwrite? [Y/n]"
     let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
     if Path::new(&plan_path).exists() {
@@ -242,6 +254,16 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str, contract: Option<
     }
 
     check_plan_fee(network)?;
+    let contracts = deployment_contract_names_from_plan(network).await?;
+    println!("[deploy] Plan contracts: {}", contracts.join(", "));
+
+    if dry_run {
+        println!(
+            "[deploy] Dry run complete. No transactions were broadcast.\n\
+             [deploy] Re-run without --dry-run to apply this plan."
+        );
+        return Ok(String::new());
+    }
 
     if network == "devnet" {
         return run_apply_devnet_direct(network).await;

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -138,7 +138,6 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>, dry_run: boo
     }
     reorder_clarinet_toml(contracts_dir, &ordered).await?;
 
-   
     if network == "testnet" || network == "mainnet" {
         println!(
             "[deploy] Checking for contract name conflicts on {}...",
@@ -147,7 +146,6 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>, dry_run: boo
         auto_version_conflicting_contracts(network, contract).await?;
     }
 
- 
     let clarinet_output = run_generate_and_apply(network, fee_flag, contract, dry_run).await?;
 
     if dry_run {
@@ -170,7 +168,6 @@ async fn reorder_clarinet_toml(
     let path = contracts_dir.join("Clarinet.toml");
     let raw = fs::read_to_string(&path).await?;
 
-   
     let first_contract = raw.find("\n[contracts.").unwrap_or(raw.len());
     let header = raw[..first_contract].to_string();
 
@@ -315,7 +312,6 @@ async fn run_generate_and_apply(
 
         // Handle interactive fee prompts
         if line.contains("Overwrite?") {
-
             let answer = if contract.is_some() { b"n\n" } else { b"y\n" };
             let _ = stdin.write_all(answer).await;
             let _ = stdin.flush().await;
@@ -1055,7 +1051,9 @@ async fn filter_plan_to_contract(network: &str, contract_name: &str) -> Result<(
         .ok_or_else(|| anyhow!("Deployment plan is missing plan.batches"))?;
 
     for batch in batches.iter_mut() {
-        let Some(transactions) = batch.get_mut("transactions").and_then(|t| t.as_sequence_mut())
+        let Some(transactions) = batch
+            .get_mut("transactions")
+            .and_then(|t| t.as_sequence_mut())
         else {
             continue;
         };

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -43,22 +43,22 @@ struct ContractEntry {
     path: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct DeploymentPlanFile {
     plan: DeploymentPlan,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct DeploymentPlan {
     batches: Vec<DeploymentBatch>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct DeploymentBatch {
     transactions: Vec<DeploymentTransaction>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 struct DeploymentTransaction {
     #[serde(rename = "transaction-type")]
     transaction_type: String,
@@ -83,14 +83,14 @@ struct CoreInfoResponse {
     stacks_tip_height: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct DeploymentInfo {
     contract_id: String,
     tx_id: String,
     block_height: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct DeploymentFile {
     network: String,
     deployed_at: String,
@@ -99,7 +99,7 @@ struct DeploymentFile {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
-pub async fn deploy(network: &str) -> Result<()> {
+pub async fn deploy(network: &str, contract: Option<&str>) -> Result<()> {
     if !Path::new("contracts/Clarinet.toml").exists() {
         return Err(anyhow!(
             "No scaffold-stacks project found. Run from the directory created by stacksdapp new"
@@ -112,17 +112,20 @@ pub async fn deploy(network: &str) -> Result<()> {
 
     let config = network_config(network);
     println!("🚀 Deploying to {} ({})", network, config.stacks_node);
+    if let Some(name) = contract {
+        println!("[deploy] Contract filter enabled: {name}");
+    }
 
     if network == "devnet" {
         wait_for_node(&config.stacks_node).await?;
     }
 
-    deploy_via_clarinet(network).await
+    deploy_via_clarinet(network, contract).await
 }
 
 // ── Core deploy ───────────────────────────────────────────────────────────────
 
-async fn deploy_via_clarinet(network: &str) -> Result<()> {
+async fn deploy_via_clarinet(network: &str, contract: Option<&str>) -> Result<()> {
     // Always use --low-cost for fee estimation.
     // Testnet fee estimation is unreliable (low tx volume → extreme outliers).
     // Mainnet fees are set conservatively — increase to "--medium-cost" if
@@ -131,6 +134,9 @@ async fn deploy_via_clarinet(network: &str) -> Result<()> {
 
     let contracts_dir = std::path::Path::new("contracts");
     let ordered = resolve_deployment_order(contracts_dir).await?;
+    if let Some(name) = contract {
+        ensure_contract_exists(&ordered, name)?;
+    }
     reorder_clarinet_toml(contracts_dir, &ordered).await?;
 
     // Step 1: resolve all conflicts BEFORE touching clarinet.
@@ -140,22 +146,22 @@ async fn deploy_via_clarinet(network: &str) -> Result<()> {
             "[deploy] Checking for contract name conflicts on {}...",
             network
         );
-        auto_version_conflicting_contracts(network).await?;
+        auto_version_conflicting_contracts(network, contract).await?;
     }
 
     // Step 2: generate + apply
-    let clarinet_output = run_generate_and_apply(network, fee_flag).await?;
+    let clarinet_output = run_generate_and_apply(network, fee_flag, contract).await?;
 
     // Step 3: if clarinet still reports ContractAlreadyExists (race condition
     // or something we missed), resolve again and retry once more.
     if clarinet_output.contains("ContractAlreadyExists") {
         println!("[deploy] Unexpected conflict after versioning — re-resolving and retrying...");
-        auto_version_conflicting_contracts(network).await?;
-        let clarinet_output2 = run_generate_and_apply(network, fee_flag).await?;
-        return write_deployments_json_from_output(network, &clarinet_output2).await;
+        auto_version_conflicting_contracts(network, contract).await?;
+        let clarinet_output2 = run_generate_and_apply(network, fee_flag, contract).await?;
+        return write_deployments_json_from_output(network, &clarinet_output2, contract).await;
     }
 
-    write_deployments_json_from_output(network, &clarinet_output).await
+    write_deployments_json_from_output(network, &clarinet_output, contract).await
 }
 
 async fn reorder_clarinet_toml(
@@ -211,7 +217,7 @@ async fn reorder_clarinet_toml(
 }
 
 /// Run `clarinet deployments generate` then `apply`, returning stdout.
-async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String> {
+async fn run_generate_and_apply(network: &str, fee_flag: &str, contract: Option<&str>) -> Result<String> {
     // Delete stale plan so clarinet never prompts "Overwrite? [Y/n]"
     let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
     if Path::new(&plan_path).exists() {
@@ -237,6 +243,11 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
              • Ensure settings/{}.toml has a valid mnemonic.",
             capitalize(network)
         ));
+    }
+
+    if let Some(contract_name) = contract {
+        filter_plan_to_contract(network, contract_name).await?;
+        println!("[deploy] Filtered deployment plan to contract: {contract_name}");
     }
 
     check_plan_fee(network)?;
@@ -268,8 +279,7 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
         .take()
         .ok_or_else(|| anyhow!("Failed to open stdout"))?;
 
-    let contracts_dir = std::path::Path::new("contracts");
-    let expected_count = resolve_deployment_order(contracts_dir).await?.len();
+    let expected_count = deployment_contract_names_from_plan(network).await?.len();
 
     let mut confirmed_count = 0;
     let mut broadcast_count = 0;
@@ -291,7 +301,17 @@ async fn run_generate_and_apply(network: &str, fee_flag: &str) -> Result<String>
         }
 
         // Handle interactive fee prompts
-        if line.contains("Overwrite?") || line.contains("Confirm?") || line.contains("[Y/n]") {
+        if line.contains("Overwrite?") {
+            // For single-contract deploys we explicitly filtered the on-disk plan.
+            // Answer "n" to preserve that file instead of letting Clarinet recompute
+            // from Clarinet.toml (which would re-include all contracts).
+            let answer = if contract.is_some() { b"n\n" } else { b"y\n" };
+            let _ = stdin.write_all(answer).await;
+            let _ = stdin.flush().await;
+        } else if line.contains("Confirm?") || line.contains("Continue [Y/n]?") {
+            let _ = stdin.write_all(b"y\n").await;
+            let _ = stdin.flush().await;
+        } else if line.contains("[Y/n]") {
             let _ = stdin.write_all(b"y\n").await;
             let _ = stdin.flush().await;
         }
@@ -591,11 +611,18 @@ fn check_plan_fee(network: &str) -> Result<()> {
     Ok(())
 }
 
-async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
+async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str>) -> Result<()> {
     let config = network_config(network);
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
+
+    // Prevent Clarinet from prompting "Overwrite? [Y/n]" during the
+    // conflict-check prepass. This command must stay non-interactive.
+    let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
+    if Path::new(&plan_path).exists() {
+        let _ = fs::remove_file(&plan_path).await;
+    }
 
     let _ = Command::new("clarinet")
         .args([
@@ -622,6 +649,9 @@ async fn auto_version_conflicting_contracts(network: &str) -> Result<()> {
     let mut any_changes = false;
 
     for (current_name, entry) in &contracts {
+        if contract.is_some() && contract != Some(current_name.as_str()) {
+            continue;
+        }
         let base_name = strip_version_suffix(current_name);
 
         // Find the next available name on the network
@@ -867,7 +897,11 @@ async fn wait_for_node(url: &str) -> Result<()> {
     ))
 }
 
-async fn write_deployments_json_from_output(network: &str, output: &str) -> Result<()> {
+async fn write_deployments_json_from_output(
+    network: &str,
+    output: &str,
+    contract: Option<&str>,
+) -> Result<()> {
     let mut txid_map: HashMap<String, String> = HashMap::new();
     let mut actual_deployer = None;
     for line in output.lines() {
@@ -909,17 +943,24 @@ async fn write_deployments_json_from_output(network: &str, output: &str) -> Resu
     let clarinet_raw = fs::read_to_string("contracts/Clarinet.toml").await?;
     let clarinet: ClarinetToml =
         toml::from_str(&clarinet_raw).map_err(|e| anyhow!("Failed to parse Clarinet.toml: {e}"))?;
-    let contract_names: Vec<String> = clarinet
+    let mut contract_names: Vec<String> = clarinet
         .contracts
         .as_ref()
         .map(|contracts| contracts.keys().cloned().collect())
         .unwrap_or_default();
+    if let Some(contract_name) = contract {
+        contract_names.retain(|name| name == contract_name);
+    }
 
     if network == "devnet" {
         wait_for_devnet_contracts(&deployer_address, &contract_names).await?;
     }
 
-    let mut contracts_map = HashMap::new();
+    let mut contracts_map = if contract.is_some() {
+        load_existing_deployments_for_network(network).await?
+    } else {
+        HashMap::new()
+    };
     let timestamp = chrono::Utc::now().to_rfc3339();
 
     for name in contract_names {
@@ -955,6 +996,113 @@ async fn write_deployments_json_from_output(network: &str, output: &str) -> Resu
     fs::write(out_path, &json).await?;
     println!("\n[deploy] Written to {}", out_path.display());
     Ok(())
+}
+
+async fn load_existing_deployments_for_network(
+    network: &str,
+) -> Result<HashMap<String, DeploymentInfo>> {
+    let path = Path::new("frontend/src/generated/deployments.json");
+    let raw = match fs::read_to_string(path).await {
+        Ok(content) => content,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let parsed: DeploymentFile = match serde_json::from_str(&raw) {
+        Ok(file) => file,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    if parsed.network == network {
+        Ok(parsed.contracts)
+    } else {
+        Ok(HashMap::new())
+    }
+}
+
+fn ensure_contract_exists(known: &[String], contract: &str) -> Result<()> {
+    if known.iter().any(|name| name == contract) {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "Contract '{contract}' was not found in contracts/Clarinet.toml.\nAvailable contracts: {}",
+        if known.is_empty() {
+            "<none>".to_string()
+        } else {
+            known.join(", ")
+        }
+    ))
+}
+
+async fn filter_plan_to_contract(network: &str, contract_name: &str) -> Result<()> {
+    let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
+    let raw = fs::read_to_string(&plan_path)
+        .await
+        .map_err(|e| anyhow!("Failed to read deployment plan at {plan_path}: {e}"))?;
+    let mut yaml: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .map_err(|e| anyhow!("Failed to parse deployment plan YAML at {plan_path}: {e}"))?;
+    let mut found = false;
+
+    let batches = yaml
+        .get_mut("plan")
+        .and_then(|plan| plan.get_mut("batches"))
+        .and_then(|batches| batches.as_sequence_mut())
+        .ok_or_else(|| anyhow!("Deployment plan is missing plan.batches"))?;
+
+    for batch in batches.iter_mut() {
+        let Some(transactions) = batch.get_mut("transactions").and_then(|t| t.as_sequence_mut())
+        else {
+            continue;
+        };
+
+        transactions.retain(|tx| {
+            let tx_type = tx
+                .get("transaction-type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if tx_type != "contract-publish" {
+                return true;
+            }
+
+            let keep = tx.get("contract-name").and_then(|v| v.as_str()) == Some(contract_name);
+            if keep {
+                found = true;
+            }
+            keep
+        });
+    }
+
+    batches.retain(|batch| {
+        batch
+            .get("transactions")
+            .and_then(|t| t.as_sequence())
+            .map(|txs| !txs.is_empty())
+            .unwrap_or(false)
+    });
+
+    if !found {
+        return Err(anyhow!(
+            "Contract '{contract_name}' is not present in the generated deployment plan.\n\
+             Ensure the contract exists and passes `clarinet check`."
+        ));
+    }
+
+    let rendered = serde_yaml::to_string(&yaml)?;
+    fs::write(&plan_path, rendered).await?;
+    Ok(())
+}
+
+async fn deployment_contract_names_from_plan(network: &str) -> Result<Vec<String>> {
+    let plan = read_deployment_plan(network).await?;
+    let names = flatten_contract_publishes(&plan)
+        .into_iter()
+        .filter_map(|tx| tx.contract_name)
+        .collect::<Vec<_>>();
+    if names.is_empty() {
+        return Err(anyhow!(
+            "No contract publish transactions found in deployment plan for {network}."
+        ));
+    }
+    Ok(names)
 }
 
 async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) -> Result<()> {

--- a/crates/process_supervisor/Cargo.toml
+++ b/crates/process_supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-process-supervisor"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "A process management library used to orchestrate background services and local devnet nodes for Stacks development."
 license     = "MIT"

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -219,16 +219,6 @@ async fn reset_local_devnet_state() -> Result<()> {
 }
 
 async fn spawn_next_dev(network: &str) -> Result<()> {
-    if fs::metadata("frontend/node_modules").await.is_err() {
-        println!("[dev] Installing frontend dependencies...");
-        Command::new("npm")
-            .arg("install")
-            .current_dir("frontend")
-            .spawn()?
-            .wait()
-            .await?;
-    }
-
     Command::new("npm")
         .args(["run", "dev"])
         .current_dir("frontend")

--- a/crates/scaffold/Cargo.toml
+++ b/crates/scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-scaffold"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "The asset provider and scaffolding engine containing the Next.js frontend templates and project initialization logic."
 license     = "MIT"

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -12,7 +12,7 @@ static FRONTEND_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-templ
 
 pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     println!();
-    println!("   \x1b[1;33mscaffold-stacks\x1b[0m  \x1b[2mv\x1b[0m");
+    println!("   \x1b[1;33mScaffold Stacks\x1b[0m  \x1b[2m\x1b[0m");
     println!("  \x1b[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m");
     println!("  \x1b[1mCreating\x1b[0m  \x1b[1;36m{name}\x1b[0m");
     println!();

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -4,6 +4,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use which::which;
 
@@ -11,7 +12,7 @@ static FRONTEND_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-templ
 
 pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     println!();
-    println!("   \x1b[1;33mscaffold-stacks\x1b[0m  \x1b[2mv0.1.0\x1b[0m");
+    println!("   \x1b[1;33mscaffold-stacks\x1b[0m  \x1b[2mv\x1b[0m");
     println!("  \x1b[2m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m");
     println!("  \x1b[1mCreating\x1b[0m  \x1b[1;36m{name}\x1b[0m");
     println!();
@@ -57,41 +58,14 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     ));
 
     // ── Step 2: Install dependencies (parallel) ───────────────────────────────
-    pb.set_message("Installing dependencies...");
+    pb.set_message("Installing frontend dependencies...");
 
     let fe_dir = frontend_dir.clone();
     let ct_dir = contracts_root.clone();
+    run_npm_install_with_feedback(&pb, &fe_dir, "frontend").await?;
 
-    let frontend_install = tokio::spawn(async move {
-        Command::new("npm")
-            .arg("install")
-            .current_dir(&fe_dir)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-    });
-
-    let contracts_install = tokio::spawn(async move {
-        Command::new("npm")
-            .arg("install")
-            .current_dir(&ct_dir)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-    });
-
-    let (fe, ct) = tokio::join!(frontend_install, contracts_install);
-
-    match fe.unwrap() {
-        Ok(s) if s.success() => {}
-        _ => return Err(anyhow!("npm install failed in frontend/")),
-    }
-    match ct.unwrap() {
-        Ok(s) if s.success() => {}
-        _ => return Err(anyhow!("npm install failed in contracts/")),
-    }
+    pb.set_message("Installing contract dependencies...");
+    run_npm_install_with_feedback(&pb, &ct_dir, "contracts").await?;
 
     pb.println("  \x1b[32m✔\x1b[0m  \x1b[1mInstalled\x1b[0m    node_modules");
 
@@ -720,4 +694,68 @@ async fn ensure_prerequisites() -> Result<()> {
         ));
     }
     Ok(())
+}
+
+async fn run_npm_install_with_feedback(pb: &ProgressBar, dir: &Path, scope: &str) -> Result<()> {
+    let mut child = Command::new("npm")
+        .args([
+            "install",
+            "--no-audit",
+            "--no-fund",
+            "--prefer-offline",
+            "--progress=false",
+            "--loglevel=verbose",
+        ])
+        .current_dir(dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("failed to capture npm install logs for {scope}"))?;
+    let mut lines = BufReader::new(stderr).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        if let Some(dep) = parse_npm_dep_hint(&line) {
+            pb.set_message(format!("Installing {scope} dependencies... {dep}"));
+        }
+    }
+
+    let status = child.wait().await?;
+    if !status.success() {
+        return Err(anyhow!("npm install failed in {scope}/"));
+    }
+    Ok(())
+}
+
+fn parse_npm_dep_hint(line: &str) -> Option<String> {
+    // Example npm verbose line:
+    // npm http fetch GET 200 https://registry.npmjs.org/react 123ms (cache hit)
+    if let Some(url_start) = line.find("https://registry.npmjs.org/") {
+        let url = &line[url_start + "https://registry.npmjs.org/".len()..];
+        let pkg = url
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_end_matches('/');
+        if !pkg.is_empty() {
+            return Some(pkg.to_string());
+        }
+    }
+
+    // Fallback for lines mentioning node_modules package paths.
+    if let Some(mod_start) = line.find("node_modules/") {
+        let after = &line[mod_start + "node_modules/".len()..];
+        let pkg = after
+            .split([' ', '\t', '\n', '\r', '/', '\\'])
+            .next()
+            .unwrap_or("");
+        if !pkg.is_empty() {
+            return Some(pkg.to_string());
+        }
+    }
+
+    None
 }


### PR DESCRIPTION
## Summary
- add `--contract <name>` support to `stacksdapp deploy` so users can deploy a single contract while keeping default all-contract deploy behavior unchanged
- add `--dry-run` support to deploy flow so users can generate a plan, view estimated fees, and inspect contract list without broadcasting
- improve deploy robustness around plan handling by preserving filtered plans during apply prompts and merging single-contract updates into `frontend/src/generated/deployments.json` instead of overwriting existing entries
- include related CLI/deployer docs updates and npm-install UX optimizations for clearer progress and faster startup paths
- Cli optimization 
closes #33 closes #60  