### PR TITLE
eat(cli): init/upgrade/watch, safer deploy & dev, frontend hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacksdapp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-codegen"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-deployer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bip39",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-process-supervisor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-scaffold"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "fs_extra",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-watcher"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "notify",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "stacksdapp"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "The official stacksdapp CLI: A complete toolkit to scaffold, build, and deploy full-stack Bitcoin applications on Stacks."
 license     = "MIT"
@@ -12,12 +12,12 @@ name = "stacksdapp"
 path = "src/main.rs"
 
 [dependencies]
-stacksdapp-scaffold           = {version = "0.1.4", path = "../crates/scaffold" }
+stacksdapp-scaffold           = {version = "0.1.5", path = "../crates/scaffold" }
 stacksdapp-parser             = {version = "0.1.1", path = "../crates/parser" }
-stacksdapp-codegen            = {version = "0.1.3", path = "../crates/codegen" }
-stacksdapp-watcher            = {version = "0.1.1", path = "../crates/watcher" }
-stacksdapp-deployer           = {version = "0.1.2", path = "../crates/deployer" }
-stacksdapp-process-supervisor = {version = "0.1.2", path = "../crates/process_supervisor" }
+stacksdapp-codegen            = {version = "0.1.4", path = "../crates/codegen" }
+stacksdapp-watcher            = {version = "0.1.2", path = "../crates/watcher" }
+stacksdapp-deployer           = {version = "0.1.3", path = "../crates/deployer" }
+stacksdapp-process-supervisor = {version = "0.1.3", path = "../crates/process_supervisor" }
 clap.workspace      = true
 tokio.workspace     = true
 anyhow.workspace    = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,13 @@ enum Commands {
         network: String,
     },
     /// Parse contracts and regenerate TypeScript bindings
-    Generate,
+    Generate {
+        /// Watch contracts and regenerate bindings on change
+        #[arg(long)]
+        watch: bool,
+    },
+    /// Adopt an existing Clarinet project in the current directory
+    Init,
     /// Add a new Clarity contract: stacks-dapp add <name> [--template blank|sip010|sip009]
     Add {
         /// Contract name
@@ -61,6 +67,8 @@ enum Commands {
     Clean,
     /// Check all prerequisites and print a status report
     Doctor,
+    /// Refresh dependencies and regenerate bindings
+    Upgrade,
 }
 
 #[tokio::main]
@@ -69,7 +77,8 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::New { name, no_git } => stacksdapp_scaffold::new_project(&name, !no_git).await,
         Commands::Dev { network } => stacksdapp_process_supervisor::dev(&network).await,
-        Commands::Generate => stacksdapp_codegen::generate_all().await,
+        Commands::Generate { watch } => run_generate(watch).await,
+        Commands::Init => stacksdapp_scaffold::init_project().await,
         Commands::Add { name, template } => {
             stacksdapp_scaffold::add_contract(&name, &template).await
         }
@@ -82,7 +91,21 @@ async fn main() -> Result<()> {
         Commands::Check => run_check().await,
         Commands::Clean => run_clean().await,
         Commands::Doctor => doctor::run().await,
+        Commands::Upgrade => stacksdapp_scaffold::upgrade_project().await,
     }
+}
+
+async fn run_generate(watch: bool) -> Result<()> {
+    use std::path::Path;
+    stacksdapp_codegen::generate_all().await?;
+    if watch {
+        println!(
+            "{}",
+            "[generate] Watching contracts/contracts for .clar changes...".cyan()
+        );
+        stacksdapp_watcher::watch_contracts(Path::new("contracts/contracts")).await?;
+    }
+    Ok(())
 }
 
 async fn run_test() -> Result<()> {

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-codegen"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "TypeScript code generation engine for Stacks dApps, using Tera templates to create type-safe contract hooks."
 license     = "MIT"

--- a/crates/codegen/templates/contracts.ts.tera
+++ b/crates/codegen/templates/contracts.ts.tera
@@ -19,6 +19,11 @@ function getContractId(name: string): { address: string; contractName: string } 
   return { address: contractId.slice(0, dot), contractName: contractId.slice(dot + 1) };
 }
 
+function getStacksApiHeaders(): Record<string, string> | undefined {
+  if (!scaffoldConfig.hiroApiKey) return undefined;
+  return { 'x-api-key': scaffoldConfig.hiroApiKey };
+}
+
 {% for contract in contracts %}
 // ── {{ contract.contract_name }} ──────────────────────
 
@@ -63,6 +68,9 @@ export async function {{ contract.contract_name | camel }}_{{ fn.name | camel }}
     functionArgs,
     network: scaffoldConfig.isDevnet ? 'devnet' : scaffoldConfig.targetNetwork,
     senderAddress: senderAddress ?? getDevnetSenderAddress() ?? address,
+    fetchOptions: {
+      headers: getStacksApiHeaders(),
+    },
   });
   return cvToValue(result);
 }

--- a/crates/codegen/templates/debug_ui.tsx.tera
+++ b/crates/codegen/templates/debug_ui.tsx.tera
@@ -392,7 +392,7 @@ function ContractPanel({ name, children }: { name: string; children: React.React
 {% for fn in contract.functions %}
 {% if fn.access == "public" or fn.access == "read_only" %}
 function FunctionCard_{{ contract.contract_name | upper_camel }}_{{ fn.name | upper_camel }}({ num, isOpen, onToggle }: { num: string, isOpen: boolean, onToggle: () => void }) {
-  const { data, loading, call } = use{{ contract.contract_name | upper_camel }}_{{ fn.name | upper_camel }}();
+  const { data, loading, txid, txStatus, txStatusError, explorerUrl, call } = use{{ contract.contract_name | upper_camel }}_{{ fn.name | upper_camel }}();
   const isReadOnly = {% if fn.access == "read_only" %}true{% else %}false{% endif %};
 
   {% if fn.args %}
@@ -442,6 +442,32 @@ function FunctionCard_{{ contract.contract_name | upper_camel }}_{{ fn.name | up
             <div style={Object.assign({}, S.resBox, { borderColor: isReadOnly ? '#2E2D2E' : '#2E2D2E' })}>
               <p style={S.resLabel}>RESULT</p>
               <pre style={S.resPre}>{JSON.stringify(data, null, 2)}</pre>
+            </div>
+          )}
+          {!isReadOnly && !!txid && (
+            <div style={Object.assign({}, S.resBox, { borderColor: '#2E2D2E' })}>
+              <p style={S.resLabel}>TRANSACTION</p>
+              <pre style={S.resPre}>{txid}</pre>
+              {!!txStatus && (
+                <p style={Object.assign({}, S.resPre, { marginTop: '8px' })}>
+                  status: {txStatus}
+                </p>
+              )}
+              {!!txStatusError && (
+                <p style={Object.assign({}, S.resPre, { marginTop: '8px', color: '#fca5a5' })}>
+                  {txStatusError}
+                </p>
+              )}
+              {!!explorerUrl && (
+                <a
+                  href={explorerUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={Object.assign({}, S.resPre, { display: 'inline-block', marginTop: '8px', color: '#93c5fd', textDecoration: 'underline' })}
+                >
+                  Open in explorer
+                </a>
+              )}
             </div>
           )}
         </form>

--- a/crates/codegen/templates/hooks.ts.tera
+++ b/crates/codegen/templates/hooks.ts.tera
@@ -2,9 +2,12 @@
 // Re-run `stacksdapp generate` to update.
 
 "use client";
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { ClarityValue } from '@stacks/transactions';
 import * as contracts from './contracts';
+import { scaffoldConfig } from '../scaffold.config';
+
+type TxLifecycleStatus = 'pending' | 'success' | 'abort_by_response' | 'error';
 
 {% for contract in contracts %}
 {% for fn in contract.functions %}
@@ -14,6 +17,8 @@ export function use{{ contract.contract_name | upper_camel }}_{{ fn.name | upper
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [txid, setTxid] = useState<string | null>(null);
+  const [txStatus, setTxStatus] = useState<TxLifecycleStatus | null>(null);
+  const [txStatusError, setTxStatusError] = useState<string | null>(null);
 
   
   const isReadOnly = {% if fn.access == "read_only" %}true{% else %}false{% endif %};
@@ -22,6 +27,8 @@ export function use{{ contract.contract_name | upper_camel }}_{{ fn.name | upper
     setLoading(true);
     setError(null);
     setTxid(null);
+    setTxStatus(null);
+    setTxStatusError(null);
     try {
       // Use the generated contract function from the index
       const fn = (contracts as any).{{ contract.contract_name | camel }}_{{ fn.name | camel }};
@@ -32,6 +39,7 @@ export function use{{ contract.contract_name | upper_camel }}_{{ fn.name | upper
 
       if (!isReadOnly && result?.txid) {
         setTxid(result.txid);
+        setTxStatus('pending');
       }
       
       setData(result ?? null);
@@ -46,7 +54,73 @@ export function use{{ contract.contract_name | upper_camel }}_{{ fn.name | upper
     // Dependency array is stable because isReadOnly is a constant literal
   }, [isReadOnly]); 
 
-  return { data, loading, error, txid, call };
+  useEffect(() => {
+    if (isReadOnly || !txid || !scaffoldConfig.nodeUrl) return;
+
+    let mounted = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const headers: Record<string, string> = {};
+    if (scaffoldConfig.hiroApiKey) {
+      headers['x-api-key'] = scaffoldConfig.hiroApiKey;
+    }
+
+    const poll = async () => {
+      try {
+        const response = await fetch(
+          `${scaffoldConfig.nodeUrl}/extended/v1/tx/${txid}`,
+          {
+            headers,
+            cache: 'no-store',
+          },
+        );
+        if (!response.ok) {
+          throw new Error(`tx status request failed with ${response.status}`);
+        }
+        const payload = await response.json();
+        const status = String(payload?.tx_status ?? '').toLowerCase();
+        if (!mounted) return;
+
+        if (status.includes('success')) {
+          setTxStatus('success');
+          setTxStatusError(null);
+          return;
+        }
+        if (status.includes('abort')) {
+          setTxStatus('abort_by_response');
+          setTxStatusError(String(payload?.tx_result?.repr ?? 'Transaction aborted.'));
+          return;
+        }
+        if (status.includes('pending')) {
+          setTxStatus('pending');
+          timer = setTimeout(() => {
+            void poll();
+          }, 2500);
+          return;
+        }
+
+        setTxStatus('error');
+        setTxStatusError(payload?.tx_status ? `Unexpected tx status: ${payload.tx_status}` : 'Unknown tx status.');
+      } catch (err) {
+        if (!mounted) return;
+        setTxStatusError(err instanceof Error ? err.message : 'Failed to poll transaction status.');
+        timer = setTimeout(() => {
+          void poll();
+        }, 4000);
+      }
+    };
+
+    void poll();
+    return () => {
+      mounted = false;
+      if (timer) clearTimeout(timer);
+    };
+  }, [isReadOnly, txid]);
+
+  const explorerUrl = txid
+    ? `${scaffoldConfig.explorerBaseUrl}${txid}${scaffoldConfig.explorerChainQuery}`
+    : null;
+
+  return { data, loading, error, txid, txStatus, txStatusError, explorerUrl, call };
 }
 {% endif %}
 {% endfor %}

--- a/crates/deployer/Cargo.toml
+++ b/crates/deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-deployer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A specialized deployment utility for broadcasting Clarity smart contracts to Stacks devnet, testnet, and mainnet."
 license     = "MIT"

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -18,18 +18,20 @@ pub struct NetworkConfig {
     pub stacks_node: String,
 }
 
-pub fn network_config(network: &str) -> NetworkConfig {
+pub fn network_config(network: &str) -> Result<NetworkConfig> {
     match network {
-        "devnet" => NetworkConfig {
+        "devnet" => Ok(NetworkConfig {
             stacks_node: "http://localhost:3999".into(),
-        },
-        "testnet" => NetworkConfig {
+        }),
+        "testnet" => Ok(NetworkConfig {
             stacks_node: "https://api.testnet.hiro.so".into(),
-        },
-        "mainnet" => NetworkConfig {
+        }),
+        "mainnet" => Ok(NetworkConfig {
             stacks_node: "https://api.hiro.so".into(),
-        },
-        other => panic!("Unknown network: {other}"),
+        }),
+        other => Err(anyhow!(
+            "Unknown network '{other}'. Expected one of: devnet | testnet | mainnet"
+        )),
     }
 }
 
@@ -110,7 +112,7 @@ pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool) -> Res
         validate_settings_mnemonic(network)?;
     }
 
-    let config = network_config(network);
+    let config = network_config(network)?;
     println!("🚀 Deploying to {} ({})", network, config.stacks_node);
     if let Some(name) = contract {
         println!("[deploy] Contract filter enabled: {name}");
@@ -250,7 +252,7 @@ async fn run_generate_and_apply(
         println!("[deploy] Filtered deployment plan to contract: {contract_name}");
     }
 
-    check_plan_fee(network)?;
+    let total_micro_stx = check_plan_fee(network)?;
     let contracts = deployment_contract_names_from_plan(network).await?;
     println!("[deploy] Plan contracts: {}", contracts.join(", "));
 
@@ -264,6 +266,10 @@ async fn run_generate_and_apply(
 
     if network == "devnet" {
         return run_apply_devnet_direct(network).await;
+    }
+    if network == "mainnet" {
+        let deployer = get_deployer_from_plan(network).await?;
+        confirm_mainnet_deploy(&deployer, &contracts, total_micro_stx)?;
     }
 
     println!("[deploy] Applying deployment plan to {}...", network);
@@ -592,7 +598,7 @@ pub async fn resolve_deployment_order(
 }
 
 // ── Auto-versioning ───────────────────────────────────────────────────────────
-fn check_plan_fee(network: &str) -> Result<()> {
+fn check_plan_fee(network: &str) -> Result<u64> {
     let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
     let plan_raw = std::fs::read_to_string(&plan_path).unwrap_or_default();
 
@@ -615,11 +621,11 @@ fn check_plan_fee(network: &str) -> Result<()> {
         );
     }
 
-    Ok(())
+    Ok(total_micro_stx)
 }
 
 async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str>) -> Result<()> {
-    let config = network_config(network);
+    let config = network_config(network)?;
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
@@ -1245,19 +1251,18 @@ fn parse_local_deps(source: &str, known_contracts: &HashSet<String>) -> Vec<Stri
     deps
 }
 
-fn topological_sort(
-    contracts: &HashMap<String, Vec<String>>, // name → [deps]
-) -> anyhow::Result<Vec<String>> {
-    // Build in-degree map
-    let mut in_degree: HashMap<&str, usize> = contracts.keys().map(|k| (k.as_str(), 0)).collect();
+fn topological_sort(contracts: &HashMap<String, Vec<String>>) -> anyhow::Result<Vec<String>> {
+    let mut in_degree: HashMap<&str, usize> = HashMap::new();
+    let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
 
-    for deps in contracts.values() {
+    for (name, deps) in contracts {
+        in_degree.insert(name.as_str(), deps.len());
         for dep in deps {
-            *in_degree.entry(dep.as_str()).or_insert(0) += 1;
+            dependents.entry(dep.as_str()).or_default().push(name.as_str());
         }
     }
 
-    // Start with contracts that have no dependencies
+    // Start with contracts that have no dependencies.
     let mut queue: VecDeque<&str> = in_degree
         .iter()
         .filter(|(_, &deg)| deg == 0)
@@ -1274,12 +1279,8 @@ fn topological_sort(
     while let Some(node) = queue.pop_front() {
         sorted.push(node.to_string());
 
-        // Find all contracts that depend on this one and reduce their in-degree
-        let mut next: Vec<&str> = contracts
-            .iter()
-            .filter(|(_, deps)| deps.iter().any(|d| d == node))
-            .map(|(name, _)| name.as_str())
-            .collect();
+        // Reduce in-degree for contracts that depend on this one.
+        let mut next = dependents.get(node).cloned().unwrap_or_default();
         next.sort();
 
         for dependent in next {
@@ -1316,9 +1317,33 @@ fn capitalize(s: &str) -> String {
     }
 }
 
+fn confirm_mainnet_deploy(deployer: &str, contracts: &[String], total_micro_stx: u64) -> Result<()> {
+    use std::io::{self, Write};
+
+    println!("\n⚠️  Mainnet deployment confirmation required");
+    println!("  Network: mainnet");
+    println!("  Deployer: {deployer}");
+    println!(
+        "  Estimated fee: {:.6} STX",
+        total_micro_stx as f64 / 1_000_000.0
+    );
+    println!("  Contracts ({}): {}", contracts.len(), contracts.join(", "));
+    print!("\nType 'y' to continue with MAINNET broadcast: ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    if input.trim() != "y" {
+        return Err(anyhow!("Mainnet deployment aborted by user."));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::strip_version_suffix;
+    use super::{strip_version_suffix, topological_sort};
+    use std::collections::HashMap;
 
     #[test]
     fn test_strip_version_suffix() {
@@ -1330,5 +1355,32 @@ mod tests {
         // should not strip non-version suffixes
         assert_eq!(strip_version_suffix("counter-v"), "counter-v");
         assert_eq!(strip_version_suffix("counter-vault"), "counter-vault");
+    }
+
+    #[test]
+    fn test_topological_sort_respects_dependencies() {
+        let mut graph = HashMap::new();
+        graph.insert("a".to_string(), vec![]);
+        graph.insert("b".to_string(), vec!["a".to_string()]);
+        graph.insert("c".to_string(), vec!["b".to_string()]);
+
+        let order = topological_sort(&graph).expect("topological sort should succeed");
+        let idx_a = order.iter().position(|name| name == "a").unwrap();
+        let idx_b = order.iter().position(|name| name == "b").unwrap();
+        let idx_c = order.iter().position(|name| name == "c").unwrap();
+        assert!(idx_a < idx_b && idx_b < idx_c);
+    }
+
+    #[test]
+    fn test_topological_sort_cycle_detection() {
+        let mut graph = HashMap::new();
+        graph.insert("a".to_string(), vec!["b".to_string()]);
+        graph.insert("b".to_string(), vec!["a".to_string()]);
+
+        let err = topological_sort(&graph).expect_err("cycle should fail");
+        assert!(
+            err.to_string().contains("Circular contract dependency detected"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -1258,7 +1258,10 @@ fn topological_sort(contracts: &HashMap<String, Vec<String>>) -> anyhow::Result<
     for (name, deps) in contracts {
         in_degree.insert(name.as_str(), deps.len());
         for dep in deps {
-            dependents.entry(dep.as_str()).or_default().push(name.as_str());
+            dependents
+                .entry(dep.as_str())
+                .or_default()
+                .push(name.as_str());
         }
     }
 
@@ -1317,7 +1320,11 @@ fn capitalize(s: &str) -> String {
     }
 }
 
-fn confirm_mainnet_deploy(deployer: &str, contracts: &[String], total_micro_stx: u64) -> Result<()> {
+fn confirm_mainnet_deploy(
+    deployer: &str,
+    contracts: &[String],
+    total_micro_stx: u64,
+) -> Result<()> {
     use std::io::{self, Write};
 
     println!("\n⚠️  Mainnet deployment confirmation required");
@@ -1327,7 +1334,11 @@ fn confirm_mainnet_deploy(deployer: &str, contracts: &[String], total_micro_stx:
         "  Estimated fee: {:.6} STX",
         total_micro_stx as f64 / 1_000_000.0
     );
-    println!("  Contracts ({}): {}", contracts.len(), contracts.join(", "));
+    println!(
+        "  Contracts ({}): {}",
+        contracts.len(),
+        contracts.join(", ")
+    );
     print!("\nType 'y' to continue with MAINNET broadcast: ");
     io::stdout().flush()?;
 
@@ -1379,7 +1390,8 @@ mod tests {
 
         let err = topological_sort(&graph).expect_err("cycle should fail");
         assert!(
-            err.to_string().contains("Circular contract dependency detected"),
+            err.to_string()
+                .contains("Circular contract dependency detected"),
             "unexpected error: {err}"
         );
     }

--- a/crates/process_supervisor/Cargo.toml
+++ b/crates/process_supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-process-supervisor"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A process management library used to orchestrate background services and local devnet nodes for Stacks development."
 license     = "MIT"
@@ -12,5 +12,5 @@ anyhow.workspace = true
 tokio.workspace  = true
 serde_json.workspace = true
 which.workspace     = true
-stacksdapp-codegen = {version = "0.1.1", path = "../codegen" }
-stacksdapp-watcher = {version = "0.1.1", path = "../watcher" }
+stacksdapp-codegen = {version = "0.1.4", path = "../codegen" }
+stacksdapp-watcher = {version = "0.1.2", path = "../watcher" }

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use std::path::Path;
-use tokio::{fs, process::Command};
+use tokio::{fs, process::Child, process::Command};
 
 /// Returns true if Clarinet.toml contains any [[project.requirements]] entries.
 async fn has_requirements() -> bool {
@@ -94,11 +94,46 @@ async fn dev_devnet() -> Result<()> {
     prefetch_requirements().await?;
     stacksdapp_codegen::generate_all().await?;
 
-    tokio::try_join!(
-        spawn_clarinet_devnet(),
-        spawn_next_dev("devnet"),
-        stacksdapp_watcher::watch_contracts(Path::new("contracts/contracts")),
-    )?;
+    let mut clarinet = spawn_clarinet_devnet()?;
+    let mut frontend = spawn_next_dev_process("devnet")?;
+    let mut watcher = tokio::spawn(stacksdapp_watcher::watch_contracts(Path::new(
+        "contracts/contracts",
+    )));
+
+    let result = tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            println!("[dev] Ctrl+C received — shutting down devnet stack...");
+            Ok(())
+        }
+        status = clarinet.wait() => {
+            match status {
+                Ok(s) if s.success() => Err(anyhow!("[dev] Clarinet devnet exited unexpectedly.")),
+                Ok(s) => Err(anyhow!("[dev] Clarinet devnet exited with status: {s}")),
+                Err(e) => Err(anyhow!("[dev] Failed to wait for Clarinet devnet process: {e}")),
+            }
+        }
+        status = frontend.wait() => {
+            match status {
+                Ok(s) if s.success() => Err(anyhow!("[dev] Frontend dev server exited unexpectedly.")),
+                Ok(s) => Err(anyhow!("[dev] Frontend dev server exited with status: {s}")),
+                Err(e) => Err(anyhow!("[dev] Failed to wait for frontend dev server: {e}")),
+            }
+        }
+        watcher_result = &mut watcher => {
+            match watcher_result {
+                Ok(Ok(())) => Err(anyhow!("[dev] Contract watcher exited unexpectedly.")),
+                Ok(Err(e)) => Err(anyhow!("[dev] Contract watcher failed: {e}")),
+                Err(e) => Err(anyhow!("[dev] Contract watcher task join failed: {e}")),
+            }
+        }
+    };
+
+    shutdown_child("clarinet devnet", &mut clarinet).await;
+    shutdown_child("frontend dev server", &mut frontend).await;
+    watcher.abort();
+    let _ = watcher.await;
+
+    result?;
 
     Ok(())
 }
@@ -198,14 +233,12 @@ fn ensure_docker() -> Result<()> {
     Ok(())
 }
 
-async fn spawn_clarinet_devnet() -> Result<()> {
-    Command::new("clarinet")
+fn spawn_clarinet_devnet() -> Result<Child> {
+    let child = Command::new("clarinet")
         .args(["devnet", "start"])
         .current_dir("contracts")
-        .spawn()?
-        .wait()
-        .await?;
-    Ok(())
+        .spawn()?;
+    Ok(child)
 }
 
 async fn reset_local_devnet_state() -> Result<()> {
@@ -219,12 +252,28 @@ async fn reset_local_devnet_state() -> Result<()> {
 }
 
 async fn spawn_next_dev(network: &str) -> Result<()> {
-    Command::new("npm")
+    let mut child = spawn_next_dev_process(network)?;
+    let status = child.wait().await?;
+    if !status.success() {
+        return Err(anyhow!("[dev] Frontend dev server exited with status: {status}"));
+    }
+    Ok(())
+}
+
+fn spawn_next_dev_process(network: &str) -> Result<Child> {
+    let child = Command::new("npm")
         .args(["run", "dev"])
         .current_dir("frontend")
         .env("NEXT_PUBLIC_NETWORK", network)
-        .spawn()?
-        .wait()
-        .await?;
-    Ok(())
+        .spawn()?;
+    Ok(child)
+}
+
+async fn shutdown_child(name: &str, child: &mut Child) {
+    if child.id().is_none() {
+        return;
+    }
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+    println!("[dev] Stopped {name}.");
 }

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -255,7 +255,9 @@ async fn spawn_next_dev(network: &str) -> Result<()> {
     let mut child = spawn_next_dev_process(network)?;
     let status = child.wait().await?;
     if !status.success() {
-        return Err(anyhow!("[dev] Frontend dev server exited with status: {status}"));
+        return Err(anyhow!(
+            "[dev] Frontend dev server exited with status: {status}"
+        ));
     }
     Ok(())
 }

--- a/crates/scaffold/Cargo.toml
+++ b/crates/scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-scaffold"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "The asset provider and scaffolding engine containing the Next.js frontend templates and project initialization logic."
 license     = "MIT"
@@ -18,6 +18,6 @@ anyhow.workspace     = true
 tokio.workspace      = true
 fs_extra.workspace   = true
 which.workspace      = true
-stacksdapp-codegen  = {version = "0.1.1", path = "../codegen" }
+stacksdapp-codegen  = {version = "0.1.4", path = "../codegen" }
 include_dir = "0.7"
 indicatif.workspace = true

--- a/crates/scaffold/frontend-template/env.local.example
+++ b/crates/scaffold/frontend-template/env.local.example
@@ -16,3 +16,7 @@ NEXT_PUBLIC_NETWORK=devnet
 #   mainnet → https://api.hiro.so
 # Uncomment to override:
 # NEXT_PUBLIC_STACKS_NODE_URL=https://api.testnet.hiro.so
+
+# ── Hiro API key (optional, recommended for testnet/mainnet) ─────────────────
+# Used for rate-limited Hiro endpoints, including read-only calls and tx polling.
+# NEXT_PUBLIC_HIRO_API_KEY=your_hiro_api_key

--- a/crates/scaffold/frontend-template/src/components/NetworkBadge.tsx
+++ b/crates/scaffold/frontend-template/src/components/NetworkBadge.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
+import { scaffoldConfig } from '../scaffold.config';
 
 function NetworkBadge() {
-    const network = process.env.NEXT_PUBLIC_NETWORK ?? 'devnet';
+    const network = scaffoldConfig.network;
     return (
       <span className={`text-xs px-2 py-0.5 font-mono text-[#8F8D8E]`}>
         {network}

--- a/crates/scaffold/frontend-template/src/scaffold.config.ts
+++ b/crates/scaffold/frontend-template/src/scaffold.config.ts
@@ -1,7 +1,19 @@
 // Network is driven by NEXT_PUBLIC_NETWORK env var.
 // stacksdapp dev --network testnet sets this automatically in frontend/.env.local
 
-const network = (process.env.NEXT_PUBLIC_NETWORK ?? 'devnet') as 'devnet' | 'testnet' | 'mainnet';
+type ScaffoldNetwork = 'devnet' | 'testnet' | 'mainnet';
+
+function resolveNetwork(value: string | undefined): ScaffoldNetwork {
+  const network = value ?? 'devnet';
+  if (network === 'devnet' || network === 'testnet' || network === 'mainnet') {
+    return network;
+  }
+  throw new Error(
+    `[scaffold-stacks] Invalid NEXT_PUBLIC_NETWORK="${network}". Expected one of: devnet | testnet | mainnet.`,
+  );
+}
+
+const network = resolveNetwork(process.env.NEXT_PUBLIC_NETWORK);
 
 const nodeUrl =
   network === 'mainnet'
@@ -17,6 +29,9 @@ export const scaffoldConfig = {
   requestNetwork: network === 'devnet' ? 'testnet' : network,
   targetNetwork: network === 'devnet' ? 'testnet' : network,
   nodeUrl,
+  hiroApiKey: process.env.NEXT_PUBLIC_HIRO_API_KEY ?? '',
+  explorerBaseUrl: network === 'mainnet' ? 'https://explorer.hiro.so/txid/' : 'https://explorer.hiro.so/txid/',
+  explorerChainQuery: network === 'mainnet' ? '?chain=mainnet' : '?chain=testnet',
   isDevnet:  network === 'devnet',
   isTestnet: network === 'testnet',
   isMainnet: network === 'mainnet',

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -142,10 +142,10 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
 
     let fe_dir = frontend_dir.clone();
     let ct_dir = contracts_root.clone();
-    run_npm_install_with_feedback(&pb, &fe_dir, "frontend").await?;
+    run_npm_install_with_feedback(&pb, &fe_dir, "frontend", "").await?;
 
     pb.set_message("Installing contract dependencies...");
-    run_npm_install_with_feedback(&pb, &ct_dir, "contracts").await?;
+    run_npm_install_with_feedback(&pb, &ct_dir, "contracts", "").await?;
 
     pb.println("  \x1b[32m✔\x1b[0m  \x1b[1mInstalled\x1b[0m    node_modules");
 
@@ -213,17 +213,112 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     Ok(())
 }
 
+/// Standard Clarinet uses `Clarinet.toml` at the repo root next to `contracts/`,
+/// `settings/`, and `tests/`. scaffold-stacks expects `contracts/Clarinet.toml`
+/// with sources under `contracts/contracts/*.clar`. When only the standard
+/// layout is present, move artifacts into the scaffold layout in-place.
+async fn normalize_standard_clarinet_layout(root: &Path) -> Result<()> {
+    let nested_clarinet = root.join("contracts").join("Clarinet.toml");
+    if nested_clarinet.exists() {
+        return Ok(());
+    }
+
+    let root_clarinet = root.join("Clarinet.toml");
+    if !root_clarinet.exists() {
+        return Ok(());
+    }
+
+    let clar_root = root.join("contracts");
+    if !clar_root.is_dir() {
+        return Err(anyhow!(
+            "Found Clarinet.toml at the repo root but no contracts/ directory.\n\
+             Create a Clarinet project first or run init from your Clarinet repo root."
+        ));
+    }
+
+    let nested_sources = clar_root.join("contracts");
+    tokio::fs::create_dir_all(&nested_sources).await?;
+
+    let mut entries = tokio::fs::read_dir(&clar_root).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        let ft = entry.file_type().await?;
+        if ft.is_file() && path.extension().is_some_and(|e| e == "clar") {
+            let dest = nested_sources.join(entry.file_name());
+            tokio::fs::rename(&path, &dest).await?;
+        }
+    }
+
+    tokio::fs::rename(&root_clarinet, &nested_clarinet).await?;
+
+    let root_settings = root.join("settings");
+    let dest_settings = clar_root.join("settings");
+    if root_settings.exists() && root_settings.is_dir() {
+        if dest_settings.exists() {
+            return Err(anyhow!(
+                "[init] Both ./settings and ./contracts/settings exist.\n\
+                 Remove or merge one directory, then rerun stacksdapp init."
+            ));
+        }
+        tokio::fs::rename(&root_settings, &dest_settings).await?;
+    }
+
+    let root_tests = root.join("tests");
+    let dest_tests = clar_root.join("tests");
+    if root_tests.exists() && root_tests.is_dir() {
+        if dest_tests.exists() {
+            return Err(anyhow!(
+                "[init] Both ./tests and ./contracts/tests exist.\n\
+                 Remove or merge one directory, then rerun stacksdapp init."
+            ));
+        }
+        tokio::fs::rename(&root_tests, &dest_tests).await?;
+    }
+
+    let root_deployments = root.join("deployments");
+    let dest_deployments = clar_root.join("deployments");
+    if root_deployments.exists() && root_deployments.is_dir() {
+        if dest_deployments.exists() {
+            return Err(anyhow!(
+                "[init] Both ./deployments and ./contracts/deployments exist.\n\
+                 Remove or merge one directory, then rerun stacksdapp init."
+            ));
+        }
+        tokio::fs::rename(&root_deployments, &dest_deployments).await?;
+    }
+
+    for fname in ["package.json", "vitest.config.ts", "tsconfig.json"] {
+        let src = root.join(fname);
+        let dst = clar_root.join(fname);
+        if src.exists() && !dst.exists() {
+            tokio::fs::rename(&src, &dst).await?;
+        }
+    }
+
+    println!(
+        "[init] Detected standard Clarinet layout (Clarinet.toml at repo root).\n\
+         Normalized to scaffold-stacks layout: contracts/Clarinet.toml and contracts/contracts/*.clar."
+    );
+
+    Ok(())
+}
+
 pub async fn init_project() -> Result<()> {
     ensure_prerequisites().await?;
 
     let root = Path::new(".");
+    normalize_standard_clarinet_layout(root).await?;
+
     let contracts_root = root.join("contracts");
     let frontend_dir = root.join("frontend");
     let clarinet_toml = contracts_root.join("Clarinet.toml");
 
     if !clarinet_toml.exists() {
         return Err(anyhow!(
-            "No Clarinet project detected. Expected contracts/Clarinet.toml in the current directory."
+            "No Clarinet project detected.\n\
+             Expected either:\n\
+               • Clarinet.toml in the current directory (standard Clarinet), or\n\
+               • contracts/Clarinet.toml (scaffold-stacks layout)."
         ));
     }
 
@@ -257,17 +352,20 @@ pub async fn init_project() -> Result<()> {
 pub async fn upgrade_project() -> Result<()> {
     ensure_prerequisites().await?;
 
+    normalize_standard_clarinet_layout(Path::new(".")).await?;
+
     if !Path::new("contracts/Clarinet.toml").exists()
         || !Path::new("frontend/package.json").exists()
     {
         return Err(anyhow!(
-            "No scaffold-stacks project found. Run from a project containing contracts/Clarinet.toml and frontend/package.json."
+            "No scaffold-stacks project found. Run from a project containing Clarinet.toml (repo root or contracts/) and frontend/package.json.\n\
+             Run stacksdapp init first if you only have a Clarinet repo."
         ));
     }
 
     println!("[upgrade] Refreshing dependencies and regenerating bindings (non-destructive)...");
-    run_npm_install(Path::new("frontend"), "frontend").await?;
-    run_npm_install(Path::new("contracts"), "contracts").await?;
+    run_npm_install(Path::new("frontend"), "frontend", "[upgrade]").await?;
+    run_npm_install(Path::new("contracts"), "contracts", "[upgrade]").await?;
     stacksdapp_codegen::generate_all().await?;
     println!("[upgrade] ✔ Upgrade complete.");
     Ok(())
@@ -610,8 +708,8 @@ async fn ensure_contract_support_files(contracts_root: &Path, frontend_dir: &Pat
 }
 
 async fn run_generate_after_setup() -> Result<()> {
-    run_npm_install(Path::new("frontend"), "frontend").await?;
-    run_npm_install(Path::new("contracts"), "contracts").await?;
+    run_npm_install(Path::new("frontend"), "frontend", "[init]").await?;
+    run_npm_install(Path::new("contracts"), "contracts", "[init]").await?;
     stacksdapp_codegen::generate_all().await?;
     Ok(())
 }
@@ -627,26 +725,36 @@ async fn write_if_missing(path: &Path, contents: &str) -> Result<()> {
     Ok(())
 }
 
-async fn run_npm_install(dir: &Path, scope: &str) -> Result<()> {
+async fn run_npm_install(dir: &Path, scope: &str, message_prefix: &str) -> Result<()> {
     if !dir.join("package.json").exists() {
         return Ok(());
     }
-    let status = Command::new("npm")
-        .args([
-            "install",
-            "--no-audit",
-            "--no-fund",
-            "--prefer-offline",
-            "--progress=false",
-            "--loglevel=error",
-        ])
-        .current_dir(dir)
-        .status()
-        .await?;
-    if !status.success() {
-        return Err(anyhow!("npm install failed in {scope}/"));
-    }
+
+    let style = ProgressStyle::with_template(
+        "  {spinner:.yellow} {wide_msg:.dim}  \x1b[2m[{elapsed}]\x1b[0m",
+    )
+    .unwrap()
+    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
+
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(style);
+    pb.enable_steady_tick(Duration::from_millis(80));
+    let head = npm_install_message_head(message_prefix);
+    pb.set_message(format!("{head}Installing {scope} dependencies..."));
+
+    run_npm_install_with_feedback(&pb, dir, scope, message_prefix).await?;
+
+    pb.finish_and_clear();
+    println!("  \x1b[32m✔\x1b[0m  {head}Finished installing {scope} dependencies.");
     Ok(())
+}
+
+fn npm_install_message_head(message_prefix: &str) -> String {
+    if message_prefix.is_empty() {
+        String::new()
+    } else {
+        format!("{message_prefix} ")
+    }
 }
 
 pub async fn add_contract(name: &str, template: &str) -> Result<()> {
@@ -871,7 +979,12 @@ async fn ensure_prerequisites() -> Result<()> {
     Ok(())
 }
 
-async fn run_npm_install_with_feedback(pb: &ProgressBar, dir: &Path, scope: &str) -> Result<()> {
+async fn run_npm_install_with_feedback(
+    pb: &ProgressBar,
+    dir: &Path,
+    scope: &str,
+    message_prefix: &str,
+) -> Result<()> {
     let mut child = Command::new("npm")
         .args([
             "install",
@@ -892,9 +1005,10 @@ async fn run_npm_install_with_feedback(pb: &ProgressBar, dir: &Path, scope: &str
         .ok_or_else(|| anyhow!("failed to capture npm install logs for {scope}"))?;
     let mut lines = BufReader::new(stderr).lines();
 
+    let head = npm_install_message_head(message_prefix);
     while let Some(line) = lines.next_line().await? {
         if let Some(dep) = parse_npm_dep_hint(&line) {
-            pb.set_message(format!("Installing {scope} dependencies... {dep}"));
+            pb.set_message(format!("{head}Installing {scope} dependencies... {dep}"));
         }
     }
 

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -10,6 +10,86 @@ use which::which;
 
 static FRONTEND_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-template");
 
+const DEFAULT_CONTRACTS_PACKAGE_JSON: &str = r#"{
+  "name": "contracts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@stacks/clarinet-sdk": "^3",
+    "@stacks/transactions": "7.4.0",
+    "typescript": "^5",
+    "vitest": "^1"
+  }
+}
+"#;
+
+const DEFAULT_VITEST_CONFIG: &str = r#"import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { environment: 'node' },
+});
+"#;
+
+const DEFAULT_CONTRACTS_TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["tests/**/*.ts"]
+}
+"#;
+
+const DEFAULT_FRONTEND_ENV_LOCAL: &str = r#"# Network: devnet | testnet | mainnet
+NEXT_PUBLIC_NETWORK=devnet
+
+# Required for testnet/mainnet deploy:
+# DEPLOYER_PRIVATE_KEY=your_private_key_hex
+"#;
+
+const DEFAULT_FRONTEND_ENV_LOCAL_EXAMPLE: &str = r#"# Network: devnet | testnet | mainnet
+NEXT_PUBLIC_NETWORK=devnet
+
+# Required for testnet/mainnet deploy:
+# DEPLOYER_PRIVATE_KEY=your_private_key_hex
+
+# Optional node URL override:
+# NEXT_PUBLIC_STACKS_NODE_URL=https://api.testnet.hiro.so
+"#;
+
+const DEFAULT_DEVNET_SETTINGS: &str = r#"[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+"#;
+
+const DEFAULT_TESTNET_SETTINGS: &str = r#"[network]
+name = "testnet"
+stacks_node_rpc_address = "https://api.testnet.hiro.so"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "<YOUR PRIVATE TESTNET MNEMONIC HERE>"
+"#;
+
+const DEFAULT_MAINNET_SETTINGS: &str = r#"[network]
+name = "mainnet"
+stacks_node_rpc_address = "https://api.hiro.so"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "<YOUR PRIVATE MAINNET MNEMONIC HERE>"
+"#;
+
 pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     println!();
     println!("   \x1b[1;33mScaffold Stacks\x1b[0m  \x1b[2m\x1b[0m");
@@ -133,6 +213,66 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
     Ok(())
 }
 
+pub async fn init_project() -> Result<()> {
+    ensure_prerequisites().await?;
+
+    let root = Path::new(".");
+    let contracts_root = root.join("contracts");
+    let frontend_dir = root.join("frontend");
+    let clarinet_toml = contracts_root.join("Clarinet.toml");
+
+    if !clarinet_toml.exists() {
+        return Err(anyhow!(
+            "No Clarinet project detected. Expected contracts/Clarinet.toml in the current directory."
+        ));
+    }
+
+    tokio::fs::create_dir_all(contracts_root.join("contracts")).await?;
+    tokio::fs::create_dir_all(contracts_root.join("settings")).await?;
+    tokio::fs::create_dir_all(contracts_root.join("tests")).await?;
+
+    if !frontend_dir.exists() {
+        tokio::fs::create_dir_all(&frontend_dir).await?;
+        FRONTEND_TEMPLATE
+            .extract(&frontend_dir)
+            .map_err(|e| anyhow!("Failed to copy frontend template: {e}"))?;
+        println!("[init] Added frontend template in ./frontend");
+    } else if !frontend_dir.join("scripts/export-abi.mjs").exists() {
+        return Err(anyhow!(
+            "frontend/ exists but is missing scripts/export-abi.mjs.\n\
+             To avoid overwriting existing frontend files, init will not continue automatically.\n\
+             Add that script or move/backup frontend/ and rerun `stacksdapp init`."
+        ));
+    } else {
+        println!("[init] Existing frontend detected. Keeping files unchanged.");
+    }
+
+    ensure_contract_support_files(&contracts_root, &frontend_dir).await?;
+    run_generate_after_setup().await?;
+
+    println!("[init] ✔ Existing Clarinet project initialized for scaffold-stacks.");
+    Ok(())
+}
+
+pub async fn upgrade_project() -> Result<()> {
+    ensure_prerequisites().await?;
+
+    if !Path::new("contracts/Clarinet.toml").exists()
+        || !Path::new("frontend/package.json").exists()
+    {
+        return Err(anyhow!(
+            "No scaffold-stacks project found. Run from a project containing contracts/Clarinet.toml and frontend/package.json."
+        ));
+    }
+
+    println!("[upgrade] Refreshing dependencies and regenerating bindings (non-destructive)...");
+    run_npm_install(Path::new("frontend"), "frontend").await?;
+    run_npm_install(Path::new("contracts"), "contracts").await?;
+    stacksdapp_codegen::generate_all().await?;
+    println!("[upgrade] ✔ Upgrade complete.");
+    Ok(())
+}
+
 async fn write_project_files(
     name: &str,
     root: &Path,
@@ -141,47 +281,19 @@ async fn write_project_files(
 ) -> Result<()> {
     tokio::fs::write(
         contracts_root.join("package.json"),
-        r#"{
-  "name": "contracts",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "test": "vitest run"
-  },
-  "devDependencies": {
-    "@stacks/clarinet-sdk": "^3",
-    "@stacks/transactions": "7.4.0",
-    "typescript": "^5",
-    "vitest": "^1"
-  }
-}
-"#,
+        DEFAULT_CONTRACTS_PACKAGE_JSON,
     )
     .await?;
 
     tokio::fs::write(
         contracts_root.join("vitest.config.ts"),
-        r#"import { defineConfig } from 'vitest/config';
-export default defineConfig({
-  test: { environment: 'node' },
-});
-"#,
+        DEFAULT_VITEST_CONFIG,
     )
     .await?;
 
     tokio::fs::write(
         contracts_root.join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true
-  },
-  "include": ["tests/**/*.ts"]
-}
-"#,
+        DEFAULT_CONTRACTS_TSCONFIG,
     )
     .await?;
 
@@ -446,31 +558,94 @@ settings/Simnet.toml
     )
     .await?;
 
-    tokio::fs::write(
-        frontend_dir.join(".env.local"),
-        r#"# Network: devnet | testnet | mainnet
-NEXT_PUBLIC_NETWORK=devnet
-
-# Required for testnet/mainnet deploy:
-# DEPLOYER_PRIVATE_KEY=your_private_key_hex
-"#,
-    )
-    .await?;
+    tokio::fs::write(frontend_dir.join(".env.local"), DEFAULT_FRONTEND_ENV_LOCAL).await?;
 
     tokio::fs::write(
         frontend_dir.join(".env.local.example"),
-        r#"# Network: devnet | testnet | mainnet
-NEXT_PUBLIC_NETWORK=devnet
-
-# Required for testnet/mainnet deploy:
-# DEPLOYER_PRIVATE_KEY=your_private_key_hex
-
-# Optional node URL override:
-# NEXT_PUBLIC_STACKS_NODE_URL=https://api.testnet.hiro.so
-"#,
+        DEFAULT_FRONTEND_ENV_LOCAL_EXAMPLE,
     )
     .await?;
 
+    Ok(())
+}
+
+async fn ensure_contract_support_files(contracts_root: &Path, frontend_dir: &Path) -> Result<()> {
+    write_if_missing(
+        &contracts_root.join("package.json"),
+        DEFAULT_CONTRACTS_PACKAGE_JSON,
+    )
+    .await?;
+    write_if_missing(
+        &contracts_root.join("vitest.config.ts"),
+        DEFAULT_VITEST_CONFIG,
+    )
+    .await?;
+    write_if_missing(
+        &contracts_root.join("tsconfig.json"),
+        DEFAULT_CONTRACTS_TSCONFIG,
+    )
+    .await?;
+    write_if_missing(
+        &contracts_root.join("settings/Devnet.toml"),
+        DEFAULT_DEVNET_SETTINGS,
+    )
+    .await?;
+    write_if_missing(
+        &contracts_root.join("settings/Testnet.toml"),
+        DEFAULT_TESTNET_SETTINGS,
+    )
+    .await?;
+    write_if_missing(
+        &contracts_root.join("settings/Mainnet.toml"),
+        DEFAULT_MAINNET_SETTINGS,
+    )
+    .await?;
+    write_if_missing(&frontend_dir.join(".env.local"), DEFAULT_FRONTEND_ENV_LOCAL).await?;
+    write_if_missing(
+        &frontend_dir.join(".env.local.example"),
+        DEFAULT_FRONTEND_ENV_LOCAL_EXAMPLE,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_generate_after_setup() -> Result<()> {
+    run_npm_install(Path::new("frontend"), "frontend").await?;
+    run_npm_install(Path::new("contracts"), "contracts").await?;
+    stacksdapp_codegen::generate_all().await?;
+    Ok(())
+}
+
+async fn write_if_missing(path: &Path, contents: &str) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::write(path, contents).await?;
+    Ok(())
+}
+
+async fn run_npm_install(dir: &Path, scope: &str) -> Result<()> {
+    if !dir.join("package.json").exists() {
+        return Ok(());
+    }
+    let status = Command::new("npm")
+        .args([
+            "install",
+            "--no-audit",
+            "--no-fund",
+            "--prefer-offline",
+            "--progress=false",
+            "--loglevel=error",
+        ])
+        .current_dir(dir)
+        .status()
+        .await?;
+    if !status.success() {
+        return Err(anyhow!("npm install failed in {scope}/"));
+    }
     Ok(())
 }
 

--- a/crates/watcher/Cargo.toml
+++ b/crates/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-watcher"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Development-mode file watcher that monitors Clarity contract changes and triggers automatic re-generation of frontend types."
 license     = "MIT"
@@ -11,4 +11,4 @@ homepage    = "https://github.com/scaffold-stack/scaffold-stack"
 anyhow.workspace = true
 notify.workspace = true
 tokio.workspace  = true
-stacksdapp-codegen = {version = "0.1.1", path = "../codegen" }
+stacksdapp-codegen = {version = "0.1.4", path = "../codegen" }

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -3,6 +3,7 @@ use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio::time::timeout;
 
 pub async fn watch_contracts(contracts_dir: &Path) -> Result<()> {
     let (tx, mut rx) = mpsc::channel(32);
@@ -15,12 +16,29 @@ pub async fn watch_contracts(contracts_dir: &Path) -> Result<()> {
 
     watcher.watch(contracts_dir, RecursiveMode::Recursive)?;
 
+    const DEBOUNCE_MS: u64 = 300;
+
     while let Some(event) = rx.recv().await {
         if let Ok(e) = event {
             if e.paths
                 .iter()
                 .any(|p| p.extension().map(|x| x == "clar").unwrap_or(false))
             {
+                // Debounce bursts of save/write events before regenerating.
+                while let Ok(Some(next_event)) =
+                    timeout(Duration::from_millis(DEBOUNCE_MS), rx.recv()).await
+                {
+                    if let Ok(next) = next_event {
+                        let is_clar_change = next
+                            .paths
+                            .iter()
+                            .any(|p| p.extension().map(|x| x == "clar").unwrap_or(false));
+                        if !is_clar_change {
+                            continue;
+                        }
+                    }
+                }
+
                 println!("[watcher] .clar change detected — regenerating...");
                 if let Err(e) = stacksdapp_codegen::generate_all().await {
                     eprintln!("[watcher] codegen error: {e}");


### PR DESCRIPTION
### Summary

This PR improves the **stacksdapp** CLI and supporting crates for safer deploys, more reliable local dev, better adoption of existing Clarinet repos, and stronger generated frontend behavior. It keeps backward-compatible defaults where possible and avoids auto-deploy on `dev` (unchanged by design).

### Changes

**Deploy (`stacksdapp-deployer`)**  
- Mainnet: explicit human confirmation (typed `y`) with deployer, estimated fee, and contract list before broadcast.  
- Invalid `--network` returns a structured error instead of panicking.  
- Fixed contract dependency topological sort (correct order, reliable cycle detection); added unit tests.

**Dev runtime (`stacksdapp-process-supervisor` + `stacksdapp-watcher`)**  
- `stacksdapp dev`: supervise Clarinet + frontend + watcher; propagate non-zero child exits; clean shutdown on Ctrl+C (kill/wait children).  
- Watcher: debounce rapid `.clar` saves to avoid bursty concurrent codegen.

**Scaffold / CLI surface (`stacksdapp-scaffold`, `cli`)**  
- `stacksdapp init`: adopt existing Clarinet projects; normalize **standard** layout (root `Clarinet.toml`) into scaffold layout (`contracts/Clarinet.toml`, sources under `contracts/contracts/`, move root `settings` / `tests` / `deployments` when safe).  
- `stacksdapp upgrade`: refresh `frontend` + `contracts` npm deps and regenerate bindings.  
- `stacksdapp generate --watch`: one-shot generate then watch `contracts/contracts`.  
- `init` / `upgrade`: npm install shows spinner + live package hints (indicatif + verbose npm stderr).

**Generated frontend (templates + `frontend-template`)**  
- Strict `NEXT_PUBLIC_NETWORK` validation at config load.  
- Optional `NEXT_PUBLIC_HIRO_API_KEY` for `x-api-key` on read-only / tx-status HTTP calls.  
- Post–write-call tx status polling + explorer link in debug UI.  
- Network badge reads validated config.

### Issues closed
Closes #38
Closes #35
Closes #34
Closes #32
Closes #30
Closes #29
Closes #27
Closes #26
Closes #23
Closes #10


### Verification

- `cargo test` for affected workspace members (`stacksdapp`, `stacksdapp-deployer`, `stacksdapp-process-supervisor`, `stacksdapp-watcher`, `stacksdapp-codegen`, `stacksdapp-scaffold`) and `cargo check -p stacksdapp`.