### PR TITLE
Scriptable CLI, shell crate, UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Keep in sync with README / stacksdapp doctor (Clarinet 3.21+).
+  CLARINET_VERSION: "3.21.1"
 
 jobs:
   lint:
@@ -58,6 +60,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -74,24 +77,39 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-integ-
 
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('crates/scaffold/frontend-template/package-lock.json', 'crates/scaffold/contracts-template/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Install Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install Clarinet
+      - name: Install Clarinet ${{ env.CLARINET_VERSION }}
         run: |
-          curl -sL https://github.com/hirosystems/clarinet/releases/download/v3.16.0/clarinet-linux-x64-glibc.tar.gz | tar xz
+          set -euo pipefail
+          curl -fsSL \
+            "https://github.com/stx-labs/clarinet/releases/download/v${CLARINET_VERSION}/clarinet-linux-x64-glibc.tar.gz" \
+            | tar xz
           sudo mv clarinet /usr/local/bin/
           clarinet --version
+          clarinet --version | head -n1 | grep -E "clarinet 3\\.21"
 
       - name: Build CLI binary
         run: cargo build --package stacksdapp
 
+      - name: CLI smoke (new → check → generate → add → test)
+        run: bash scripts/ci-smoke.sh ./target/debug/stacksdapp
+
   build:
     name: Release Build
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests]
+    needs: [lint, unit-tests, integration-tests]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.9). Leave empty to use the pushed tag."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: stacksdapp-x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: stacksdapp-aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact: stacksdapp-x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release binary
+        run: cargo build --release --package stacksdapp --target ${{ matrix.target }}
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.target }}/release/stacksdapp"
+          STAGE="${{ matrix.artifact }}"
+          mkdir -p "$STAGE"
+          cp "$BIN" "$STAGE/stacksdapp"
+          cp README.md CHANGELOG.md "$STAGE/"
+          chmod +x "$STAGE/stacksdapp"
+          tar -czf "${STAGE}.tar.gz" "$STAGE"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  github-release:
+    name: GitHub Release
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Resolve tag
+        id: meta
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          CLI_VER=$(grep -E '^version' cli/Cargo.toml | head -1 | sed -E 's/.*=\s*"([^"]+)".*/\1/')
+          echo "cli_version=$CLI_VER" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$TAG cli=$CLI_VER"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: stacksdapp ${{ steps.meta.outputs.tag }}
+          body: |
+            ## stacksdapp ${{ steps.meta.outputs.tag }}
+
+            CLI crate version: **${{ steps.meta.outputs.cli_version }}**
+
+            ### Install from this release
+            Download the archive for your platform, extract, and place `stacksdapp` on your `PATH`.
+
+            ### Or via crates.io
+            ```bash
+            cargo install stacksdapp --locked
+            ```
+
+            See [CHANGELOG.md](https://github.com/scaffold-stack/scaffold-stack/blob/main/CHANGELOG.md) for details.
+          files: dist/**/*.tar.gz
+          draft: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ dist
 .vscode
 frontend-template/.next
 frontend-template/node_modules
-pub.sh
 create_issues.sh
-
+scripts/verify-p0.sh
+scripts/verify-e2e.sh
+scripts/check-versions.sh
+scripts/verify-p1-display.sh
+scripts/verify-p1-exit-codes.sh
+scripts/verify-functional.sh
+pub.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,257 @@
+# Changelog
+
+All notable changes to **stacksdapp** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Version history is reconstructed from git tags, `cli/Cargo.toml` version bumps, and commit messages.
+
+> **Note:** Only **`v0.1.9`** is git-tagged today. Intermediate versions (`0.1.0`–`0.1.8`) were published to crates.io
+
+---
+
+## [Unreleased]
+
+## [0.2.0] — 2026-07-14
+
+### Added
+
+- Stable CLI exit codes via typed `CliError` (`thiserror`):
+  - `2` project not found / invalid `--root`
+  - `3` prerequisite / `doctor` failure
+  - `4` user aborted (confirmations)
+  - `5` validation (names, args)
+  - `6` type-check failed
+  - `7` tests failed
+  - `8` deploy failed
+  - `10` generate / codegen failed
+- New crate **`stacksdapp-shell`**: shared `-v` / `-q` / `--color` / `--json` output and project-root discovery.
+- Global flags: `-v` / `-vv…`, `-q`, `--color auto|always|never`, `--json`, `--root` (`STACKSDAPP_ROOT`).
+- Project root walk-up via `stacksdapp.toml` or `contracts/Clarinet.toml`.
+- `stacksdapp completions <shell>` (alias `com`) for bash, zsh, fish, powershell, elvish.
+- `doctor --strict` — treat warnings as failures (exit `3`).
+- `clean --force` — skip confirmation prompt.
+- `deploy -y` / `--yes` — non-interactive deploy and Clarinet fee prompts.
+- GitHub Actions **Release** workflow (multi-target binaries + GitHub Release on `v*` tags).
+- `scripts/check-versions.sh`, `CONTRIBUTING.md`, and local verify scripts under `scripts/`.
+- CI Clarinet pin **3.21.1** and real smoke integration job (`scripts/ci-smoke.sh`).
+
+### Changed
+
+- `pub.sh` resolves repo root from script path, publishes `stacksdapp-shell`, requires clean git worktree by default (`--allow-dirty` opt-in).
+- README command table: `init`, `doctor`, `upgrade`, `completions`, global flags, exit codes.
+- JSON error payloads include `code` and `exit_code`; doctor JSON includes `exit_code`.
+
+### Fixed
+
+- `doctor` returns meaningful non-zero exit when checks fail (was always `0`).
+- `new` / `add` reject path traversal, absolute paths, and invalid Clarity identifiers.
+- Devnet Node broadcast no longer passes private keys on argv (stdin payload).
+- False `REDEPLOYMENT REQUIRED` when `deployments.json` is empty or `network=""`.
+- JSON mode avoids double-printing error objects.
+
+---
+
+## [0.1.9] — 2026-07-05
+
+Released on crates.io; git tag **`v0.1.9`** (2026-07-06).
+
+### Added
+
+- `stacksdapp dev --auto-deploy` — deploy contracts once local devnet is ready.
+- Devnet chain health monitoring and prefixed dev logs.
+- Contract ABI caching (`contracts/.cache/`) to skip redundant `initSimnet` runs during `generate`.
+- `npm ci` in `generate` when `package-lock.json` exists.
+- Committed `contracts/package-lock.json` in scaffold template for reproducible installs.
+- Devnet mnemonic safety warning in CLI output.
+
+### Changed
+
+- **Clarinet 3.21+** required (`doctor` check and template alignment).
+- Frontend template updated for Clarinet SDK 3.21 (`@stacks/clarinet-sdk`).
+- Run Next.js and Vitest via `node` to avoid `.bin` permission errors.
+- Bump workspace crates: `stacksdapp-codegen` 0.1.6, `stacksdapp-deployer` 0.1.4, `stacksdapp-process-supervisor` 0.1.6, `stacksdapp-scaffold` 0.1.8.
+
+### Fixed
+
+- Treat transient tx poll 404s as pending instead of hard errors.
+- Node modules unload fix during generate.
+
+---
+
+## [0.1.8] — 2026-05-17
+
+### Added
+
+- Frontend Vitest runs in `stacksdapp test` (`vitest run --passWithNoTests`).
+- Vercel deployment config for frontend template (`vercel.json`, `public/` directory).
+- Pinned `package-lock.json` in frontend template.
+- Hiro API key support via `getReadOnlyNetwork` (`@stacks/network` v7).
+
+### Changed
+
+- Migrate frontend to **`@stacks/network` v7** and **`@stacks/transactions` v7**.
+- Wallet provider simplified to Jotai-based sync (removed unused `WalletContext`).
+- Consistent `stacksdapp` branding in CLI messages, codegen hints, and dev supervisor output.
+- README clone path and codegen template docs corrected.
+- MIT `LICENSE` file committed (removed from `.gitignore`).
+
+---
+
+## [0.1.7] — 2026-05-03
+
+### Added
+
+- Branded CLI banner (FIGlet-style `stacks` / `dapp` wordmark, boxed tagline).
+- `.githooks/pre-commit` — blocks likely mnemonic commits in `Testnet.toml` / `Mainnet.toml` (override via env).
+- Colored init/upgrade step output.
+
+### Changed
+
+- Extended `--help` with examples and clearer command descriptions.
+- Root `.gitignore` narrowed to generated Clarinet settings only.
+
+---
+
+## [0.1.6] — 2026-05-02
+
+### Added
+
+- **`stacksdapp init`** — adopt an existing Clarinet project (adds frontend, bindings, debug UI).
+- **`stacksdapp upgrade`** — refresh deps and regenerate bindings non-destructively.
+- **`stacksdapp generate --watch`** — regenerate bindings on `.clar` changes.
+- Debug UI: transaction status, errors, and explorer links for contract writes.
+- Generated hooks poll transaction lifecycle after write calls.
+- Optional Hiro API key headers for read-only Stacks calls (`NEXT_PUBLIC_HIRO_API_KEY`).
+- Complex ABI argument JSON handling in debug UI.
+- Mainnet deploy confirmation prompt (interactive safety gate).
+
+### Changed
+
+- `init` normalizes root Clarinet layout and shows npm install progress spinners.
+- `scaffold.config.ts` validates `NEXT_PUBLIC_NETWORK`; network badge reads from validated config.
+- Dev runtime: supervised child processes, debounced watcher codegen, clean Ctrl+C shutdown.
+
+### Fixed
+
+- Deploy safety checks hardened for testnet/mainnet.
+
+---
+
+## [0.1.5] — 2026-04-22
+
+### Added
+
+- **`stacksdapp deploy --dry-run`** — generate deployment plan and fee estimate without broadcasting.
+- **`stacksdapp deploy --contract <name>`** — deploy a single contract by name.
+- Live npm dependency feedback spinner during scaffold npm installs.
+
+### Changed
+
+- Performance: skip redundant frontend install check in dev; optimize codegen npm install step.
+
+---
+
+## [0.1.4] — 2026-04-22
+
+### Added
+
+- CLI integration test suite and CI workflow.
+- Release workflow scaffolding (`bin: release workflow`).
+- npm compatibility fixes for generated projects.
+
+### Changed
+
+- Workspace crate versions aligned across `Cargo.toml` files and lockfile.
+
+---
+
+## [0.1.3] — 2026-04-13
+
+Git tag **`v0.1.3`** (2026-04-16).
+
+### Changed
+
+- Support **`@stacks/transactions` 7.4.0**.
+- Crates.io version control and dependency pinning across workspace crates.
+
+### Fixed
+
+- Frontend template test fixes.
+
+---
+
+## [0.1.2] — 2026-04-13
+
+### Added
+
+- CLI integration tests (foundation for CI smoke).
+
+### Fixed
+
+- Template test reliability fixes.
+
+---
+
+## [0.1.1] — 2026-04-12
+
+First crates.io-ready release wave.
+
+### Added
+
+- **`stacksdapp doctor`** — prerequisite checks (Rust, Node, Clarinet, Docker, git).
+- **`stacksdapp add --template sip010|sip009`** — SIP-010 fungible token and SIP-009 NFT templates.
+- Network-aware **`stacksdapp dev --network devnet|testnet|mainnet`** (devnet spins local chain; testnet/mainnet runs frontend only).
+- Devnet burner wallet flow in frontend template.
+- Responsive header, footer, wallet connect, and debug UI layout.
+- `build-tx.mjs` for testnet/mainnet transaction signing.
+- Stale deployment warning after `generate` when on-chain state diverges.
+- Prefetch Clarinet requirements before devnet starts.
+- Per-arg typed inputs in generated debug UI.
+- crates.io naming convention (`stacksdapp`, `stacksdapp-scaffold`, etc.).
+
+### Changed
+
+- Flattened `add` command (removed nested subcommand).
+- Default deploy network set to **devnet**.
+- Next.js 15, `@stacks/clarinet-sdk` v3, `@stacks/connect` v8 in frontend template.
+- Default new contracts to **Clarity v4** and `epoch = "latest"`.
+- Full README developer guide with network workflows.
+
+### Fixed
+
+- Multi-contract deployment dependency ordering.
+- Auto-versioning on testnet/mainnet redeploy conflicts (`counter` → `counter-v2`).
+- Devnet deploy stability and stale chain state reset.
+- Deployer: node readiness wait, stdin `y` piping to Clarinet, real txid parsing.
+- Codegen: Tera filters, read-only call generation, `deployments.json` seeding, hot-reload-safe writes.
+- Parser: Clarity ABI type renames (`string-ascii`, `string-utf8`, buffer variant).
+- Frontend: wallet connect consistency, read-only API calls, post-condition mode defaults.
+- Deploy hang and interactive prompt issues.
+
+---
+
+## [0.1.0] — 2026-03-12
+
+Initial public CLI draft.
+
+### Added
+
+- **`stacksdapp`** binary with core commands:
+  - `new` — scaffold monorepo (contracts + Next.js frontend)
+  - `dev` — devnet + frontend + file watcher
+  - `generate` — parse ABIs and regenerate TypeScript bindings
+  - `add` — add Clarity contract
+  - `deploy` — deploy to devnet / testnet / mainnet
+  - `test` — contract and frontend tests
+  - `check` — Clarinet type-check
+  - `clean` — remove generated files and devnet state
+- Workspace crates: `scaffold`, `parser`, `codegen`, `watcher`, `deployer`, `process_supervisor`.
+- Next.js frontend template with wallet connect and generated debug UI.
+- Tera templates for `contracts.ts`, `hooks.ts`, `DebugContracts.tsx`.
+
+[Unreleased]: https://github.com/scaffold-stack/scaffold-stack/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/scaffold-stack/scaffold-stack/compare/v0.1.9...v0.2.0
+[0.1.9]: https://github.com/scaffold-stack/scaffold-stack/compare/v0.1.3...v0.1.9
+[0.1.3]: https://github.com/scaffold-stack/scaffold-stack/releases/tag/v0.1.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to scaffold-stacks
+
+Thanks for helping improve `stacksdapp`. This guide covers local development, checks we expect before a PR, and how releases are cut.
+
+## Prerequisites
+
+| Tool | Notes |
+|---|---|
+| Rust 1.75+ | via [rustup](https://rustup.rs) |
+| Node.js 20+ | frontend + Vitest contract tests |
+| Clarinet 3.21+ | contract toolchain (`brew install clarinet` or CI-style install) |
+| Docker Desktop | only for local `stacksdapp dev` (devnet) |
+
+Run `stacksdapp doctor` after building to verify your machine.
+
+## Setup
+
+```bash
+git clone https://github.com/scaffold-stack/scaffold-stack.git
+cd scaffold-stack
+cargo build -p stacksdapp
+./target/debug/stacksdapp doctor
+```
+
+## Day-to-day checks
+
+```bash
+# Unit / lib tests across the workspace
+cargo test --all
+
+# Fast CI-shaped smoke (doctor, name rejection, new → check → generate → add → test)
+bash scripts/ci-smoke.sh
+```
+
+## Project layout
+
+- `cli/` — `stacksdapp` binary (clap, exit codes, command dispatch)
+- `crates/shell/` — verbosity / quiet / color / JSON + root discovery
+- `crates/scaffold/` — `new` / `init` / `add` / `upgrade` + frontend template
+- `crates/codegen/`, `parser/`, `deployer/`, `watcher/`, `process_supervisor/` — domain crates
+
+Prefer small, focused PRs. Match existing naming and error style; use `CliError` (or messages classified in `cli/src/error.rs`) when adding failure paths scripts need to distinguish.
+
+## Exit codes
+
+Scripts should rely on stable codes documented in the README (project `2`, prerequisite/`doctor` `3`, aborted `4`, validation `5`, check `6`, test `7`, deploy `8`, generate `10`).
+
+## Releases
+
+1. Bump crate versions in the relevant `Cargo.toml` files (CLI version is the user-facing release).
+2. Run `bash scripts/check-versions.sh` and update `CHANGELOG.md`.
+3. Commit on a clean tree, tag `vX.Y.Z` matching `cli` version, and push the tag.
+4. GitHub Actions **Release** builds platform binaries and attaches them to a GitHub Release.
+5. Publish crates.io with `./pub.sh` (clean worktree by default; `--allow-dirty` only for emergencies).
+
+Do not hardcode machine-local paths in release scripts.
+
+## Pull requests
+
+- Describe **why**, not only what changed.
+- Include a short test plan (commands you ran).
+- Avoid committing secrets, large `target/` artifacts, or one-off local verify scripts that belong in `.gitignore`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,6 +2131,7 @@ dependencies = [
  "bip39",
  "bitcoin",
  "chrono",
+ "colored",
  "hex",
  "reqwest",
  "serde",
@@ -2157,10 +2158,12 @@ name = "stacksdapp-process-supervisor"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "colored",
  "reqwest",
  "serde_json",
  "stacksdapp-codegen",
  "stacksdapp-deployer",
+ "stacksdapp-shell",
  "stacksdapp-watcher",
  "tokio",
  "which",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1564,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1576,7 +1585,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2082,24 +2091,28 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacksdapp"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "colored",
  "indicatif",
+ "serde_json",
  "stacksdapp-codegen",
  "stacksdapp-deployer",
  "stacksdapp-parser",
  "stacksdapp-process-supervisor",
  "stacksdapp-scaffold",
+ "stacksdapp-shell",
  "stacksdapp-watcher",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "stacksdapp-codegen"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2112,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-deployer"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bip39",
@@ -2141,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-process-supervisor"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -2155,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "stacksdapp-scaffold"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2163,8 +2176,20 @@ dependencies = [
  "include_dir",
  "indicatif",
  "stacksdapp-codegen",
+ "stacksdapp-shell",
  "tokio",
  "which",
+]
+
+[[package]]
+name = "stacksdapp-shell"
+version = "0.2.0"
+dependencies = [
+ "colored",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -2278,11 +2303,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/watcher",
     "crates/deployer",
     "crates/process_supervisor",
+    "crates/shell",
 ]
 
 [workspace.dependencies]
@@ -17,7 +18,8 @@ serde_json     = "1"
 anyhow         = "1"
 thiserror      = "1"
 tera           = "1"
-clap           = { version = "4", features = ["derive"] }
+clap           = { version = "4", features = ["derive", "env"] }
+clap_complete  = "4"
 reqwest        = { version = "0.12", features = ["json", "rustls-tls"] }
 notify         = "6"
 indicatif      = "0.17"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ stacksdapp deploy --network testnet --dry-run
 ```
 
 ```
-🚀 Deploying to testnet (https://api.testnet.hiro.so)
+Deploying to testnet (https://api.testnet.hiro.so)
 [deploy] Generating deployment plan...
 [deploy] Applying deployment plan to testnet...
   ✔ counter | txid 0x86fa3030... | address ST3JAE....counter

--- a/README.md
+++ b/README.md
@@ -214,7 +214,11 @@ my-app/
 
 | Command | Description |
 |---|---|
-| `stacksdapp new <name>` | Scaffold a new project |
+| `stacksdapp new <name>` | Scaffold a new monorepo workspace |
+| `stacksdapp init` | Adopt an existing Clarinet project in the current directory |
+| `stacksdapp doctor [--strict] [--json]` | Check prerequisites (Rust, Node, Clarinet, Docker, …) |
+| `stacksdapp upgrade` | Refresh dependencies and regenerate bindings |
+| `stacksdapp completions <shell>` | Print shell completions (`bash`, `zsh`, `fish`, `powershell`, `elvish`) |
 | `stacksdapp dev --network testnet` | Run frontend against testnet (no Docker) |
 | `stacksdapp dev --network mainnet` | Run frontend against mainnet (no Docker) |
 | `stacksdapp dev` | Start local devnet + frontend + watcher (Docker required) |
@@ -222,28 +226,41 @@ my-app/
 | `stacksdapp deploy --network testnet` | Deploy to testnet |
 | `stacksdapp deploy --network testnet --contract <name>` | Deploy only one contract by name |
 | `stacksdapp deploy --network testnet --dry-run` | Generate plan + estimated fee without broadcasting |
+| `stacksdapp deploy --network testnet -y` | Non-interactive deploy (skip confirmation / Clarinet fee prompts) |
 | `stacksdapp deploy --network mainnet` | Deploy to mainnet |
 | `stacksdapp deploy --network devnet` | Deploy to local devnet |
-| `stacksdapp generate` | Parse ABIs → regenerate TS bindings + debug UI |
+| `stacksdapp generate [--watch]` | Parse ABIs → regenerate TS bindings + debug UI |
 | `stacksdapp add <name>` | Add a blank Clarity contract |
 | `stacksdapp add <name> --template sip010` | Add a SIP-010 fungible token |
 | `stacksdapp add <name> --template sip009` | Add a SIP-009 NFT |
 | `stacksdapp test` | Run contract + frontend tests |
 | `stacksdapp check` | Type-check all Clarity contracts |
-| `stacksdapp clean` | Remove generated files and devnet state |
+| `stacksdapp clean [--force]` | Remove generated files and devnet state |
 
----
+### Global flags
 
-## How Auto-Codegen Works
+| Flag | Description |
+|---|---|
+| `-v` / `-vv`… | Increase diagnostic verbosity |
+| `-q` / `--quiet` | Suppress non-error human logs |
+| `--color auto\|always\|never` | Color control (default `auto`) |
+| `--json` | Machine-readable stdout (single JSON object) |
+| `--root <PATH>` | Project root (or set `STACKSDAPP_ROOT`); otherwise walks up for `stacksdapp.toml` / `contracts/Clarinet.toml` |
 
-`stacksdapp generate` runs in four stages:
+### Exit codes
 
-1. **Parse** — `export-abi.mjs` calls `initSimnet()` to extract the ABI of every contract in `Clarinet.toml`
-2. **Normalise** — maps Clarity types to TypeScript (`uint128` → `bigint`, `string-ascii` → `string`, tuples → typed objects)
-3. **Render** — Tera templates produce `contracts.ts` (typed call wrappers), `hooks.ts` (React hooks), and `DebugContracts.tsx` (live debug panel)
-4. **Write** — SHA-256 hashes new vs existing output; only writes if content changed, keeping Next.js hot-reload fast
-
-The file watcher calls this pipeline automatically on every `.clar` save during `stacksdapp dev`.
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Generic / unexpected error |
+| `2` | Project not found or invalid `--root` |
+| `3` | Missing / failing prerequisite (`doctor`, clarinet, node, …) |
+| `4` | User aborted (confirmations) |
+| `5` | Input / argument validation |
+| `6` | Contract type-check failed |
+| `7` | Tests failed |
+| `8` | Deploy failed |
+| `10` | Generate / codegen failed |
 
 ---
 
@@ -252,7 +269,8 @@ The file watcher calls this pipeline automatically on every `.clar` save during 
 ```
 cli/                              # Binary — clap CLI entrypoint
 crates/
-  scaffold/                       # stacksdapp new + stacksdapp add
+  shell/                          # verbosity / quiet / color / JSON + project root discovery
+  scaffold/                       # stacksdapp new + init + add + upgrade
     frontend-template/            # copied into every new project's frontend/
   parser/                         # Clarity ABI → Rust structs
   codegen/                        # Rust structs → TypeScript via Tera
@@ -269,12 +287,17 @@ crates/
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build, test, release, and PR guidelines.
+
 ```bash
 git clone https://github.com/scaffold-stack/scaffold-stack.git
 cd scaffold-stack
-cargo build
+cargo build -p stacksdapp
 cargo test --all
+bash scripts/ci-smoke.sh
 ```
+
+Release notes live in [CHANGELOG.md](CHANGELOG.md).
 
 ---
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "stacksdapp"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 description = "The official stacksdapp CLI: A complete toolkit to scaffold, build, and deploy full-stack Bitcoin applications on Stacks."
 license     = "MIT"
@@ -12,14 +12,18 @@ name = "stacksdapp"
 path = "src/main.rs"
 
 [dependencies]
-stacksdapp-scaffold           = {version = "0.1.8", path = "../crates/scaffold" }
+stacksdapp-scaffold           = {version = "0.2.0", path = "../crates/scaffold" }
 stacksdapp-parser             = {version = "0.1.2", path = "../crates/parser" }
-stacksdapp-codegen            = {version = "0.1.6", path = "../crates/codegen" }
+stacksdapp-codegen            = {version = "0.2.0", path = "../crates/codegen" }
 stacksdapp-watcher            = {version = "0.1.2", path = "../crates/watcher" }
-stacksdapp-deployer           = {version = "0.1.4", path = "../crates/deployer" }
-stacksdapp-process-supervisor = {version = "0.1.6", path = "../crates/process_supervisor" }
+stacksdapp-deployer           = {version = "0.2.0", path = "../crates/deployer" }
+stacksdapp-process-supervisor = {version = "0.2.0", path = "../crates/process_supervisor" }
+thiserror.workspace = true
 clap.workspace      = true
+clap_complete.workspace = true
 tokio.workspace     = true
 anyhow.workspace    = true
 colored.workspace   = true
 indicatif.workspace = true
+serde_json.workspace = true
+stacksdapp-shell    = { version = "0.2.0", path = "../crates/shell" }

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
 use colored::Colorize;
+use serde_json::json;
+use stacksdapp_shell::{self as shell, status};
 use std::process::Stdio;
 use tokio::process::Command;
+
+use crate::error::CliError;
 
 struct Check {
     name: &'static str,
@@ -14,11 +18,29 @@ enum CheckResult {
     Fail(String),
 }
 
-pub async fn run() -> Result<()> {
-    println!(
-        "\n{}\n",
-        "stacksdapp doctor — checking prerequisites".bold()
-    );
+impl CheckResult {
+    fn status_str(&self) -> &'static str {
+        match self {
+            Self::Ok(_) => "ok",
+            Self::Warn(_) => "warn",
+            Self::Fail(_) => "fail",
+        }
+    }
+
+    fn detail(&self) -> &str {
+        match self {
+            Self::Ok(s) | Self::Warn(s) | Self::Fail(s) => s,
+        }
+    }
+}
+
+/// Run prerequisite checks.
+///
+/// Exit semantics (for CI / preflight):
+/// - Fail → always non-zero
+/// - Warn → zero by default; non-zero when `strict` is true
+pub async fn run(strict: bool) -> Result<()> {
+    shell::debug(1, "doctor: probing rustc, node, clarinet, docker, git");
 
     let checks = vec![
         check_rust().await,
@@ -29,56 +51,133 @@ pub async fn run() -> Result<()> {
         check_stacksdapp().await,
     ];
 
-    let mut all_ok = true;
+    let mut fail_count = 0usize;
+    let mut warn_count = 0usize;
 
     for check in &checks {
         match &check.result {
-            CheckResult::Ok(msg) => {
-                println!(
-                    "  {}  {} {}",
-                    "✔".green().bold(),
-                    check.name.white(),
-                    msg.dimmed()
-                );
-            }
-            CheckResult::Warn(msg) => {
-                println!(
-                    "  {}  {} {}",
-                    "⚠".yellow().bold(),
-                    check.name.white(),
-                    msg.yellow()
-                );
-                all_ok = false;
-            }
-            CheckResult::Fail(msg) => {
-                println!(
-                    "  {}  {} {}",
-                    "✗".red().bold(),
-                    check.name.white().bold(),
-                    msg.red()
-                );
-                all_ok = false;
-            }
+            CheckResult::Ok(_) => {}
+            CheckResult::Warn(_) => warn_count += 1,
+            CheckResult::Fail(_) => fail_count += 1,
         }
     }
 
-    println!();
+    let ok = fail_count == 0 && (!strict || warn_count == 0);
 
-    if all_ok {
-        println!(
-            "{}",
-            "  All checks passed. You're ready to build on Stacks!"
-                .green()
-                .bold()
-        );
+    let exit_code = if !ok { 3 } else { 0 };
+    if shell::is_json() {
+        let checks_json: Vec<_> = checks
+            .iter()
+            .map(|c| {
+                json!({
+                    "name": c.name,
+                    "status": c.result.status_str(),
+                    "detail": c.result.detail(),
+                })
+            })
+            .collect();
+        shell::emit_json(&json!({
+            "ok": ok,
+            "command": "doctor",
+            "strict": strict,
+            "fail_count": fail_count,
+            "warn_count": warn_count,
+            "code": if ok { "ok" } else { "prerequisite" },
+            "exit_code": exit_code,
+            "checks": checks_json,
+        }));
     } else {
-        println!(
-            "{}",
-            "  Some checks failed. Fix the issues above before running stacksdapp new.".yellow()
-        );
+        status(format!(
+            "\n{}\n",
+            "stacksdapp doctor — checking prerequisites".bold()
+        ));
+
+        for check in &checks {
+            match &check.result {
+                CheckResult::Ok(msg) => {
+                    status(format!(
+                        "  {}  {} {}",
+                        "✔".green().bold(),
+                        check.name.white(),
+                        msg.dimmed()
+                    ));
+                }
+                CheckResult::Warn(msg) => {
+                    status(format!(
+                        "  {}  {} {}",
+                        "⚠".yellow().bold(),
+                        check.name.white(),
+                        msg.yellow()
+                    ));
+                }
+                CheckResult::Fail(msg) => {
+                    status(format!(
+                        "  {}  {} {}",
+                        "✗".red().bold(),
+                        check.name.white().bold(),
+                        msg.red()
+                    ));
+                }
+            }
+        }
+
+        status("");
+
+        if fail_count == 0 && warn_count == 0 {
+            status(
+                "  All checks passed. You're ready to build on Stacks!"
+                    .green()
+                    .bold()
+                    .to_string(),
+            );
+            status("");
+            return Ok(());
+        }
+
+        if fail_count > 0 {
+            status(
+                "  Some checks failed. Fix the issues above before running stacksdapp new."
+                    .red()
+                    .bold()
+                    .to_string(),
+            );
+            status("");
+        } else {
+            status(
+                "  Some checks warned. Review the issues above before running stacksdapp new."
+                    .yellow()
+                    .to_string(),
+            );
+            if strict {
+                status(
+                    "  (--strict: treating warnings as failures)"
+                        .dimmed()
+                        .to_string(),
+                );
+            }
+            status("");
+        }
     }
 
-    println!();
+    if fail_count > 0 {
+        return Err(CliError::Prerequisite(format!(
+            "doctor failed: {fail_count} failing check(s){}",
+            if warn_count > 0 {
+                format!(", {warn_count} warning(s)")
+            } else {
+                String::new()
+            }
+        ))
+        .into());
+    }
+
+    if warn_count > 0 && strict {
+        return Err(CliError::Prerequisite(format!(
+            "doctor failed: {warn_count} warning(s) under --strict"
+        ))
+        .into());
+    }
+
     Ok(())
 }
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,212 @@
+//! Stable CLI exit codes for scripting (Foundry-style distinguishability).
+//!
+//! | Code | Meaning |
+//! |------|---------|
+//! | 0    | Success |
+//! | 1    | Generic / unexpected error |
+//! | 2    | Project not found or invalid `--root` |
+//! | 3    | Missing / failing prerequisite tool (`doctor`, clarinet, node, …) |
+//! | 4    | User aborted (confirmations) |
+//! | 5    | Invalid / argument validation |
+//! | 6    | Contract type-check failed |
+//! | 7    | Tests failed |
+//! | 8    | Deploy failed |
+//! | 10   | Generate / codegen failed |
+
+use thiserror::Error;
+
+/// Typed CLI failures with stable process exit codes.
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("{0}")]
+    Project(String),
+
+    #[error("{0}")]
+    Prerequisite(String),
+
+    #[error("{0}")]
+    Aborted(String),
+
+    #[error("{0}")]
+    Validation(String),
+
+    #[error("{0}")]
+    Check(String),
+
+    #[error("{0}")]
+    Test(String),
+
+    #[error("{0}")]
+    Deploy(String),
+
+    #[error("{0}")]
+    Generate(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl CliError {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Project(_) => 2,
+            Self::Prerequisite(_) => 3,
+            Self::Aborted(_) => 4,
+            Self::Validation(_) => 5,
+            Self::Check(_) => 6,
+            Self::Test(_) => 7,
+            Self::Deploy(_) => 8,
+            Self::Generate(_) => 10,
+            Self::Other(_) => 1,
+        }
+    }
+
+    pub fn code_name(&self) -> &'static str {
+        match self {
+            Self::Project(_) => "project",
+            Self::Prerequisite(_) => "prerequisite",
+            Self::Aborted(_) => "aborted",
+            Self::Validation(_) => "validation",
+            Self::Check(_) => "check",
+            Self::Test(_) => "test",
+            Self::Deploy(_) => "deploy",
+            Self::Generate(_) => "generate",
+            Self::Other(_) => "error",
+        }
+    }
+}
+
+/// Map an `anyhow` error (including nested [`CliError`]) to a stable exit code.
+pub fn exit_code_for(err: &anyhow::Error) -> i32 {
+    if let Some(cli) = err.downcast_ref::<CliError>() {
+        return cli.exit_code();
+    }
+    classify_message(&format!("{err:#}"))
+}
+
+pub fn code_name_for(err: &anyhow::Error) -> &'static str {
+    if let Some(cli) = err.downcast_ref::<CliError>() {
+        return cli.code_name();
+    }
+    match classify_message(&format!("{err:#}")) {
+        2 => "project",
+        3 => "prerequisite",
+        4 => "aborted",
+        5 => "validation",
+        6 => "check",
+        7 => "test",
+        8 => "deploy",
+        10 => "generate",
+        _ => "error",
+    }
+}
+
+fn classify_message(msg: &str) -> i32 {
+    let m = msg.to_ascii_lowercase();
+
+    if m.contains("no stacksdapp project")
+        || m.contains("invalid --root")
+        || m.contains("is not a stacksdapp project")
+        || m.contains("is not a clarinet/stacksdapp project")
+        || m.contains("no scaffold-stacks project")
+        || m.contains("no clarinet project detected")
+    {
+        return 2;
+    }
+
+    if m.contains("doctor failed")
+        || m.contains("clarinet is required")
+        || m.contains("node.js")
+        || m.contains("nodejs")
+        || m.contains("not found. install")
+        || m.contains("rust 1.75")
+    {
+        return 3;
+    }
+
+    if m.contains("aborted")
+        || m.contains("refusing to clean")
+        || m.contains("refusing to deploy")
+        || m.contains("confirmation") && (m.contains("aborted") || m.contains("refusing"))
+    {
+        return 4;
+    }
+
+    if m.contains("invalid project name")
+        || m.contains("invalid contract name")
+        || m.contains("cannot contain path")
+        || m.contains("cannot be an absolute path")
+        || m.contains("must be a single directory")
+        || m.contains("must be at most")
+        || m.contains("cannot be empty")
+        || m.contains("cannot be '.' or '..'")
+    {
+        return 5;
+    }
+
+    if m.contains("type-check failed") || m.contains("clarity type-check") {
+        return 6;
+    }
+
+    if m.contains("tests failed") || m.contains("test failed") {
+        return 7;
+    }
+
+    if m.contains("deploy")
+        && (m.contains("failed")
+            || m.contains("broadcast")
+            || m.contains("mnemonic")
+            || m.contains("deployment plan"))
+    {
+        return 8;
+    }
+
+    if m.contains("[generate]")
+        || m.contains("failed to export")
+        || m.contains("abi") && m.contains("fail")
+    {
+        return 10;
+    }
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_exit_codes() {
+        assert_eq!(CliError::Project("x".into()).exit_code(), 2);
+        assert_eq!(CliError::Prerequisite("x".into()).exit_code(), 3);
+        assert_eq!(CliError::Aborted("x".into()).exit_code(), 4);
+        assert_eq!(CliError::Validation("x".into()).exit_code(), 5);
+        assert_eq!(CliError::Check("x".into()).exit_code(), 6);
+        assert_eq!(CliError::Test("x".into()).exit_code(), 7);
+        assert_eq!(CliError::Deploy("x".into()).exit_code(), 8);
+        assert_eq!(CliError::Generate("x".into()).exit_code(), 10);
+    }
+
+    #[test]
+    fn classifies_common_messages() {
+        assert_eq!(
+            classify_message("No stacksdapp project found above '/tmp'."),
+            2
+        );
+        assert_eq!(
+            classify_message("doctor failed: 1 warning(s) under --strict"),
+            3
+        );
+        assert_eq!(classify_message("Clean aborted."), 4);
+        assert_eq!(
+            classify_message("Invalid project name 'bad name'. Use a letter..."),
+            5
+        );
+        assert_eq!(classify_message("Clarity type-check failed."), 6);
+        assert_eq!(classify_message("Contract tests failed."), 7);
+        assert_eq!(
+            classify_message("Direct devnet deployment failed for counter."),
+            8
+        );
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,10 +1,19 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, CommandFactory, Parser, Subcommand};
+use clap_complete::{generate, Shell};
 use colored::Colorize;
+use serde_json::json;
+use stacksdapp_shell::{self as shell, status};
+use std::io;
+use std::process::ExitCode;
+
 mod commands {
     pub mod doctor;
 }
+mod error;
+
 use commands::doctor;
+use error::{code_name_for, exit_code_for, CliError};
 
 const CLI_BEFORE_HELP: &str = r#"
   ┌─ Scaffold Stacks ─────────────────────────────────────────┐
@@ -19,9 +28,29 @@ const CLI_BEFORE_HELP: &str = r#"
     version,
     about = "Full-stack toolkit for Stacks: scaffold, run, and ship Clarity + Next.js apps.",
     before_help = CLI_BEFORE_HELP,
-    after_help = "Examples:\n  stacksdapp new my-dapp && cd my-dapp && stacksdapp dev\n  stacksdapp generate\n  stacksdapp deploy --network testnet"
+    after_help = "Examples:\n  stacksdapp new my-dapp && cd my-dapp && stacksdapp dev\n  stacksdapp generate\n  stacksdapp deploy --network testnet\n  stacksdapp doctor --json\n  cd frontend && stacksdapp check   # walks up to project root\n  stacksdapp --root ../my-dapp test\n  stacksdapp completions zsh > ~/.zfunc/_stacksdapp"
 )]
 struct Cli {
+    /// Verbosity (-v, -vv, …). Higher values print more diagnostic detail.
+    #[arg(short = 'v', long = "verbosity", action = ArgAction::Count, global = true)]
+    verbosity: u8,
+
+    /// Suppress non-error log messages
+    #[arg(short = 'q', long, global = true, conflicts_with = "verbosity")]
+    quiet: bool,
+
+    /// Color of log messages: auto | always | never
+    #[arg(long, global = true, default_value = "auto", value_parser = ["auto", "always", "never"])]
+    color: String,
+
+    /// Format command results as JSON (implies quiet human logs)
+    #[arg(long, global = true)]
+    json: bool,
+
+    /// Project root (default: walk up for stacksdapp.toml or contracts/Clarinet.toml)
+    #[arg(long, global = true, value_name = "PATH", env = "STACKSDAPP_ROOT")]
+    root: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -30,7 +59,7 @@ struct Cli {
 enum Commands {
     /// Scaffold a new monorepo workspace
     New {
-        /// Project name (becomes directory name)
+        /// Project name (single directory segment: letters, digits, -, _)
         name: String,
         /// Skip git init
         #[arg(long)]
@@ -59,7 +88,7 @@ enum Commands {
     Init,
     /// Add a new Clarity contract: stacksdapp add <name> [--template blank|sip010|sip009]
     Add {
-        /// Contract name
+        /// Contract name (Clarity id: letter, then letters/digits/-/_; max 40)
         name: String,
         /// Template to use
         #[arg(long, default_value = "blank")]
@@ -75,64 +104,269 @@ enum Commands {
         /// Generate plan and fee estimate without broadcasting transactions
         #[arg(long)]
         dry_run: bool,
+        /// Skip interactive confirmation and auto-answer Clarinet fee prompts
+        /// (required for non-interactive testnet/mainnet deploys)
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
     /// Run contract and frontend tests (vitest)
     Test,
     /// Type-check all Clarity contracts
     Check,
     /// Remove generated files and devnet state
-    Clean,
+    Clean {
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
     /// Check all prerequisites and print a status report
-    Doctor,
+    Doctor {
+        /// Treat warnings as failures (non-zero exit)
+        #[arg(long)]
+        strict: bool,
+    },
     /// Refresh dependencies and regenerate bindings
     Upgrade,
+    /// Generate shell completions (bash, zsh, fish, powershell, elvish)
+    #[command(visible_alias = "com")]
+    Completions {
+        /// Target shell
+        #[arg(value_enum)]
+        shell: Shell,
+    },
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> ExitCode {
     let cli = Cli::parse();
+    init_shell(&cli);
+    shell::debug(
+        1,
+        format!(
+            "stacksdapp starting (verbosity={}, quiet={}, json={}, color={})",
+            cli.verbosity, cli.quiet, cli.json, cli.color
+        ),
+    );
+
+    match dispatch(cli).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let code = exit_code_for(&e);
+            let kind = code_name_for(&e);
+            if shell::is_json() {
+                if !shell::json_already_emitted() {
+                    shell::emit_json(&json!({
+                        "ok": false,
+                        "command": "stacksdapp",
+                        "error": e.to_string(),
+                        "code": kind,
+                        "exit_code": code,
+                    }));
+                }
+            } else {
+                eprintln!("Error: {e:?}");
+                shell::debug(1, format!("exit_code={code} ({kind})"));
+            }
+            ExitCode::from(code as u8)
+        }
+    }
+}
+
+fn init_shell(cli: &Cli) {
+    let color = shell::ColorMode::parse(&cli.color).unwrap_or(shell::ColorMode::Auto);
+    let format = if cli.json {
+        shell::Format::Json
+    } else {
+        shell::Format::Human
+    };
+    shell::init(shell::Shell {
+        verbosity: cli.verbosity,
+        quiet: cli.quiet,
+        format,
+        color,
+    });
+}
+
+async fn dispatch(cli: Cli) -> Result<()> {
+    enter_project_context(&cli)?;
+
     match cli.command {
-        Commands::New { name, no_git } => stacksdapp_scaffold::new_project(&name, !no_git).await,
+        Commands::New { name, no_git } => stacksdapp_scaffold::new_project(&name, !no_git)
+            .await
+            .map_err(map_scaffold_err),
         Commands::Dev {
             network,
             auto_deploy,
         } => stacksdapp_process_supervisor::dev(&network, auto_deploy).await,
         Commands::Generate { watch } => run_generate(watch).await,
-        Commands::Init => stacksdapp_scaffold::init_project().await,
-        Commands::Add { name, template } => {
-            stacksdapp_scaffold::add_contract(&name, &template).await
-        }
+        Commands::Init => stacksdapp_scaffold::init_project()
+            .await
+            .map_err(map_scaffold_err),
+        Commands::Add { name, template } => stacksdapp_scaffold::add_contract(&name, &template)
+            .await
+            .map_err(map_scaffold_err),
         Commands::Deploy {
             network,
             contract,
             dry_run,
-        } => stacksdapp_deployer::deploy(&network, contract.as_deref(), dry_run).await,
+            yes,
+        } => stacksdapp_deployer::deploy(&network, contract.as_deref(), dry_run, yes)
+            .await
+            .map_err(|e| {
+                let msg = format!("{e:#}");
+                let lower = msg.to_ascii_lowercase();
+                if lower.contains("refusing to deploy")
+                    || lower.contains("aborted")
+                    || lower.contains("confirmation cancelled")
+                {
+                    anyhow::Error::new(CliError::Aborted(msg))
+                } else {
+                    anyhow::Error::new(CliError::Deploy(msg))
+                }
+            }),
         Commands::Test => run_test().await,
         Commands::Check => run_check().await,
-        Commands::Clean => run_clean().await,
-        Commands::Doctor => doctor::run().await,
-        Commands::Upgrade => stacksdapp_scaffold::upgrade_project().await,
+        Commands::Clean { force } => run_clean(force).await,
+        Commands::Doctor { strict } => doctor::run(strict).await,
+        Commands::Upgrade => stacksdapp_scaffold::upgrade_project()
+            .await
+            .map_err(map_scaffold_err),
+        Commands::Completions { shell } => print_completions(shell),
+    }
+}
+
+fn map_scaffold_err(e: anyhow::Error) -> anyhow::Error {
+    let msg = format!("{e:#}");
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("invalid project name")
+        || lower.contains("invalid contract name")
+        || lower.contains("cannot contain path")
+        || lower.contains("cannot be an absolute path")
+        || lower.contains("must be a single directory")
+        || lower.contains("must be at most")
+        || lower.contains("cannot be empty")
+        || lower.contains("cannot be '.' or '..'")
+    {
+        anyhow::Error::new(CliError::Validation(msg))
+    } else {
+        e
+    }
+}
+
+fn print_completions(shell: Shell) -> Result<()> {
+    use std::io::Write;
+
+    let mut cmd = Cli::command();
+    let mut buf = Vec::new();
+    generate(shell, &mut cmd, "stacksdapp", &mut buf);
+    match io::stdout().write_all(&buf) {
+        Ok(()) => Ok(()),
+        // `… | head` closes the pipe early — not a real failure.
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Foundry-style root discovery: chdir into the project before path-relative commands.
+fn enter_project_context(cli: &Cli) -> Result<()> {
+    use std::env;
+
+    match &cli.command {
+        // Create / diagnose / completions relative to the caller's cwd — do not walk up.
+        Commands::New { .. } | Commands::Doctor { .. } | Commands::Completions { .. } => Ok(()),
+
+        // Init: prefer nearest Clarinet or scaffold root, else stay in cwd.
+        Commands::Init => {
+            if let Some(ref explicit) = cli.root {
+                let root = if explicit.is_absolute() {
+                    explicit.clone()
+                } else {
+                    env::current_dir()?.join(explicit)
+                };
+                let root = root.canonicalize().map_err(|e| {
+                    anyhow::Error::new(CliError::Project(format!(
+                        "Invalid --root '{}': {e}",
+                        explicit.display()
+                    )))
+                })?;
+                let is_ok = root.join(shell::CONFIG_FILE).is_file()
+                    || root.join("contracts").join("Clarinet.toml").is_file()
+                    || root.join("Clarinet.toml").is_file();
+                if !is_ok {
+                    return Err(CliError::Project(format!(
+                        "Directory '{}' is not a Clarinet/stacksdapp project.",
+                        root.display()
+                    ))
+                    .into());
+                }
+                env::set_current_dir(&root)?;
+                shell::debug(1, format!("init: using --root {}", root.display()));
+                return Ok(());
+            }
+            let cwd = env::current_dir()?;
+            if let Some(root) = shell::find_init_root(&cwd) {
+                if root != cwd {
+                    shell::debug(1, format!("init: walking up to {}", root.display()));
+                    env::set_current_dir(&root)?;
+                } else {
+                    shell::debug(1, format!("init: project root {}", root.display()));
+                }
+            }
+            Ok(())
+        }
+
+        // All other commands require a scaffold project root.
+        _ => {
+            let root = shell::enter_scaffold_root(cli.root.as_deref()).map_err(|msg| {
+                anyhow::Error::new(if msg.to_ascii_lowercase().contains("invalid --root") {
+                    CliError::Project(msg)
+                } else if msg.contains("No stacksdapp project")
+                    || msg.contains("is not a stacksdapp project")
+                {
+                    CliError::Project(msg)
+                } else {
+                    CliError::Other(msg)
+                })
+            })?;
+            shell::debug(1, format!("project root {}", root.display()));
+            if let Ok(cfg) = shell::load_config(&root) {
+                if let Some(name) = cfg.project.and_then(|p| p.name) {
+                    shell::debug(1, format!("stacksdapp.toml project.name={name}"));
+                }
+            }
+            Ok(())
+        }
     }
 }
 
 async fn run_generate(watch: bool) -> Result<()> {
     use std::path::Path;
-    stacksdapp_codegen::generate_all().await?;
+    stacksdapp_codegen::generate_all()
+        .await
+        .map_err(|e| CliError::Generate(format!("{e:#}")))?;
     if watch {
-        println!(
-            "{}",
-            "[generate] Watching contracts/contracts for .clar changes...".cyan()
+        status(
+            "[generate] Watching contracts/contracts for .clar changes..."
+                .cyan()
+                .to_string(),
         );
-        stacksdapp_watcher::watch_contracts(Path::new("contracts/contracts")).await?;
+        stacksdapp_watcher::watch_contracts(Path::new("contracts/contracts"))
+            .await
+            .map_err(|e| CliError::Generate(format!("{e:#}")))?;
+    }
+    if shell::is_json() {
+        shell::emit_json(&json!({ "ok": true, "command": "generate", "watch": watch }));
     }
     Ok(())
 }
 
 async fn run_test() -> Result<()> {
     if !tokio::fs::metadata("contracts/Clarinet.toml").await.is_ok() {
-        anyhow::bail!(
+        return Err(CliError::Project(
             "No scaffold-stacks project found. Run from the directory created by stacksdapp new"
-        );
+                .into(),
+        )
+        .into());
     }
 
     run_vitest_suite("contracts", "contract", VitestRunMode::NpmScript).await?;
@@ -141,7 +375,10 @@ async fn run_test() -> Result<()> {
         run_vitest_suite("frontend", "frontend", VitestRunMode::RunPassWithNoTests).await?;
     }
 
-    println!("{}", "All tests passed.".green().bold());
+    status("All tests passed.".green().bold().to_string());
+    if shell::is_json() {
+        shell::emit_json(&json!({ "ok": true, "command": "test" }));
+    }
     Ok(())
 }
 
@@ -162,9 +399,10 @@ async fn ensure_npm_dependencies(dir: &str) -> Result<()> {
         return Ok(());
     }
 
-    println!(
-        "{}",
-        format!("[test] Installing {dir} dependencies...").cyan()
+    status(
+        format!("[test] Installing {dir} dependencies...")
+            .cyan()
+            .to_string(),
     );
     let subcommand = if tokio::fs::metadata(format!("{dir}/package-lock.json"))
         .await
@@ -189,8 +427,11 @@ async fn ensure_npm_dependencies(dir: &str) -> Result<()> {
 
     match install {
         Ok(s) if s.success() => Ok(()),
-        Ok(_) => anyhow::bail!("npm install failed in {dir}/"),
-        Err(_) => anyhow::bail!("Node.js >=20 is required. Install from nodejs.org"),
+        Ok(_) => Err(CliError::Other(format!("npm install failed in {dir}/")).into()),
+        Err(_) => Err(CliError::Prerequisite(
+            "Node.js >=20 is required. Install from nodejs.org".into(),
+        )
+        .into()),
     }
 }
 
@@ -199,20 +440,15 @@ async fn run_vitest_suite(dir: &str, label: &str, mode: VitestRunMode) -> Result
 
     ensure_npm_dependencies(dir).await?;
 
-    println!(
-        "{}",
-        format!("[test] Running {label} tests (vitest)...").cyan()
+    status(
+        format!("[test] Running {label} tests (vitest)...")
+            .cyan()
+            .to_string(),
     );
+    shell::debug(1, format!("vitest cwd={dir}"));
 
-    let status = match mode {
-        VitestRunMode::NpmScript => {
-            Command::new("npm")
-                .args(["run", "test"])
-                .current_dir(dir)
-                .status()
-                .await
-        }
-        VitestRunMode::RunPassWithNoTests => {
+    let status_code = match mode {
+        VitestRunMode::NpmScript | VitestRunMode::RunPassWithNoTests => {
             Command::new("npm")
                 .args(["run", "test"])
                 .current_dir(dir)
@@ -221,16 +457,22 @@ async fn run_vitest_suite(dir: &str, label: &str, mode: VitestRunMode) -> Result
         }
     };
 
-    match status {
+    match status_code {
         Ok(s) if s.success() => {
-            println!(
-                "{}",
-                format!("[test] {} tests passed.", capitalize_test_label(label)).green()
+            status(
+                format!("[test] {} tests passed.", capitalize_test_label(label))
+                    .green()
+                    .to_string(),
             );
             Ok(())
         }
-        Ok(_) => anyhow::bail!("{} tests failed.", capitalize_test_label(label)),
-        Err(_) => anyhow::bail!("Node.js >=20 is required. Install from nodejs.org"),
+        Ok(_) => {
+            Err(CliError::Test(format!("{} tests failed.", capitalize_test_label(label))).into())
+        }
+        Err(_) => Err(CliError::Prerequisite(
+            "Node.js >=20 is required. Install from nodejs.org".into(),
+        )
+        .into()),
     }
 }
 
@@ -245,71 +487,145 @@ fn capitalize_test_label(label: &str) -> String {
 async fn run_check() -> Result<()> {
     use tokio::process::Command;
 
-    println!("{}", "[check] Type-checking Clarity contracts...".cyan());
+    status(
+        "[check] Type-checking Clarity contracts..."
+            .cyan()
+            .to_string(),
+    );
 
-    let status = Command::new("clarinet")
+    let cmd_status = Command::new("clarinet")
         .args(["check"])
         .current_dir("contracts")
         .status()
         .await;
 
-    match status {
+    match cmd_status {
         Ok(s) if s.success() => {
-            println!("{}", "[check] All contracts passed type-checking.".green());
+            status(
+                "[check] All contracts passed type-checking."
+                    .green()
+                    .to_string(),
+            );
+            if shell::is_json() {
+                shell::emit_json(&json!({ "ok": true, "command": "check" }));
+            }
             Ok(())
         }
-        Ok(_) => anyhow::bail!("Clarity type-check failed. Fix the errors reported above."),
-        Err(_) => anyhow::bail!(
-            "clarinet is required. Install: brew install clarinet OR cargo install clarinet"
-        ),
+        Ok(_) => Err(CliError::Check(
+            "Clarity type-check failed. Fix the errors reported above.".into(),
+        )
+        .into()),
+        Err(_) => Err(CliError::Prerequisite(
+            "clarinet is required. Install: brew install clarinet OR cargo install clarinet".into(),
+        )
+        .into()),
     }
 }
 
-async fn run_clean() -> Result<()> {
-    use std::path::Path;
+async fn run_clean(force: bool) -> Result<()> {
+    use std::io::{self, IsTerminal, Write};
+    use std::path::{Path, PathBuf};
     use tokio::fs;
 
-    println!(
-        "{}",
-        "[clean] Removing generated files and devnet state...".cyan()
-    );
+    if !Path::new("contracts/Clarinet.toml").exists() {
+        return Err(CliError::Project(
+            "No scaffold-stacks project found. Run from the directory created by stacksdapp new"
+                .into(),
+        )
+        .into());
+    }
 
-    let generated_dir = Path::new("frontend/src/generated");
+    let mut targets: Vec<(PathBuf, &'static str)> = Vec::new();
+    let generated_dir = PathBuf::from("frontend/src/generated");
     if generated_dir.exists() {
-        fs::remove_dir_all(generated_dir).await?;
-        println!("{}", "[clean] Removed frontend/src/generated/".yellow());
+        targets.push((generated_dir.clone(), "directory"));
     }
-
-    let devnet_dir = Path::new("contracts/.cache");
-    if devnet_dir.exists() {
-        fs::remove_dir_all(devnet_dir).await?;
-        println!("{}", "[clean] Removed contracts/.cache/".yellow());
+    for dir in ["contracts/.cache", "contracts/.devnet"] {
+        let path = PathBuf::from(dir);
+        if path.exists() {
+            targets.push((path, "directory"));
+        }
     }
-
-    let devnet_data = Path::new("contracts/.devnet");
-    if devnet_data.exists() {
-        fs::remove_dir_all(devnet_data).await?;
-        println!("{}", "[clean] Removed contracts/.devnet/".yellow());
-    }
-
-    for auto_generated in &["Simnet.toml", "Epoch25.toml", "Epoch30.toml"] {
+    for auto_generated in ["Simnet.toml", "Epoch25.toml", "Epoch30.toml"] {
         let path = Path::new("contracts/settings").join(auto_generated);
         if path.exists() {
-            fs::remove_file(&path).await?;
-            println!("[clean] Removed contracts/settings/{auto_generated}");
+            targets.push((path, "file"));
         }
     }
 
-    fs::create_dir_all(generated_dir).await?;
+    if targets.is_empty() {
+        status("[clean] Nothing to remove.".green().to_string());
+        if shell::is_json() {
+            shell::emit_json(&json!({
+                "ok": true,
+                "command": "clean",
+                "removed": [],
+            }));
+        }
+        return Ok(());
+    }
+
+    status("[clean] Will remove:".cyan().to_string());
+    for (path, kind) in &targets {
+        status(format!("  • {} ({kind})", path.display()));
+    }
+
+    if !force {
+        if shell::is_json() || !io::stdin().is_terminal() {
+            return Err(CliError::Aborted(
+                "Refusing to clean without confirmation in a non-interactive terminal.\n\
+                 Re-run with: stacksdapp clean --force"
+                    .into(),
+            )
+            .into());
+        }
+        print!("\nType 'y' to confirm deletion: ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if input.trim() != "y" {
+            return Err(CliError::Aborted("Clean aborted.".into()).into());
+        }
+    }
+
+    status(
+        "[clean] Removing generated files and devnet state..."
+            .cyan()
+            .to_string(),
+    );
+
+    let mut removed = Vec::new();
+    for (path, kind) in &targets {
+        match *kind {
+            "directory" => fs::remove_dir_all(path).await?,
+            _ => fs::remove_file(path).await?,
+        }
+        removed.push(path.display().to_string());
+        status(
+            format!("[clean] Removed {}", path.display())
+                .yellow()
+                .to_string(),
+        );
+    }
+
+    fs::create_dir_all(&generated_dir).await?;
     fs::write(
         generated_dir.join("deployments.json"),
         r#"{ "network": "", "deployed_at": "", "contracts": {} }"#,
     )
     .await?;
 
-    println!(
-        "{}",
-        "[clean] Done. Run `stacksdapp generate` to regenerate bindings.".green()
+    status(
+        "[clean] Done. Run `stacksdapp generate` to regenerate bindings."
+            .green()
+            .to_string(),
     );
+    if shell::is_json() {
+        shell::emit_json(&json!({
+            "ok": true,
+            "command": "clean",
+            "removed": removed,
+        }));
+    }
     Ok(())
 }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-codegen"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 description = "TypeScript code generation engine for Stacks dApps, using Tera templates to create type-safe contract hooks."
 license     = "MIT"

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -72,6 +72,15 @@ impl Filter for UpperCamelFilter {
 // ── Public API ────────────────────────────────────────────────────────────────
 
 pub async fn generate_all() -> Result<()> {
+    generate_all_impl(false).await
+}
+
+/// Same as [`generate_all`] but suppresses progress logs (for nested CLI steps).
+pub async fn generate_all_quiet() -> Result<()> {
+    generate_all_impl(true).await
+}
+
+async fn generate_all_impl(quiet: bool) -> Result<()> {
     let project_root = std::env::current_dir()?;
     let contracts_dir = project_root.join("contracts");
     if !contracts_dir.join("Clarinet.toml").exists()
@@ -82,9 +91,15 @@ pub async fn generate_all() -> Result<()> {
         );
     }
 
+    let log = |msg: String| {
+        if !quiet {
+            println!("{msg}");
+        }
+    };
+
     let frontend_dir = project_root.join("frontend");
     if !frontend_dir.join("node_modules").exists() {
-        println!("[generate] Installing frontend dependencies...");
+        log("[generate] Installing frontend dependencies...".into());
         let subcommand = if frontend_dir.join("package-lock.json").exists() {
             "ci"
         } else {
@@ -107,29 +122,26 @@ pub async fn generate_all() -> Result<()> {
         }
     }
 
-    println!("[generate] Parsing contract ABIs...");
+    log("[generate] Parsing contract ABIs...".into());
     let abis = stacksdapp_parser::parse_project(&contracts_dir).await?;
 
     if abis.is_empty() {
-        println!("[generate] No user contracts found in Clarinet.toml — nothing to generate.");
+        log("[generate] No user contracts found in Clarinet.toml — nothing to generate.".into());
         return Ok(());
     }
 
-    println!(
+    log(format!(
         "[generate] Found {} contract(s): {}",
         abis.len(),
         abis.iter()
             .map(|a| a.contract_name.as_str())
             .collect::<Vec<_>>()
             .join(", ")
-    );
+    ));
 
     let out_dir = project_root.join("frontend/src/generated");
     tokio::fs::create_dir_all(&out_dir).await?;
 
-    // Write empty deployments.json if it doesn't exist yet so that
-    // contracts.ts can always require() it without crashing at import time.
-    // The real content is written by `stacksdapp deploy`.
     let deployments_path = out_dir.join("deployments.json");
     if !deployments_path.exists() {
         tokio::fs::write(
@@ -137,20 +149,20 @@ pub async fn generate_all() -> Result<()> {
             r#"{ "network": "", "deployed_at": "", "contracts": {} }"#,
         )
         .await?;
-        println!("[generate] Created empty deployments.json (run stacksdapp deploy to populate)");
+        log("[generate] Created empty deployments.json (run stacksdapp deploy to populate)".into());
     }
 
-    let written = render(&abis, &out_dir)?;
+    let written = render_with_quiet(&abis, &out_dir, quiet)?;
 
     if written == 0 {
-        println!("[generate] All files already up to date.");
+        log("[generate] All files already up to date.".into());
     } else {
-        println!("[generate] Done — {written} file(s) written.");
+        log(format!("[generate] Done — {written} file(s) written."));
     }
 
     let network = std::env::var("NEXT_PUBLIC_NETWORK").unwrap_or_else(|_| "<network>".into());
     let stale = find_stale_deployments(&abis, &out_dir);
-    if !stale.is_empty() {
+    if !stale.is_empty() && !quiet {
         warn_redeploy_required(&stale, &network);
     }
 
@@ -159,6 +171,10 @@ pub async fn generate_all() -> Result<()> {
 
 /// Render all templates. Returns the number of files actually written.
 pub fn render(abis: &[ContractAbi], out_dir: &Path) -> Result<usize> {
+    render_with_quiet(abis, out_dir, false)
+}
+
+fn render_with_quiet(abis: &[ContractAbi], out_dir: &Path, quiet: bool) -> Result<usize> {
     let mut tera = Tera::default();
     tera.register_filter("camel", CamelFilter);
     tera.register_filter("upper_camel", UpperCamelFilter);
@@ -197,14 +213,17 @@ pub fn render(abis: &[ContractAbi], out_dir: &Path) -> Result<usize> {
     written += write_if_changed(
         out_dir.join("contracts.ts"),
         &tera.render("contracts.ts.tera", &ctx)?,
+        quiet,
     )?;
     written += write_if_changed(
         out_dir.join("hooks.ts"),
         &tera.render("hooks.ts.tera", &ctx)?,
+        quiet,
     )?;
     written += write_if_changed(
         out_dir.join("DebugContracts.tsx"),
         &tera.render("debug_ui.tsx.tera", &ctx)?,
+        quiet,
     )?;
 
     Ok(written)
@@ -303,7 +322,7 @@ fn deployment_id_matches(deployed_id: &str, contract_name: &str) -> bool {
 }
 
 /// Write file only if content changed. Returns 1 if written, 0 if skipped.
-fn write_if_changed(path: PathBuf, contents: &str) -> Result<usize> {
+fn write_if_changed(path: PathBuf, contents: &str, quiet: bool) -> Result<usize> {
     let new_bytes = contents.as_bytes();
     let new_hash = hash_bytes(new_bytes);
 
@@ -318,7 +337,9 @@ fn write_if_changed(path: PathBuf, contents: &str) -> Result<usize> {
     }
     let mut file = fs::File::create(&path)?;
     file.write_all(new_bytes)?;
-    println!("[generated] {}", path.display());
+    if !quiet {
+        println!("[generated] {}", path.display());
+    }
     Ok(1)
 }
 

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -257,28 +257,49 @@ fn hash_bytes(bytes: &[u8]) -> Vec<u8> {
 fn find_stale_deployments(abis: &[ContractAbi], out_dir: &Path) -> Vec<String> {
     let deployments_path = out_dir.join("deployments.json");
     let Ok(raw) = std::fs::read_to_string(&deployments_path) else {
-        return vec![]; // no deployments yet — nothing to compare
+        return vec![]; // no deployments file — nothing to compare
     };
     let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
         return vec![];
     };
+    stale_contract_names(abis, &json)
+}
 
-    let deployed = json["contracts"].as_object();
+/// Contracts that were previously deployed under a *different* on-chain name
+/// (e.g. version bump `counter` → `counter-v2`). Undeployed / empty deployments
+/// are not stale — they just have not been deployed yet.
+fn stale_contract_names(abis: &[ContractAbi], json: &serde_json::Value) -> Vec<String> {
+    let network = json["network"].as_str().unwrap_or("").trim();
+    let Some(deployed) = json["contracts"].as_object() else {
+        return vec![];
+    };
+    // Fresh scaffold / post-clean: not "out of sync".
+    if network.is_empty() || deployed.is_empty() {
+        return vec![];
+    }
 
     abis.iter()
-        .filter(|abi| {
-            match deployed.and_then(|d| d.get(&abi.contract_name)) {
-                None => true, // never deployed
-                Some(entry) => {
-                    let deployed_id = entry["contract_id"].as_str().unwrap_or("");
-                    // If the deployed name doesn't end with the current contract name,
-                    // the contract has been renamed (versioned) and needs redeployment
-                    !deployed_id.ends_with(&format!(".{}", abi.contract_name))
-                }
+        .filter_map(|abi| {
+            let entry = deployed.get(&abi.contract_name)?;
+            let deployed_id = entry["contract_id"].as_str().unwrap_or("").trim();
+            if deployed_id.is_empty() {
+                return None;
+            }
+            if deployment_id_matches(deployed_id, &abi.contract_name) {
+                None
+            } else {
+                Some(abi.contract_name.clone())
             }
         })
-        .map(|abi| abi.contract_name.clone())
         .collect()
+}
+
+/// `ST….counter` or bare `counter` matches local name `counter`.
+fn deployment_id_matches(deployed_id: &str, contract_name: &str) -> bool {
+    match deployed_id.rsplit_once('.') {
+        Some((_, name)) => name == contract_name,
+        None => deployed_id == contract_name,
+    }
 }
 
 /// Write file only if content changed. Returns 1 if written, 0 if skipped.
@@ -307,15 +328,105 @@ fn warn_redeploy_required(stale: &[String], network: &str) {
     eprintln!("\n{}", "━".repeat(60));
     eprintln!("  ⚠  REDEPLOYMENT REQUIRED");
     eprintln!("{}", "━".repeat(60));
-    eprintln!("  Contracts on-chain are out of sync with local source:");
+    eprintln!("  On-chain contract ids no longer match local names:");
     eprintln!("  {}", names);
     eprintln!();
-    eprintln!("  Clarity contracts are immutable. Your changes won't take");
-    eprintln!("  effect until you redeploy:");
+    eprintln!("  Clarity contracts are immutable. Redeploy so bindings");
+    eprintln!("  point at the current contract ids:");
     eprintln!();
     eprintln!("    stacksdapp deploy --network {network}");
     eprintln!("    where network is either devnet/testnet/mainnet");
     eprintln!();
-    eprintln!("  Until then, calls to new/changed functions will fail.");
+    eprintln!("  Until then, calls to renamed/versioned contracts will fail.");
     eprintln!("{}\n", "━".repeat(60));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stacksdapp_parser::ContractAbi;
+
+    fn abi(name: &str) -> ContractAbi {
+        ContractAbi {
+            contract_id: format!(".{}", name),
+            contract_name: name.to_string(),
+            functions: vec![],
+            variables: vec![],
+            maps: vec![],
+            fungible_tokens: vec![],
+            non_fungible_tokens: vec![],
+        }
+    }
+
+    #[test]
+    fn empty_deployments_are_not_stale() {
+        let json = serde_json::json!({
+            "network": "",
+            "deployed_at": "",
+            "contracts": {}
+        });
+        let stale = stale_contract_names(&[abi("counter")], &json);
+        assert!(stale.is_empty(), "fresh project must not warn: {stale:?}");
+    }
+
+    #[test]
+    fn matching_deployment_is_not_stale() {
+        let json = serde_json::json!({
+            "network": "devnet",
+            "deployed_at": "2026-01-01T00:00:00Z",
+            "contracts": {
+                "counter": {
+                    "contract_id": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.counter",
+                    "tx_id": "0xabc",
+                    "block_height": 1
+                }
+            }
+        });
+        let stale = stale_contract_names(&[abi("counter")], &json);
+        assert!(stale.is_empty(), "in-sync deploy must not warn: {stale:?}");
+    }
+
+    #[test]
+    fn renamed_deployment_is_stale() {
+        let json = serde_json::json!({
+            "network": "devnet",
+            "deployed_at": "2026-01-01T00:00:00Z",
+            "contracts": {
+                "counter": {
+                    "contract_id": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.counter-v2",
+                    "tx_id": "0xabc",
+                    "block_height": 1
+                }
+            }
+        });
+        let stale = stale_contract_names(&[abi("counter")], &json);
+        assert_eq!(stale, vec!["counter".to_string()]);
+    }
+
+    #[test]
+    fn undeployed_sibling_is_not_stale() {
+        // New local contract while others are deployed — not a rename mismatch.
+        let json = serde_json::json!({
+            "network": "devnet",
+            "contracts": {
+                "counter": {
+                    "contract_id": "ST1.counter",
+                    "tx_id": "0x1",
+                    "block_height": 1
+                }
+            }
+        });
+        let stale = stale_contract_names(&[abi("counter"), abi("hello-token")], &json);
+        assert!(
+            stale.is_empty(),
+            "missing entry is undeployed, not stale: {stale:?}"
+        );
+    }
+
+    #[test]
+    fn deployment_id_match_is_exact_suffix() {
+        assert!(deployment_id_matches("ST1.counter", "counter"));
+        assert!(!deployment_id_matches("ST1.my-counter", "counter"));
+        assert!(deployment_id_matches("counter", "counter"));
+    }
 }

--- a/crates/deployer/Cargo.toml
+++ b/crates/deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-deployer"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "A specialized deployment utility for broadcasting Clarity smart contracts to Stacks devnet, testnet, and mainnet."
 license     = "MIT"

--- a/crates/deployer/Cargo.toml
+++ b/crates/deployer/Cargo.toml
@@ -20,3 +20,4 @@ serde_yaml = "0.9"
 bip39 = "2"
 bitcoin = "0.32"
 tempfile.workspace = true
+colored.workspace = true

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -14,6 +14,9 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
+mod ui;
+use ui::DeployUi;
+
 pub struct NetworkConfig {
     pub stacks_node: String,
 }
@@ -117,63 +120,84 @@ pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: b
     }
 
     let config = network_config(network)?;
-    println!("🚀 Deploying to {} ({})", network, config.stacks_node);
-    if let Some(name) = contract {
-        println!("[deploy] Contract filter enabled: {name}");
-    }
-    if dry_run {
-        println!("[deploy] Dry run enabled: plan will not be applied.");
-    }
-    if yes {
-        println!("[deploy] --yes: skipping interactive confirmation prompts.");
-    }
+    let ui = DeployUi::start(network, &config.stacks_node);
 
     if network == "devnet" {
         wait_for_node(&config.stacks_node).await?;
     }
 
-    deploy_via_clarinet(network, contract, dry_run, yes).await
+    deploy_via_clarinet(&ui, network, contract, dry_run, yes).await
 }
 
 // ── Core deploy ───────────────────────────────────────────────────────────────
 
 async fn deploy_via_clarinet(
+    ui: &DeployUi,
     network: &str,
     contract: Option<&str>,
     dry_run: bool,
     yes: bool,
 ) -> Result<()> {
     let fee_flag = "--low-cost";
-
     let contracts_dir = std::path::Path::new("contracts");
-    let ordered = resolve_deployment_order(contracts_dir).await?;
+
+    let step = ui.begin_step("Analyzing project");
+    let ordered = match resolve_deployment_order(contracts_dir).await {
+        Ok(o) => o,
+        Err(e) => {
+            step.fail();
+            return Err(e);
+        }
+    };
     if let Some(name) = contract {
-        ensure_contract_exists(&ordered, name)?;
+        if let Err(e) = ensure_contract_exists(&ordered, name) {
+            step.fail();
+            return Err(e);
+        }
     }
-    reorder_clarinet_toml(contracts_dir, &ordered).await?;
+    step.finish();
+
+    let step = ui.begin_step("Resolving contract dependencies");
+    if let Err(e) = reorder_clarinet_toml(contracts_dir, &ordered).await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
 
     if network == "testnet" || network == "mainnet" {
-        println!(
-            "[deploy] Checking for contract name conflicts on {}...",
-            network
-        );
-        auto_version_conflicting_contracts(network, contract).await?;
+        let step = ui.begin_step("Checking existing contracts...");
+        let renames = match auto_version_conflicting_contracts(network, contract).await {
+            Ok(r) => r,
+            Err(e) => {
+                step.fail();
+                return Err(e);
+            }
+        };
+        step.finish();
+        for (old, new) in &renames {
+            ui.step_detail(&format!("{old} already exists"));
+            ui.step_detail(&format!("renamed → {new}"));
+        }
+        if renames.is_empty() {
+            ui.step_detail("no conflicts");
+        }
     }
 
-    let clarinet_output = run_generate_and_apply(network, fee_flag, contract, dry_run, yes).await?;
+    let clarinet_output =
+        run_generate_and_apply(ui, network, fee_flag, contract, dry_run, yes).await?;
 
     if dry_run {
         return Ok(());
     }
     if clarinet_output.contains("ContractAlreadyExists") {
-        println!("[deploy] Unexpected conflict after versioning — re-resolving and retrying...");
-        auto_version_conflicting_contracts(network, contract).await?;
+        ui.step_detail("Conflict after versioning — retrying...");
+        let _ = auto_version_conflicting_contracts(network, contract).await?;
         let clarinet_output2 =
-            run_generate_and_apply(network, fee_flag, contract, dry_run, yes).await?;
-        return write_deployments_json_from_output(network, &clarinet_output2, contract).await;
+            run_generate_and_apply(ui, network, fee_flag, contract, dry_run, yes).await?;
+        return write_deployments_json_from_output(ui, network, &clarinet_output2, contract).await;
     }
 
-    write_deployments_json_from_output(network, &clarinet_output, contract).await
+    write_deployments_json_from_output(ui, network, &clarinet_output, contract).await
 }
 
 async fn reorder_clarinet_toml(
@@ -222,12 +246,67 @@ async fn reorder_clarinet_toml(
     }
 
     fs::write(&path, output).await?;
-    println!("[deploy] Clarinet.toml reordered to respect dependency graph.");
     Ok(())
+}
+
+/// Quiet clarinet helper — captures stderr for errors, hides upgrade spam.
+async fn run_clarinet_quiet(args: &[&str]) -> Result<()> {
+    let output = Command::new("clarinet")
+        .args(args)
+        .current_dir("contracts")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "clarinet is required. Install: brew install clarinet OR cargo install clarinet"
+            )
+        })?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        // Filter clarinet upgrade nags from the error surface
+        let filtered: String = err
+            .lines()
+            .filter(|l| !l.contains("A new release of clarinet"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(anyhow!(
+            "clarinet {} failed.\n{}",
+            args.join(" "),
+            filtered.trim()
+        ));
+    }
+    Ok(())
+}
+
+async fn run_generate_quiet() -> Result<()> {
+    // Prefer in-tree binary if present; fall back to PATH.
+    let bin = std::env::current_exe().unwrap_or_else(|_| "stacksdapp".into());
+    let status = Command::new(&bin)
+        .args(["-q", "generate"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        _ => {
+            // Fallback: PATH stacksdapp
+            let _ = Command::new("stacksdapp")
+                .args(["-q", "generate"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .await;
+            Ok(())
+        }
+    }
 }
 
 /// Run `clarinet deployments generate` then `apply`, returning stdout.
 async fn run_generate_and_apply(
+    ui: &DeployUi,
     network: &str,
     fee_flag: &str,
     contract: Option<&str>,
@@ -240,53 +319,67 @@ async fn run_generate_and_apply(
         fs::remove_file(&plan_path).await?;
     }
 
-    println!("[deploy] Generating deployment plan...");
-    let gen = Command::new("clarinet")
-        .args(["deployments", "generate", &format!("--{network}"), fee_flag])
-        .current_dir("contracts")
-        .status()
-        .await
-        .map_err(|_| {
-            anyhow!(
-                "clarinet is required. Install: brew install clarinet OR cargo install clarinet"
-            )
-        })?;
-
-    if !gen.success() {
+    let step = ui.begin_step("Generating deployment artifacts");
+    let net_flag = format!("--{network}");
+    if let Err(e) = run_clarinet_quiet(&["deployments", "generate", &net_flag, fee_flag]).await {
+        step.fail();
         return Err(anyhow!(
             "Failed to generate deployment plan.\n\
              • Run `clarinet check` to validate your contracts.\n\
-             • Ensure settings/{}.toml has a valid mnemonic.",
+             • Ensure settings/{}.toml has a valid mnemonic.\n{e}",
             capitalize(network)
         ));
     }
-
     if let Some(contract_name) = contract {
-        filter_plan_to_contract(network, contract_name).await?;
-        println!("[deploy] Filtered deployment plan to contract: {contract_name}");
+        if let Err(e) = filter_plan_to_contract(network, contract_name).await {
+            step.fail();
+            return Err(e);
+        }
     }
+    step.finish();
 
-    let total_micro_stx = check_plan_fee(network)?;
-    let contracts = deployment_contract_names_from_plan(network).await?;
-    println!("[deploy] Plan contracts: {}", contracts.join(", "));
+    let step = ui.begin_step("Exporting TypeScript bindings");
+    let _ = run_generate_quiet().await;
+    step.finish();
+
+    let step = ui.begin_step("Building deployment plan");
+    let total_micro_stx = match check_plan_fee(network) {
+        Ok(v) => v,
+        Err(e) => {
+            step.fail();
+            return Err(e);
+        }
+    };
+    let contracts = match deployment_contract_names_from_plan(network).await {
+        Ok(c) => c,
+        Err(e) => {
+            step.fail();
+            return Err(e);
+        }
+    };
+    step.finish();
 
     if dry_run {
-        println!(
-            "[deploy] Dry run complete. No transactions were broadcast.\n\
-             [deploy] Re-run without --dry-run to apply this plan."
-        );
+        ui.dry_run_done(&contracts, total_micro_stx);
         return Ok(String::new());
     }
 
     if network == "devnet" {
-        return run_apply_devnet_direct(network).await;
+        return run_apply_devnet_direct(ui, network).await;
     }
 
-    // testnet / mainnet: require opt-in before auto-answering Clarinet fee prompts
     let deployer = get_deployer_from_plan(network).await?;
-    ensure_remote_deploy_consent(network, &deployer, &contracts, total_micro_stx, yes)?;
+    ui.print_summary(&deployer, &contracts, total_micro_stx);
 
-    println!("[deploy] Applying deployment plan to {}...", network);
+    if !ui.confirm_continue(yes)? {
+        return Err(anyhow!(
+            "{} deployment aborted by user.",
+            capitalize(network)
+        ));
+    }
+
+    ui.broadcasting_start();
+
     let mut child = Command::new("clarinet")
         .args([
             "deployments",
@@ -297,7 +390,7 @@ async fn run_generate_and_apply(
         .current_dir("contracts")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::null())
         .spawn()?;
 
     let mut stdin = child
@@ -309,28 +402,27 @@ async fn run_generate_and_apply(
         .take()
         .ok_or_else(|| anyhow!("Failed to open stdout"))?;
 
-    let expected_count = deployment_contract_names_from_plan(network).await?.len();
-
-    let mut confirmed_count = 0;
-    let mut broadcast_count = 0;
-
+    let expected_count = contracts.len().max(1);
+    let mut confirmed_count = 0usize;
+    let mut broadcast_count = 0usize;
     let mut reader = tokio::io::BufReader::new(stdout).lines();
     let mut captured_stdout = String::new();
+    let mut last_txid_by_name: HashMap<String, String> = HashMap::new();
+
+    ui.render_bar(0, expected_count);
 
     while let Ok(Some(line)) = reader.next_line().await {
-        println!("{}", line);
         captured_stdout.push_str(&line);
         captured_stdout.push('\n');
 
         if line.contains("REDEPLOYMENT REQUIRED") || line.contains("out of sync") {
-            println!("[deploy] Error: Devnet is out of sync. You may need to restart Clarinet or increment contract version.");
             let _ = child.kill().await;
             return Err(anyhow!(
                 "Devnet redeployment required. Check your contract versions."
             ));
         }
 
-        // Consent already obtained (--yes or interactive). Auto-answer Clarinet prompts.
+        // Auto-answer Clarinet prompts silently (consent already obtained).
         if line.contains("Overwrite?") {
             let answer = if contract.is_some() { b"n\n" } else { b"y\n" };
             let _ = stdin.write_all(answer).await;
@@ -342,39 +434,46 @@ async fn run_generate_and_apply(
             let _ = stdin.write_all(b"y\n").await;
             let _ = stdin.flush().await;
         }
+
         if line.contains("Broadcasted") && line.contains("ContractPublish(") {
             broadcast_count += 1;
-            println!(
-                "[deploy] Broadcast progress: {}/{}",
-                broadcast_count, expected_count
-            );
+            if let Some((name, txid)) = parse_broadcast_line(&line) {
+                last_txid_by_name.insert(name, txid);
+            }
+            ui.render_bar(broadcast_count, expected_count);
         }
 
         if line.contains("Confirmed Publish") || line.contains("Published") {
             confirmed_count += 1;
-            println!(
-                "[deploy] Confirmation progress: {}/{}",
-                confirmed_count, expected_count
-            );
         }
 
-        if confirmed_count >= expected_count {
-            println!("[deploy] All contracts confirmed. Finalizing JSON...");
-            let _ = child.kill().await; // Clarinet can linger after local confirmations
-            break;
-        }
-
-        if broadcast_count >= expected_count {
-            println!("[deploy] All contracts broadcasted. Finalizing JSON...");
-            let _ = child.kill().await; // Don't block on extra Clarinet output after broadcast
+        if confirmed_count >= expected_count || broadcast_count >= expected_count {
+            let _ = child.kill().await;
             break;
         }
     }
+
+    // Finalize bar once if we somehow exited without hitting 100%.
+    if broadcast_count > 0 && broadcast_count < expected_count {
+        ui.render_bar(expected_count, expected_count);
+    } else if broadcast_count >= expected_count {
+        // Already finalized inside render_bar when done == total.
+    } else {
+        ui.render_bar(expected_count, expected_count);
+    }
+
+    // Stable order matching the deployment plan.
+    for name in &contracts {
+        if let Some(txid) = last_txid_by_name.get(name) {
+            ui.contract_broadcast_ok(name, txid);
+        }
+    }
+
     Ok(captured_stdout)
 }
 
-async fn run_apply_devnet_direct(network: &str) -> Result<String> {
-    println!("[deploy] Applying deployment plan to devnet...");
+async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String> {
+    ui.step_ok("Preparing direct devnet broadcast");
     let plan = read_deployment_plan(network).await?;
     let transactions = flatten_contract_publishes(&plan);
     if transactions.is_empty() {
@@ -398,9 +497,11 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
     let script_path = write_devnet_broadcast_script()?;
     let mut captured_stdout = String::new();
 
-    println!("[deploy] Broadcasting transactions to http://localhost:20443");
+    ui.broadcasting_start();
+    let expected = transactions.len().max(1);
+    ui.render_bar(0, expected);
 
-    for tx in transactions {
+    for (i, tx) in transactions.into_iter().enumerate() {
         let contract_name = tx
             .contract_name
             .clone()
@@ -471,18 +572,14 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
                 )
             })?;
 
-        println!(
-            "🟦  Publish {}.{}  Transaction broadcast {}",
-            expected_sender,
-            tx.contract_name.as_deref().unwrap_or(""),
-            txid
-        );
         captured_stdout.push_str(&format!(
             "Broadcasted ContractPublish(StandardPrincipalData({}), ContractName(\"{}\"), \"{}\")\n",
             expected_sender,
             tx.contract_name.as_deref().unwrap_or(""),
             txid,
         ));
+        ui.render_bar(i + 1, expected);
+        ui.contract_broadcast_ok(tx.contract_name.as_deref().unwrap_or(""), txid);
         nonce += 1;
     }
 
@@ -624,14 +721,13 @@ pub async fn resolve_deployment_order(
         let deps = parse_local_deps(&source, &known);
 
         if !deps.is_empty() {
-            println!("[deploy] {name} depends on: {}", deps.join(", "));
+            // Dependency details are intentionally quiet — shown at summary level.
         }
 
         dep_graph.insert(name.clone(), deps);
     }
 
     let order = topological_sort(&dep_graph)?;
-    println!("[deploy] Deployment order: {}", order.join(" → "));
 
     Ok(order)
 }
@@ -653,17 +749,14 @@ fn check_plan_fee(network: &str) -> Result<u64> {
             }
         })
         .sum();
-    if total_micro_stx > 0 {
-        println!(
-            "[deploy] Estimated fee: {:.6} STX",
-            total_micro_stx as f64 / 1_000_000.0
-        );
-    }
 
     Ok(total_micro_stx)
 }
 
-async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str>) -> Result<()> {
+async fn auto_version_conflicting_contracts(
+    network: &str,
+    contract: Option<&str>,
+) -> Result<Vec<(String, String)>> {
     let config = network_config(network)?;
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
@@ -674,19 +767,10 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
         let _ = fs::remove_file(&plan_path).await;
     }
 
-    let _ = Command::new("clarinet")
-        .args([
-            "deployments",
-            "generate",
-            &format!("--{}", network),
-            "--low-cost",
-        ])
-        .current_dir("contracts")
-        .status()
-        .await;
+    let net_flag = format!("--{network}");
+    run_clarinet_quiet(&["deployments", "generate", &net_flag, "--low-cost"]).await?;
 
     let deployer = get_deployer_from_plan(network).await?;
-    println!("[deploy] Using derived deployer address: {}", deployer);
 
     let base_dir = Path::new("contracts");
     let clarinet_path = base_dir.join("Clarinet.toml");
@@ -696,7 +780,7 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
     let clarinet_struct: ClarinetToml = toml::from_str(&clarinet_raw)?;
     let contracts = clarinet_struct.contracts.unwrap_or_default();
 
-    let mut any_changes = false;
+    let mut renames: Vec<(String, String)> = Vec::new();
 
     for (current_name, entry) in &contracts {
         if contract.is_some() && contract != Some(current_name.as_str()) {
@@ -712,18 +796,12 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
             continue;
         }
 
-        println!(
-            "[deploy] Conflict detected: '{}' already exists on-chain. Renaming to '{}'",
-            current_name, correct_name
-        );
-
         let old_file_path = base_dir.join(&entry.path);
         let new_rel_path = format!("contracts/{}.clar", correct_name);
         let new_file_path = base_dir.join(&new_rel_path);
 
         if old_file_path.exists() {
             fs::rename(&old_file_path, &new_file_path).await?;
-            println!("[deploy] Renamed file: {} -> {}", entry.path, new_rel_path);
         }
 
         let old_header = format!("[contracts.{}]", current_name);
@@ -751,18 +829,14 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
                 if source.contains(&dot_old_name) {
                     let updated_source = source.replace(&dot_old_name, &dot_new_name);
                     fs::write(target_file, updated_source).await?;
-                    println!(
-                        "[deploy] Updated internal reference in {}",
-                        target_file.display()
-                    );
                 }
             }
         }
 
-        any_changes = true;
+        renames.push((current_name.clone(), correct_name));
     }
 
-    if any_changes {
+    if !renames.is_empty() {
         fs::write(&clarinet_path, &clarinet_content).await?;
 
         for plan_name in [
@@ -775,12 +849,11 @@ async fn auto_version_conflicting_contracts(network: &str, contract: Option<&str
             let _ = fs::remove_file(plan_path).await;
         }
 
-        println!("[deploy] Clarinet.toml updated with new versions.");
-        // Regenerate bindings so the frontend/tests use the new names
-        let _ = Command::new("stacksdapp").arg("generate").status().await;
+        // Regenerate bindings so the frontend/tests use the new names (quiet).
+        let _ = run_generate_quiet().await;
     }
 
-    Ok(())
+    Ok(renames)
 }
 
 /// Helper to parse the address Clarinet derived in the plan file
@@ -921,7 +994,6 @@ async fn wait_for_node(url: &str) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
         .build()?;
-    println!("[deploy] Waiting for Stacks node at {url}...");
     for attempt in 1..=60 {
         if client
             .get(&format!("{url}/v2/info"))
@@ -930,11 +1002,10 @@ async fn wait_for_node(url: &str) -> Result<()> {
             .map(|r| r.status().is_success())
             .unwrap_or(false)
         {
-            println!("[deploy] ✔ Node is ready");
             return Ok(());
         }
         if attempt % 10 == 0 {
-            println!("[deploy] Still waiting... ({attempt}s)");
+            // Quiet wait — only fail after timeout.
         }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
@@ -944,7 +1015,23 @@ async fn wait_for_node(url: &str) -> Result<()> {
     ))
 }
 
+fn parse_broadcast_line(line: &str) -> Option<(String, String)> {
+    let cn_marker = "ContractName(\"";
+    let name = {
+        let pos = line.find(cn_marker)?;
+        let rest = &line[pos + cn_marker.len()..];
+        let end = rest.find('"')?;
+        rest[..end].to_string()
+    };
+    let txid = line
+        .split('"')
+        .find(|part| part.len() == 64 && part.chars().all(|c| c.is_ascii_hexdigit()))?
+        .to_string();
+    Some((name, txid))
+}
+
 async fn write_deployments_json_from_output(
+    ui: &DeployUi,
     network: &str,
     output: &str,
     contract: Option<&str>,
@@ -953,7 +1040,6 @@ async fn write_deployments_json_from_output(
     let mut actual_deployer = None;
     for line in output.lines() {
         if line.contains("Broadcasted") {
-            // Extract Deployer Address: Look for StandardPrincipalData(ADDRESS)
             if let Some(start) = line.find("StandardPrincipalData(") {
                 let rest = &line[start + "StandardPrincipalData(".len()..];
                 if let Some(end) = rest.find(')') {
@@ -961,22 +1047,8 @@ async fn write_deployments_json_from_output(
                 }
             }
 
-            // Extract Contract Name: Look for ContractName("NAME")
-            let cn_marker = "ContractName(\"";
-            if let Some(pos) = line.find(cn_marker) {
-                let rest = &line[pos + cn_marker.len()..];
-                if let Some(end) = rest.find('"') {
-                    let contract_name = rest[..end].to_string();
-
-                    // Extract TXID: It's the 64-char hex string inside quotes at the end
-                    // Format: ...), "TXID") Publish ...
-                    let parts: Vec<&str> = line.split('"').collect();
-                    for part in parts {
-                        if part.len() == 64 && part.chars().all(|c| c.is_ascii_hexdigit()) {
-                            txid_map.insert(contract_name.clone(), part.to_string());
-                        }
-                    }
-                }
+            if let Some((contract_name, txid)) = parse_broadcast_line(line) {
+                txid_map.insert(contract_name, txid);
             }
         }
     }
@@ -1000,6 +1072,7 @@ async fn write_deployments_json_from_output(
     }
 
     if network == "devnet" {
+        ui.waiting_confirmation();
         wait_for_devnet_contracts(&deployer_address, &contract_names).await?;
     }
 
@@ -1010,16 +1083,21 @@ async fn write_deployments_json_from_output(
     };
     let timestamp = chrono::Utc::now().to_rfc3339();
 
-    for name in contract_names {
+    let mut success_entries: Vec<(String, String, String)> = Vec::new();
+
+    for name in &contract_names {
         let contract_id = format!("{deployer_address}.{name}");
         let txid = txid_map
-            .get(&name)
-            .map(|t| format!("0x{t}"))
+            .get(name)
+            .map(|t| {
+                if t.starts_with("0x") {
+                    t.clone()
+                } else {
+                    format!("0x{t}")
+                }
+            })
             .unwrap_or_default();
-        println!(
-            "  ✔ {name} | txid {} | address {contract_id}",
-            if txid.is_empty() { "(pending)" } else { &txid }
-        );
+        success_entries.push((name.clone(), contract_id.clone(), txid.clone()));
         contracts_map.insert(
             name.clone(),
             DeploymentInfo {
@@ -1041,7 +1119,11 @@ async fn write_deployments_json_from_output(
         fs::create_dir_all(p).await?;
     }
     fs::write(out_path, &json).await?;
-    println!("\n[deploy] Written to {}", out_path.display());
+
+    // Ensure bindings are fresh after rename (quiet).
+    let _ = run_generate_quiet().await;
+
+    ui.success(&success_entries);
     Ok(())
 }
 
@@ -1165,7 +1247,7 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
     let node = "http://localhost:20443";
     let initial_info = fetch_local_core_info().await.ok();
 
-    println!("[deploy] Verifying contract publish on local devnet core node...");
+    // Quietly wait for local core to expose published contracts.
     for attempt in 1..=30 {
         let mut pending = Vec::new();
 
@@ -1184,17 +1266,10 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
         }
 
         if pending.is_empty() {
-            println!("[deploy] ✔ Local devnet core node reports all contracts deployed");
             return Ok(());
         }
 
-        if attempt == 1 || attempt % 5 == 0 {
-            println!(
-                "[deploy] Waiting for devnet core to expose: {}",
-                pending.join(", ")
-            );
-        }
-
+        let _ = attempt;
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 
@@ -1360,7 +1435,8 @@ fn capitalize(s: &str) -> String {
 }
 
 /// Require opt-in before broadcasting on testnet/mainnet.
-/// `--yes` skips the interactive prompt (for CI / automation).
+/// Prefer [`DeployUi::confirm_continue`] for interactive flow.
+#[allow(dead_code)]
 fn ensure_remote_deploy_consent(
     network: &str,
     deployer: &str,
@@ -1389,6 +1465,7 @@ fn ensure_remote_deploy_consent(
     confirm_remote_deploy(network, deployer, contracts, total_micro_stx)
 }
 
+#[allow(dead_code)]
 fn confirm_remote_deploy(
     network: &str,
     deployer: &str,

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -105,7 +105,7 @@ pub async fn wait_for_devnet_node() -> Result<()> {
     wait_for_node("http://localhost:3999").await
 }
 
-pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool) -> Result<()> {
+pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: bool) -> Result<()> {
     if !Path::new("contracts/Clarinet.toml").exists() {
         return Err(anyhow!(
             "No scaffold-stacks project found. Run from the directory created by stacksdapp new"
@@ -124,17 +124,25 @@ pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool) -> Res
     if dry_run {
         println!("[deploy] Dry run enabled: plan will not be applied.");
     }
+    if yes {
+        println!("[deploy] --yes: skipping interactive confirmation prompts.");
+    }
 
     if network == "devnet" {
         wait_for_node(&config.stacks_node).await?;
     }
 
-    deploy_via_clarinet(network, contract, dry_run).await
+    deploy_via_clarinet(network, contract, dry_run, yes).await
 }
 
 // ── Core deploy ───────────────────────────────────────────────────────────────
 
-async fn deploy_via_clarinet(network: &str, contract: Option<&str>, dry_run: bool) -> Result<()> {
+async fn deploy_via_clarinet(
+    network: &str,
+    contract: Option<&str>,
+    dry_run: bool,
+    yes: bool,
+) -> Result<()> {
     let fee_flag = "--low-cost";
 
     let contracts_dir = std::path::Path::new("contracts");
@@ -152,7 +160,7 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>, dry_run: boo
         auto_version_conflicting_contracts(network, contract).await?;
     }
 
-    let clarinet_output = run_generate_and_apply(network, fee_flag, contract, dry_run).await?;
+    let clarinet_output = run_generate_and_apply(network, fee_flag, contract, dry_run, yes).await?;
 
     if dry_run {
         return Ok(());
@@ -160,7 +168,8 @@ async fn deploy_via_clarinet(network: &str, contract: Option<&str>, dry_run: boo
     if clarinet_output.contains("ContractAlreadyExists") {
         println!("[deploy] Unexpected conflict after versioning — re-resolving and retrying...");
         auto_version_conflicting_contracts(network, contract).await?;
-        let clarinet_output2 = run_generate_and_apply(network, fee_flag, contract, dry_run).await?;
+        let clarinet_output2 =
+            run_generate_and_apply(network, fee_flag, contract, dry_run, yes).await?;
         return write_deployments_json_from_output(network, &clarinet_output2, contract).await;
     }
 
@@ -223,6 +232,7 @@ async fn run_generate_and_apply(
     fee_flag: &str,
     contract: Option<&str>,
     dry_run: bool,
+    yes: bool,
 ) -> Result<String> {
     // Delete stale plan so clarinet never prompts "Overwrite? [Y/n]"
     let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
@@ -271,10 +281,10 @@ async fn run_generate_and_apply(
     if network == "devnet" {
         return run_apply_devnet_direct(network).await;
     }
-    if network == "mainnet" {
-        let deployer = get_deployer_from_plan(network).await?;
-        confirm_mainnet_deploy(&deployer, &contracts, total_micro_stx)?;
-    }
+
+    // testnet / mainnet: require opt-in before auto-answering Clarinet fee prompts
+    let deployer = get_deployer_from_plan(network).await?;
+    ensure_remote_deploy_consent(network, &deployer, &contracts, total_micro_stx, yes)?;
 
     println!("[deploy] Applying deployment plan to {}...", network);
     let mut child = Command::new("clarinet")
@@ -320,15 +330,15 @@ async fn run_generate_and_apply(
             ));
         }
 
-        // Handle interactive fee prompts
+        // Consent already obtained (--yes or interactive). Auto-answer Clarinet prompts.
         if line.contains("Overwrite?") {
             let answer = if contract.is_some() { b"n\n" } else { b"y\n" };
             let _ = stdin.write_all(answer).await;
             let _ = stdin.flush().await;
-        } else if line.contains("Confirm?") || line.contains("Continue [Y/n]?") {
-            let _ = stdin.write_all(b"y\n").await;
-            let _ = stdin.flush().await;
-        } else if line.contains("[Y/n]") {
+        } else if line.contains("Confirm?")
+            || line.contains("Continue [Y/n]?")
+            || line.contains("[Y/n]")
+        {
             let _ = stdin.write_all(b"y\n").await;
             let _ = stdin.flush().await;
         }
@@ -399,6 +409,8 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
             anyhow!("Missing contract path for {contract_name} in deployment plan.")
         })?;
         let fee = tx.cost.unwrap_or(0);
+        // Non-secret metadata only on the wire via stdin
+        // (visible in `ps`). The Node bridge reads one JSON object from stdin.
         let args = serde_json::json!({
             "contractName": contract_name,
             "codePath": contract_path,
@@ -408,13 +420,28 @@ async fn run_apply_devnet_direct(network: &str) -> Result<String> {
             "clarityVersion": tx.clarity_version,
         });
 
-        let output = Command::new("node")
+        let mut child = Command::new("node")
             .arg(&script_path)
-            .arg(args.to_string())
             .current_dir("contracts")
-            .output()
-            .await
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
             .map_err(|_| anyhow!("node is required to deploy directly to devnet"))?;
+
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| anyhow!("Failed to open node stdin for devnet broadcast"))?;
+            stdin.write_all(args.to_string().as_bytes()).await?;
+            // Closing stdin signals EOF so the Node script can finish reading.
+        }
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| anyhow!("Failed waiting for node broadcast process: {e}"))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -483,7 +510,15 @@ fn flatten_contract_publishes(plan: &DeploymentPlanFile) -> Vec<DeploymentTransa
 
 fn write_devnet_broadcast_script() -> Result<std::path::PathBuf> {
     let mut file = NamedTempFile::new()?;
-    let script = r#"
+    use std::io::Write;
+    file.write_all(DEVNET_BROADCAST_SCRIPT.as_bytes())?;
+    let (_, path) = file.keep()?;
+    Ok(path)
+}
+
+/// Node bridge for direct devnet publishes. Payload (including senderKey) is read
+/// from stdin — never from argv — so keys do not appear in `ps`.
+const DEVNET_BROADCAST_SCRIPT: &str = r#"
 import fs from 'fs';
 import { createRequire } from 'module';
 
@@ -495,7 +530,12 @@ const {
   broadcastRawTransaction,
 } = require('@stacks/transactions');
 
-const input = JSON.parse(process.argv[2]);
+// Read deploy payload from stdin so the private key never appears in process argv.
+const chunks = [];
+for await (const chunk of process.stdin) {
+  chunks.push(chunk);
+}
+const input = JSON.parse(Buffer.concat(chunks).toString('utf8'));
 const codeBody = fs.readFileSync(input.codePath, 'utf8');
 
 const transaction = await makeContractDeploy({
@@ -520,11 +560,6 @@ if (!response?.txid) {
   process.exit(1);
 }
 "#;
-    use std::io::Write;
-    file.write_all(script.as_bytes())?;
-    let (_, path) = file.keep()?;
-    Ok(path)
-}
 
 async fn fetch_local_core_nonce(address: &str) -> Result<u64> {
     let client = reqwest::Client::builder()
@@ -1324,15 +1359,51 @@ fn capitalize(s: &str) -> String {
     }
 }
 
-fn confirm_mainnet_deploy(
+/// Require opt-in before broadcasting on testnet/mainnet.
+/// `--yes` skips the interactive prompt (for CI / automation).
+fn ensure_remote_deploy_consent(
+    network: &str,
+    deployer: &str,
+    contracts: &[String],
+    total_micro_stx: u64,
+    yes: bool,
+) -> Result<()> {
+    use std::io::IsTerminal;
+
+    if yes {
+        if network == "mainnet" {
+            eprintln!(
+                "[deploy] WARNING: --yes skips mainnet confirmation. Broadcasting with real funds."
+            );
+        }
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(anyhow!(
+            "Refusing to deploy to {network} without confirmation in a non-interactive terminal.\n\
+             Re-run with: stacksdapp deploy --network {network} --yes"
+        ));
+    }
+
+    confirm_remote_deploy(network, deployer, contracts, total_micro_stx)
+}
+
+fn confirm_remote_deploy(
+    network: &str,
     deployer: &str,
     contracts: &[String],
     total_micro_stx: u64,
 ) -> Result<()> {
     use std::io::{self, Write};
 
-    println!("\n⚠️  Mainnet deployment confirmation required");
-    println!("  Network: mainnet");
+    let is_mainnet = network == "mainnet";
+    if is_mainnet {
+        println!("\n⚠️  Mainnet deployment confirmation required");
+    } else {
+        println!("\n⚠️  {network} deployment confirmation required");
+    }
+    println!("  Network: {network}");
     println!("  Deployer: {deployer}");
     println!(
         "  Estimated fee: {:.6} STX",
@@ -1343,13 +1414,20 @@ fn confirm_mainnet_deploy(
         contracts.len(),
         contracts.join(", ")
     );
-    print!("\nType 'y' to continue with MAINNET broadcast: ");
+    if is_mainnet {
+        print!("\nType 'y' to continue with MAINNET broadcast: ");
+    } else {
+        print!("\nType 'y' to continue with {network} broadcast (or pass --yes to skip): ");
+    }
     io::stdout().flush()?;
 
     let mut input = String::new();
     io::stdin().read_line(&mut input)?;
     if input.trim() != "y" {
-        return Err(anyhow!("Mainnet deployment aborted by user."));
+        return Err(anyhow!(
+            "{} deployment aborted by user.",
+            capitalize(network)
+        ));
     }
 
     Ok(())
@@ -1397,6 +1475,18 @@ mod tests {
             err.to_string()
                 .contains("Circular contract dependency detected"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn devnet_broadcast_script_reads_payload_from_stdin_not_argv() {
+        assert!(
+            !super::DEVNET_BROADCAST_SCRIPT.contains("process.argv"),
+            "sender key must not be passed via argv"
+        );
+        assert!(
+            super::DEVNET_BROADCAST_SCRIPT.contains("process.stdin"),
+            "deploy payload must be read from stdin"
         );
     }
 }

--- a/crates/deployer/src/ui.rs
+++ b/crates/deployer/src/ui.rs
@@ -1,0 +1,377 @@
+//! Clean Foundry-style deploy terminal UI.
+
+use colored::Colorize;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+pub struct DeployUi {
+    start: Instant,
+    network: String,
+    rpc: String,
+    project: String,
+    bar_finalized: AtomicBool,
+}
+
+/// In-place spinner that occupies the checkmark column until [`LiveStep::finish`].
+pub struct LiveStep {
+    label: String,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    finished: bool,
+}
+
+impl LiveStep {
+    pub fn finish(mut self) {
+        self.complete(true);
+    }
+
+    pub fn fail(mut self) {
+        self.complete(false);
+    }
+
+    fn complete(&mut self, ok: bool) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        // Clear spinner line, then print final status.
+        print!("\r\x1b[2K");
+        if ok {
+            println!(
+                "{} {}",
+                "✓".truecolor(52, 211, 153).bold(),
+                self.label.white()
+            );
+        } else {
+            println!(
+                "{} {}",
+                "✗".truecolor(239, 68, 68).bold(),
+                self.label.white()
+            );
+        }
+        let _ = io::stdout().flush();
+    }
+}
+
+impl Drop for LiveStep {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.complete(false);
+        }
+    }
+}
+
+impl DeployUi {
+    pub fn start(network: &str, rpc: &str) -> Self {
+        let project = std::env::current_dir()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| ".".into());
+
+        let title = match network {
+            "mainnet" => "Deploying to Stacks Mainnet 🚀",
+            "devnet" => "Deploying to Local Devnet 🚀",
+            _ => "Deploying to Stacks Testnet 🚀",
+        };
+
+        println!();
+        println!("{}", "━".repeat(46).truecolor(75, 85, 99));
+        println!("{:^46}", title.bold().white());
+        println!("{}", "━".repeat(46).truecolor(75, 85, 99));
+        println!();
+        kv("Network", network);
+        kv("RPC", rpc);
+        kv("Project", &project);
+        println!();
+
+        Self {
+            start: Instant::now(),
+            network: network.to_string(),
+            rpc: rpc.to_string(),
+            project,
+            bar_finalized: AtomicBool::new(false),
+        }
+    }
+
+    /// Start a live spinner on the current line; call [`LiveStep::finish`] when done.
+    pub fn begin_step(&self, label: &str) -> LiveStep {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_c = Arc::clone(&stop);
+        let label_c = label.to_string();
+
+        // Seed the line immediately so the screen isn't blank.
+        print!(
+            "\r{} {}",
+            SPINNER[0].truecolor(167, 139, 250),
+            label.truecolor(156, 163, 175)
+        );
+        let _ = io::stdout().flush();
+
+        let handle = thread::spawn(move || {
+            let mut i = 0usize;
+            while !stop_c.load(Ordering::Relaxed) {
+                print!(
+                    "\r{} {}",
+                    SPINNER[i % SPINNER.len()].truecolor(167, 139, 250),
+                    label_c.truecolor(156, 163, 175)
+                );
+                let _ = io::stdout().flush();
+                i = i.wrapping_add(1);
+                thread::sleep(Duration::from_millis(80));
+            }
+        });
+
+        LiveStep {
+            label: label.to_string(),
+            stop,
+            handle: Some(handle),
+            finished: false,
+        }
+    }
+
+    pub fn step_ok(&self, label: &str) {
+        println!("{} {}", "✓".truecolor(52, 211, 153).bold(), label.white());
+    }
+
+    pub fn step_detail(&self, text: &str) {
+        println!(
+            "  {} {}",
+            "↳".truecolor(156, 163, 175),
+            text.truecolor(156, 163, 175)
+        );
+    }
+
+    pub fn print_summary(&self, deployer: &str, contracts: &[String], fee_micro: u64) {
+        println!();
+        println!("{}", "─".repeat(46).truecolor(75, 85, 99));
+        println!();
+        println!("{}", "Deployment Summary".bold().white());
+        println!();
+        kv("Deployer", &short_addr(deployer));
+        kv("Contracts", &contracts.len().to_string());
+        if fee_micro > 0 {
+            kv("Fee", &format!("{:.6} STX", fee_micro as f64 / 1_000_000.0));
+        }
+        println!();
+        for name in contracts {
+            println!("  {}", name.truecolor(52, 211, 153));
+        }
+        println!();
+        println!("{}", "─".repeat(46).truecolor(75, 85, 99));
+        println!();
+    }
+
+    pub fn confirm_continue(&self, yes: bool) -> anyhow::Result<bool> {
+        use std::io::IsTerminal;
+
+        if yes {
+            return Ok(true);
+        }
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!(
+                "Refusing to deploy to {} without confirmation in a non-interactive terminal.\n\
+                 Re-run with: stacksdapp deploy --network {} --yes",
+                self.network,
+                self.network
+            );
+        }
+        if self.network == "mainnet" {
+            eprintln!(
+                "{}",
+                "Mainnet broadcast — real funds will be spent."
+                    .yellow()
+                    .bold()
+            );
+        }
+        print!("{} ", "Continue? (Y/n)".bold().white());
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let t = input.trim();
+        if t.is_empty() || t.eq_ignore_ascii_case("y") || t.eq_ignore_ascii_case("yes") {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn broadcasting_start(&self) {
+        self.bar_finalized.store(false, Ordering::SeqCst);
+        println!();
+        println!("{}", "Broadcasting...".bold().white());
+        println!();
+    }
+
+    /// Update the single in-place progress bar. Finalizes (newline) only once at 100%.
+    pub fn render_bar(&self, done: usize, total: usize) {
+        if self.bar_finalized.load(Ordering::SeqCst) {
+            return;
+        }
+        let total = total.max(1);
+        let pct = ((done * 100) / total).min(100);
+        let width = 32usize;
+        let filled = (pct * width) / 100;
+        let bar: String = "█".repeat(filled) + &"░".repeat(width.saturating_sub(filled));
+        print!("\r[{}] {pct}%   ", bar.truecolor(52, 211, 153));
+        let _ = io::stdout().flush();
+        if done >= total {
+            self.bar_finalized.store(true, Ordering::SeqCst);
+            println!();
+            println!();
+        }
+    }
+
+    pub fn contract_broadcast_ok(&self, name: &str, txid: &str) {
+        println!("{} {}", "✓".truecolor(52, 211, 153).bold(), name.white());
+        println!(
+            "  {:<8} {}",
+            "txid".truecolor(156, 163, 175),
+            short_txid(txid).truecolor(156, 163, 175)
+        );
+        println!();
+    }
+
+    pub fn waiting_confirmation(&self) {
+        println!(
+            "{}",
+            "Waiting for node confirmation...".truecolor(156, 163, 175)
+        );
+        println!();
+    }
+
+    pub fn success(
+        &self,
+        entries: &[(String, String, String)], // name, full_contract_id, full_txid
+    ) {
+        println!(
+            "{} {}",
+            "✓".truecolor(52, 211, 153).bold(),
+            "Deployment complete.".white()
+        );
+        println!();
+        println!("{}", "━".repeat(46).truecolor(75, 85, 99));
+        println!("{:^46}", "Success 🎉".bold().truecolor(52, 211, 153));
+        println!("{}", "━".repeat(46).truecolor(75, 85, 99));
+        println!();
+
+        println!("{}", "Contract".bold().white());
+        println!();
+        for (name, id, _) in entries {
+            let _ = name;
+            println!("{}", id.truecolor(52, 211, 153));
+        }
+        println!();
+
+        println!("{}", "Transaction".bold().white());
+        println!();
+        for (_, _, txid) in entries {
+            if txid.is_empty() {
+                println!("{}", "(pending)".truecolor(156, 163, 175));
+            } else {
+                println!("{}", txid.white());
+            }
+        }
+        println!();
+
+        println!("{}", "Generated".bold().white());
+        println!();
+        for f in [
+            "frontend/src/generated/contracts.ts",
+            "frontend/src/generated/hooks.ts",
+            "frontend/src/generated/deployments.json",
+        ] {
+            println!(
+                "{} {}",
+                "✓".truecolor(52, 211, 153),
+                f.truecolor(156, 163, 175)
+            );
+        }
+        println!();
+
+        println!("{}", "Next".bold().white());
+        println!();
+        println!(
+            "{}",
+            format!("stacksdapp dev --network {}", self.network)
+                .truecolor(52, 211, 153)
+                .bold()
+        );
+        println!();
+
+        let chain = match self.network.as_str() {
+            "mainnet" => "mainnet",
+            "devnet" => "devnet",
+            _ => "testnet",
+        };
+        let explorer_urls: Vec<String> = entries
+            .iter()
+            .filter(|(_, _, txid)| !txid.is_empty())
+            .map(|(_, _, txid)| {
+                format!(
+                    "https://explorer.hiro.so/txid/{}?chain={chain}",
+                    txid.trim_start_matches("0x")
+                )
+            })
+            .collect();
+
+        if !explorer_urls.is_empty() {
+            println!("{}", "Explorer".bold().white());
+            println!();
+            for url in explorer_urls {
+                println!("{}", url.truecolor(167, 139, 250));
+            }
+            println!();
+        }
+
+        let secs = self.start.elapsed().as_secs_f64();
+        println!("{} {:.1}s", "Done in".truecolor(156, 163, 175), secs);
+        println!();
+        let _ = (&self.rpc, &self.project);
+    }
+
+    pub fn dry_run_done(&self, contracts: &[String], fee_micro: u64) {
+        println!();
+        println!("{}", "Dry run complete — nothing broadcast.".bold().white());
+        if fee_micro > 0 {
+            println!("Estimated fee: {:.6} STX", fee_micro as f64 / 1_000_000.0);
+        }
+        println!("Contracts: {}", contracts.join(", "));
+        println!(
+            "{}",
+            "Re-run without --dry-run to apply.".truecolor(156, 163, 175)
+        );
+        println!();
+    }
+}
+
+fn kv(key: &str, value: &str) {
+    println!("{:<12} {}", soft_grey(key), value.white());
+}
+
+fn soft_grey(s: &str) -> colored::ColoredString {
+    s.truecolor(156, 163, 175)
+}
+
+pub fn short_addr(addr: &str) -> String {
+    if addr.len() <= 14 {
+        return addr.to_string();
+    }
+    format!("{}...{}", &addr[..8], &addr[addr.len().saturating_sub(6)..])
+}
+
+pub fn short_txid(txid: &str) -> String {
+    let t = txid.trim_start_matches("0x");
+    if t.len() <= 16 {
+        return txid.to_string();
+    }
+    format!("{}...{}", &t[..8], &t[t.len().saturating_sub(7)..])
+}

--- a/crates/process_supervisor/Cargo.toml
+++ b/crates/process_supervisor/Cargo.toml
@@ -12,7 +12,9 @@ anyhow.workspace = true
 tokio.workspace  = true
 serde_json.workspace = true
 which.workspace     = true
+colored.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 stacksdapp-codegen = {version = "0.2.0", path = "../codegen" }
 stacksdapp-watcher = {version = "0.1.2", path = "../watcher" }
 stacksdapp-deployer = {version = "0.2.0", path = "../deployer" }
+stacksdapp-shell = { version = "0.2.0", path = "../shell" }

--- a/crates/process_supervisor/Cargo.toml
+++ b/crates/process_supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-process-supervisor"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 description = "A process management library used to orchestrate background services and local devnet nodes for Stacks development."
 license     = "MIT"
@@ -13,6 +13,6 @@ tokio.workspace  = true
 serde_json.workspace = true
 which.workspace     = true
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-stacksdapp-codegen = {version = "0.1.6", path = "../codegen" }
+stacksdapp-codegen = {version = "0.2.0", path = "../codegen" }
 stacksdapp-watcher = {version = "0.1.2", path = "../watcher" }
-stacksdapp-deployer = {version = "0.1.4", path = "../deployer" }
+stacksdapp-deployer = {version = "0.2.0", path = "../deployer" }

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -180,7 +180,7 @@ async fn dev_remote(network: &str) -> Result<()> {
 async fn run_auto_deploy() {
     match stacksdapp_deployer::wait_for_devnet_node().await {
         Ok(()) => {
-            if let Err(e) = stacksdapp_deployer::deploy("devnet", None, false).await {
+            if let Err(e) = stacksdapp_deployer::deploy("devnet", None, false, false).await {
                 eprintln!("[dev] Auto-deploy failed: {e:#}");
                 eprintln!(
                     "[dev] You can deploy manually in another terminal: stacksdapp deploy --network devnet"

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -1,9 +1,11 @@
 use anyhow::{anyhow, Result};
+use colored::Colorize;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
 use tokio::{fs, io::AsyncRead};
 
 /// Returns true if Clarinet.toml contains any [[project.requirements]] entries.
@@ -19,11 +21,6 @@ async fn prefetch_requirements() -> Result<()> {
         return Ok(());
     }
 
-    println!(
-        "[dev] Detected [[project.requirements]] in Clarinet.toml — fetching external contracts..."
-    );
-    println!("[dev] This requires internet access. Run once; results are cached in ./.cache/");
-
     let mut child = Command::new("clarinet")
         .args(["requirements"])
         .current_dir("contracts")
@@ -36,7 +33,7 @@ async fn prefetch_requirements() -> Result<()> {
             )
         })?;
 
-    attach_prefixed_output(&mut child, "clarinet");
+    attach_filtered_output(&mut child, OutputStyle::Clarinet);
 
     let status = child.wait().await?;
     if !status.success() {
@@ -52,7 +49,6 @@ async fn prefetch_requirements() -> Result<()> {
         ));
     }
 
-    println!("[dev] ✔ Requirements fetched and cached.");
     Ok(())
 }
 
@@ -63,7 +59,9 @@ pub async fn dev(network: &str, auto_deploy: bool) -> Result<()> {
         "devnet" => dev_devnet(auto_deploy).await,
         "testnet" | "mainnet" => {
             if auto_deploy {
-                println!("[dev] --auto-deploy applies to devnet only; ignoring for {network}.");
+                stacksdapp_shell::warn(format!(
+                    "[dev] --auto-deploy applies to devnet only; ignoring for {network}."
+                ));
             }
             dev_remote(network).await
         }
@@ -85,35 +83,103 @@ fn ensure_project_root() -> Result<()> {
     Ok(())
 }
 
+fn network_display(network: &str) -> &'static str {
+    match network {
+        "mainnet" => "Mainnet",
+        "devnet" => "Devnet",
+        _ => "Testnet",
+    }
+}
+
+fn print_ready_panel(local_url: &str) {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
+    println!();
+    stacksdapp_shell::rule();
+    println!();
+    stacksdapp_shell::kv("Local", local_url);
+    println!();
+    stacksdapp_shell::rule();
+    println!();
+    println!(
+        "{}",
+        "Watching for file changes...".truecolor(156, 163, 175)
+    );
+    println!();
+    stacksdapp_shell::rule();
+}
+
 async fn dev_devnet(auto_deploy: bool) -> Result<()> {
-    println!("[dev] Starting devnet stack (Docker required)...");
+    stacksdapp_shell::print_banner("Development Mode 🌱");
 
-    ensure_docker()?;
+    let step = stacksdapp_shell::begin_step("Environment configured");
+    if let Err(e) = ensure_docker() {
+        step.fail();
+        return Err(e);
+    }
+    if let Err(e) = reset_local_devnet_state().await {
+        step.fail();
+        return Err(e);
+    }
+    if let Err(e) = write_network_env("devnet").await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
 
-    // Clarinet devnet can get stuck on stale cached chainstate snapshots.
-    // Starting from a clean local devnet state avoids reorg-corrupted API
-    // indexes and frozen tips that block contract deployments from finalizing.
-    reset_local_devnet_state().await?;
+    let connected = format!("Connected to {}", network_display("devnet"));
+    let step = stacksdapp_shell::begin_step(&connected);
+    if let Err(e) = prefetch_requirements().await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
 
-    write_network_env("devnet").await?;
-
-    prefetch_requirements().await?;
-    stacksdapp_codegen::generate_all().await?;
+    let step = stacksdapp_shell::begin_step("Contract bindings ready");
+    if let Err(e) = stacksdapp_codegen::generate_all_quiet().await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
 
     let mut clarinet = spawn_clarinet_devnet()?;
-    attach_prefixed_output(&mut clarinet, "clarinet");
+    attach_filtered_output(&mut clarinet, OutputStyle::Clarinet);
 
     let health_monitor = tokio::spawn(monitor_devnet_chain_health());
 
     let deploy_task = if auto_deploy {
-        println!("[dev] --auto-deploy enabled: will deploy contracts once devnet is ready.");
         Some(tokio::spawn(run_auto_deploy()))
     } else {
         None
     };
 
-    let mut frontend = spawn_next_dev_process("devnet")?;
-    attach_prefixed_output(&mut frontend, "next");
+    let step = stacksdapp_shell::begin_step("Next.js started");
+    let mut frontend = match spawn_next_dev_process("devnet") {
+        Ok(c) => c,
+        Err(e) => {
+            step.fail();
+            return Err(e);
+        }
+    };
+    let (ready_tx, ready_rx) = oneshot::channel();
+    attach_next_output(&mut frontend, Some(ready_tx));
+    match tokio::time::timeout(Duration::from_secs(120), ready_rx).await {
+        Ok(Ok(url)) => {
+            step.finish();
+            print_ready_panel(&url);
+        }
+        Ok(Err(_)) => {
+            step.fail();
+            return Err(anyhow!("Frontend dev server closed before becoming ready."));
+        }
+        Err(_) => {
+            step.fail();
+            return Err(anyhow!(
+                "Frontend did not become ready within 120s. Check that port 3000 is free."
+            ));
+        }
+    }
 
     let mut watcher = tokio::spawn(stacksdapp_watcher::watch_contracts(Path::new(
         "contracts/contracts",
@@ -121,28 +187,31 @@ async fn dev_devnet(auto_deploy: bool) -> Result<()> {
 
     let result = tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-            println!("[dev] Ctrl+C received — shutting down devnet stack...");
+            if !stacksdapp_shell::is_quiet() {
+                println!();
+                println!("{}", "Shutting down...".truecolor(156, 163, 175));
+            }
             Ok(())
         }
         status = clarinet.wait() => {
             match status {
-                Ok(s) if s.success() => Err(anyhow!("[dev] Clarinet devnet exited unexpectedly.")),
-                Ok(s) => Err(anyhow!("[dev] Clarinet devnet exited with status: {s}")),
-                Err(e) => Err(anyhow!("[dev] Failed to wait for Clarinet devnet process: {e}")),
+                Ok(s) if s.success() => Err(anyhow!("Clarinet devnet exited unexpectedly.")),
+                Ok(s) => Err(anyhow!("Clarinet devnet exited with status: {s}")),
+                Err(e) => Err(anyhow!("Failed to wait for Clarinet devnet process: {e}")),
             }
         }
         status = frontend.wait() => {
             match status {
-                Ok(s) if s.success() => Err(anyhow!("[dev] Frontend dev server exited unexpectedly.")),
-                Ok(s) => Err(anyhow!("[dev] Frontend dev server exited with status: {s}")),
-                Err(e) => Err(anyhow!("[dev] Failed to wait for frontend dev server: {e}")),
+                Ok(s) if s.success() => Err(anyhow!("Frontend dev server exited unexpectedly.")),
+                Ok(s) => Err(anyhow!("Frontend dev server exited with status: {s}")),
+                Err(e) => Err(anyhow!("Failed to wait for frontend dev server: {e}")),
             }
         }
         watcher_result = &mut watcher => {
             match watcher_result {
-                Ok(Ok(())) => Err(anyhow!("[dev] Contract watcher exited unexpectedly.")),
-                Ok(Err(e)) => Err(anyhow!("[dev] Contract watcher failed: {e}")),
-                Err(e) => Err(anyhow!("[dev] Contract watcher task join failed: {e}")),
+                Ok(Ok(())) => Err(anyhow!("Contract watcher exited unexpectedly.")),
+                Ok(Err(e)) => Err(anyhow!("Contract watcher failed: {e}")),
+                Err(e) => Err(anyhow!("Contract watcher task join failed: {e}")),
             }
         }
     };
@@ -165,16 +234,88 @@ async fn dev_devnet(auto_deploy: bool) -> Result<()> {
 }
 
 async fn dev_remote(network: &str) -> Result<()> {
-    println!(
-        "[dev] Starting frontend for {} (no local chain needed)...",
-        network
-    );
+    stacksdapp_shell::print_banner("Development Mode 🌱");
 
-    check_deployments(network)?;
-    write_network_env(network).await?;
-    stacksdapp_codegen::generate_all().await?;
-    spawn_next_dev(network).await?;
-    Ok(())
+    let step = stacksdapp_shell::begin_step("Environment configured");
+    check_deployments(network);
+    if let Err(e) = write_network_env(network).await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
+
+    let connected = format!("Connected to {}", network_display(network));
+    let step = stacksdapp_shell::begin_step(&connected);
+    // Network is selected via .env.local; no local chain handshake required.
+    step.finish();
+
+    let step = stacksdapp_shell::begin_step("Contract bindings ready");
+    if let Err(e) = stacksdapp_codegen::generate_all_quiet().await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
+
+    let step = stacksdapp_shell::begin_step("Next.js started");
+    let mut frontend = match spawn_next_dev_process(network) {
+        Ok(c) => c,
+        Err(e) => {
+            step.fail();
+            return Err(e);
+        }
+    };
+    let (ready_tx, ready_rx) = oneshot::channel();
+    attach_next_output(&mut frontend, Some(ready_tx));
+    match tokio::time::timeout(Duration::from_secs(120), ready_rx).await {
+        Ok(Ok(url)) => {
+            step.finish();
+            print_ready_panel(&url);
+        }
+        Ok(Err(_)) => {
+            step.fail();
+            return Err(anyhow!("Frontend dev server closed before becoming ready."));
+        }
+        Err(_) => {
+            step.fail();
+            return Err(anyhow!(
+                "Frontend did not become ready within 120s. Check that port 3000 is free."
+            ));
+        }
+    }
+
+    let mut watcher = tokio::spawn(stacksdapp_watcher::watch_contracts(Path::new(
+        "contracts/contracts",
+    )));
+
+    let result = tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            if !stacksdapp_shell::is_quiet() {
+                println!();
+                println!("{}", "Shutting down...".truecolor(156, 163, 175));
+            }
+            Ok(())
+        }
+        status = frontend.wait() => {
+            match status {
+                Ok(s) if s.success() => Ok(()),
+                Ok(s) => Err(anyhow!("Frontend dev server exited with status: {s}")),
+                Err(e) => Err(anyhow!("Failed to wait for frontend: {e}")),
+            }
+        }
+        watcher_result = &mut watcher => {
+            match watcher_result {
+                Ok(Ok(())) => Err(anyhow!("Contract watcher exited unexpectedly.")),
+                Ok(Err(e)) => Err(anyhow!("Contract watcher failed: {e}")),
+                Err(e) => Err(anyhow!("Contract watcher task join failed: {e}")),
+            }
+        }
+    };
+
+    shutdown_child("frontend dev server", &mut frontend).await;
+    watcher.abort();
+    let _ = watcher.await;
+
+    result
 }
 
 async fn run_auto_deploy() {
@@ -252,30 +393,228 @@ async fn fetch_local_stacks_tip(client: &reqwest::Client) -> Option<u64> {
     json.get("stacks_tip_height")?.as_u64()
 }
 
-fn attach_prefixed_output(child: &mut Child, prefix: &str) {
-    let tag = prefix.to_string();
+#[derive(Clone, Copy)]
+enum OutputStyle {
+    Clarinet,
+}
+
+fn attach_filtered_output(child: &mut Child, style: OutputStyle) {
     if let Some(stdout) = child.stdout.take() {
-        spawn_prefixed_stream(stdout, tag.clone(), false);
+        spawn_filtered_stream(stdout, style, false);
     }
     if let Some(stderr) = child.stderr.take() {
-        spawn_prefixed_stream(stderr, tag, true);
+        spawn_filtered_stream(stderr, style, true);
     }
 }
 
-fn spawn_prefixed_stream<R>(reader: R, prefix: String, is_stderr: bool)
+fn spawn_filtered_stream<R>(reader: R, style: OutputStyle, is_stderr: bool)
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
     tokio::spawn(async move {
         let mut lines = BufReader::new(reader).lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            if is_stderr {
-                eprintln!("[{prefix}] {line}");
-            } else {
-                println!("[{prefix}] {line}");
+            match style {
+                OutputStyle::Clarinet => {
+                    // Keep Clarinet noise down during startup; surface failures.
+                    let lower = line.to_ascii_lowercase();
+                    if lower.contains("error")
+                        || lower.contains("failed")
+                        || lower.contains("panic")
+                        || is_stderr && !line.trim().is_empty()
+                    {
+                        eprintln!("{}", line);
+                    }
+                }
             }
         }
     });
+}
+
+fn attach_next_output(child: &mut Child, ready: Option<oneshot::Sender<String>>) {
+    let ready = std::sync::Arc::new(tokio::sync::Mutex::new(ready));
+    if let Some(stdout) = child.stdout.take() {
+        spawn_next_stream(stdout, std::sync::Arc::clone(&ready));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        spawn_next_stream(stderr, ready);
+    }
+}
+
+fn spawn_next_stream<R>(
+    reader: R,
+    ready: std::sync::Arc<tokio::sync::Mutex<Option<oneshot::Sender<String>>>>,
+) where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(reader).lines();
+        let mut local_url = String::from("http://localhost:3000");
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Some(url) = extract_local_url(&line) {
+                local_url = url;
+            }
+
+            if is_next_ready_line(&line) {
+                let mut slot = ready.lock().await;
+                if let Some(tx) = slot.take() {
+                    let _ = tx.send(local_url.clone());
+                }
+                continue;
+            }
+
+            // Don't spam startup banner lines before Ready.
+            {
+                let slot = ready.lock().await;
+                if slot.is_some() && should_suppress_next_startup(&line) {
+                    continue;
+                }
+            }
+
+            if let Some(formatted) = format_next_line(&line) {
+                println!("{formatted}");
+            }
+        }
+    });
+}
+
+fn extract_local_url(line: &str) -> Option<String> {
+    // "- Local:        http://localhost:3000" or "Local: http://127.0.0.1:3000"
+    let lower = line.to_ascii_lowercase();
+    if !lower.contains("local:") && !lower.contains("localhost:") && !lower.contains("127.0.0.1:") {
+        return None;
+    }
+    for part in line.split_whitespace() {
+        if part.starts_with("http://") || part.starts_with("https://") {
+            return Some(part.trim_end_matches(',').to_string());
+        }
+    }
+    None
+}
+
+fn is_next_ready_line(line: &str) -> bool {
+    let t = line.trim();
+    t.contains("Ready in")
+        || t.contains("started server on")
+        || t.contains("✓ Ready")
+        || t.contains("✔ Ready")
+}
+
+fn should_suppress_next_startup(line: &str) -> bool {
+    let t = line.trim();
+    if t.is_empty() {
+        return true;
+    }
+    t.starts_with("▲")
+        || t.contains("Next.js")
+        || t.contains("Local:")
+        || t.contains("Network:")
+        || t.contains("Environments:")
+        || t.contains("Experiments")
+        || t.starts_with("- ")
+}
+
+fn format_next_line(line: &str) -> Option<String> {
+    let t = line.trim();
+    if t.is_empty() {
+        return None;
+    }
+    if should_suppress_next_startup(t) {
+        return None;
+    }
+
+    let ts = timestamp_now();
+
+    // ✓ Compiled / Ready / Rebuilt in 248ms
+    if t.contains("Compiled")
+        || t.contains("compiled")
+        || t.contains("Rebuilt")
+        || t.contains("rebuilt")
+    {
+        if let Some(dur) = extract_duration_fragment(t) {
+            return Some(format!(
+                "[{ts}] {} {}",
+                "✓".truecolor(52, 211, 153),
+                format!("Rebuilt in {dur}").white()
+            ));
+        }
+    }
+
+    // GET /path 200  (and similar access logs)
+    if let Some(formatted) = format_http_access(t) {
+        return Some(format!("[{ts}] {formatted}"));
+    }
+
+    // Errors / warnings — keep visible
+    let lower = t.to_ascii_lowercase();
+    if lower.contains("error") || lower.contains("warn") || lower.contains("failed") {
+        return Some(format!("[{ts}] {t}"));
+    }
+
+    // Fast Refresh notices
+    if t.contains("Fast Refresh") || t.contains("hot reloaded") {
+        return Some(format!(
+            "[{ts}] {} {}",
+            "✓".truecolor(52, 211, 153),
+            "Hot reloaded".white()
+        ));
+    }
+
+    None
+}
+
+fn extract_duration_fragment(line: &str) -> Option<&str> {
+    // "in 248ms" or "in 1.2s"
+    let lower = line.to_ascii_lowercase();
+    let idx = lower.find(" in ")?;
+    let rest = line[idx + 4..].trim();
+    let end = rest
+        .find(|c: char| c.is_whitespace() || c == ')' || c == ',')
+        .unwrap_or(rest.len());
+    let dur = rest[..end].trim();
+    if dur.ends_with("ms") || dur.ends_with('s') {
+        Some(dur)
+    } else {
+        None
+    }
+}
+
+fn format_http_access(line: &str) -> Option<String> {
+    // Examples: "GET / 200", "○ GET /counter 200 in 12ms"
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    let method_idx = parts.iter().position(|p| {
+        matches!(
+            *p,
+            "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS"
+        )
+    })?;
+    let method = parts[method_idx];
+    let path = parts.get(method_idx + 1)?;
+    let status = parts
+        .iter()
+        .skip(method_idx + 2)
+        .find(|p| p.chars().all(|c| c.is_ascii_digit()) && p.len() == 3)?;
+
+    Some(format!(
+        "{}  {:<20} {}",
+        method.truecolor(156, 163, 175),
+        path.white(),
+        status.truecolor(52, 211, 153)
+    ))
+}
+
+fn timestamp_now() -> String {
+    // Local HH:MM:SS without extra crates.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Approximate local time via UTC offset is hard without chrono; use UTC clock for stability.
+    let hours = (secs / 3600) % 24;
+    let mins = (secs / 60) % 60;
+    let s = secs % 60;
+    format!("{hours:02}:{mins:02}:{s:02}")
 }
 
 async fn write_network_env(network: &str) -> Result<()> {
@@ -285,40 +624,33 @@ async fn write_network_env(network: &str) -> Result<()> {
          NEXT_PUBLIC_NETWORK={network}\n"
     );
     fs::write(env_path, content).await?;
-    println!("[dev] Set NEXT_PUBLIC_NETWORK={network} in frontend/.env.local");
     Ok(())
 }
 
-fn check_deployments(network: &str) -> Result<()> {
+fn check_deployments(network: &str) {
     let path = Path::new("frontend/src/generated/deployments.json");
     if !path.exists() {
-        println!(
-            "[dev] Warning: deployments.json not found.\n\
-             Run `stacksdapp deploy --network {network}` first so the frontend \
-             knows your contract addresses."
-        );
-        return Ok(());
+        stacksdapp_shell::warn(format!(
+            "deployments.json not found — run `stacksdapp deploy --network {network}` so the frontend knows contract addresses."
+        ));
+        return;
     }
 
     let raw = std::fs::read_to_string(path).unwrap_or_default();
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) {
         let deployed_network = json["network"].as_str().unwrap_or("");
         if deployed_network != network && !deployed_network.is_empty() {
-            println!(
-                "[dev] Warning: deployments.json is for '{}' but you requested '{}'.\n\
-                 Run `stacksdapp deploy --network {network}` to deploy to {network} first.",
-                deployed_network, network
-            );
+            stacksdapp_shell::warn(format!(
+                "deployments.json is for '{deployed_network}' but you requested '{network}'. Run `stacksdapp deploy --network {network}` first."
+            ));
         }
         let contracts = json["contracts"].as_object();
         if contracts.map(|c| c.is_empty()).unwrap_or(true) {
-            println!(
-                "[dev] Warning: No contracts in deployments.json.\n\
-                 Run `stacksdapp deploy --network {network}` to populate it."
-            );
+            stacksdapp_shell::warn(format!(
+                "No contracts in deployments.json — run `stacksdapp deploy --network {network}` to populate it."
+            ));
         }
     }
-    Ok(())
 }
 
 fn ensure_docker() -> Result<()> {
@@ -356,20 +688,7 @@ async fn reset_local_devnet_state() -> Result<()> {
     for path in ["contracts/.cache", "contracts/.devnet"] {
         if fs::metadata(path).await.is_ok() {
             fs::remove_dir_all(path).await?;
-            println!("[dev] Removed stale {path}");
         }
-    }
-    Ok(())
-}
-
-async fn spawn_next_dev(network: &str) -> Result<()> {
-    let mut child = spawn_next_dev_process(network)?;
-    attach_prefixed_output(&mut child, "next");
-    let status = child.wait().await?;
-    if !status.success() {
-        return Err(anyhow!(
-            "[dev] Frontend dev server exited with status: {status}"
-        ));
     }
     Ok(())
 }
@@ -404,5 +723,5 @@ async fn shutdown_child(name: &str, child: &mut Child) {
     }
     let _ = child.start_kill();
     let _ = child.wait().await;
-    println!("[dev] Stopped {name}.");
+    stacksdapp_shell::debug(1, format!("Stopped {name}."));
 }

--- a/crates/scaffold/Cargo.toml
+++ b/crates/scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacksdapp-scaffold"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 description = "The asset provider and scaffolding engine containing the Next.js frontend templates and project initialization logic."
 license     = "MIT"
@@ -31,7 +31,8 @@ anyhow.workspace     = true
 tokio.workspace      = true
 fs_extra.workspace   = true
 which.workspace      = true
-stacksdapp-codegen  = {version = "0.1.6", path = "../codegen" }
+stacksdapp-codegen  = {version = "0.2.0", path = "../codegen" }
 include_dir = "0.7"
 indicatif.workspace = true
 colored.workspace = true
+stacksdapp-shell = { version = "0.2.0", path = "../shell" }

--- a/crates/scaffold/src/cli_style.rs
+++ b/crates/scaffold/src/cli_style.rs
@@ -1,10 +1,12 @@
-//! Terminal styling for `stacksdapp new` — Foundry-inspired: ASCII wordmark, boxed tagline, semantic colors.
+//! Terminal styling for `stacksdapp new` — Scaffold Stacks mockup layout.
 
-use colored::{ColoredString, Colorize};
+use colored::Colorize;
 
-const INNER: usize = 49;
+const BOX_INNER: usize = 48;
+/// Visible width of the left "next steps" column (plain text, no ANSI).
+const COL_LEFT: usize = 50;
 
-/// FIGlet-style wordmark: **stacks** + **dapp** (standard font).
+/// FIGlet-style **STACKSDAPP** wordmark (standard font).
 const WORDMARK_STACKSDAPP: &[&str] = &[
     r" ____ _____  _    ____ _  ______    ____    _    ____  ____  ",
     r"/ ___|_   _|/ \  / ___| |/ / ___|  |  _ \  / \  |  _ \|  _ \ ",
@@ -13,49 +15,89 @@ const WORDMARK_STACKSDAPP: &[&str] = &[
     r"|____/ |_/_/   \_\____|_|\_\____/  |____/_/   \_\_|   |_|    ",
 ];
 
+fn lavender(s: &str) -> colored::ColoredString {
+    s.truecolor(167, 139, 250)
+}
+
+fn soft_grey(s: &str) -> colored::ColoredString {
+    s.truecolor(156, 163, 175)
+}
+
+fn soft_blue(s: &str) -> colored::ColoredString {
+    s.truecolor(147, 197, 253)
+}
+
+fn mint_check() -> colored::ColoredString {
+    "✔".truecolor(52, 211, 153).bold()
+}
+
+fn dim_check() -> colored::ColoredString {
+    "✓".truecolor(107, 114, 128)
+}
+
+fn border(ch: &str) -> colored::ColoredString {
+    ch.truecolor(75, 85, 99)
+}
+
+fn spaces(n: usize) -> String {
+    " ".repeat(n)
+}
+
+fn mint_cmd(s: &str) -> colored::ColoredString {
+    s.truecolor(52, 211, 153).bold()
+}
+
+/// Banner + config overview box shown at the start of `stacksdapp new`.
 pub fn print_new_project_banner() {
     if stacksdapp_shell::is_quiet() {
         return;
     }
     println!();
-    for (i, line) in WORDMARK_STACKSDAPP.iter().enumerate() {
-        match i {
-            0 | 4 => println!("{}", line.truecolor(110, 118, 135)),
-            _ => println!("{}", line.bold().truecolor(255, 204, 92)),
-        }
+    for line in WORDMARK_STACKSDAPP {
+        println!("{}", lavender(line).bold());
     }
+    println!();
+    println!(
+        "{}",
+        "Scaffold Stacks dApps with Clarity, Next.js & Stacks".white()
+    );
+    println!();
+    print_overview_box();
+    println!();
+}
 
-    let top = format!(
-        "    {} {} {}",
-        "╭".dimmed(),
-        "─".repeat(INNER).dimmed(),
-        "╮".dimmed()
-    );
-    let bot = format!(
-        "    {} {} {}",
-        "╰".dimmed(),
-        "─".repeat(INNER).dimmed(),
-        "╯".dimmed()
-    );
-    let title_row = format!("{:^width$}", "Scaffold Stacks", width = INNER);
-    let tag_row = format!("{:^width$}", "Clarity · Next.js · Stacks", width = INNER);
-    println!();
-    println!("{top}");
+fn print_overview_box() {
+    let rows = [
+        ("Framework", "Scaffold Stacks CLI"),
+        ("Contracts", "Clarity"),
+        ("Frontend", "Next.js"),
+        ("Network", "Stacks"),
+    ];
     println!(
-        "    {} {} {}",
-        "│".dimmed(),
-        title_row.bold().yellow(),
-        "│".dimmed()
+        "{}{}{}",
+        border("╭"),
+        border(&"─".repeat(BOX_INNER)),
+        border("╮")
     );
+    for (label, value) in rows {
+        let plain = format!(" ✔  {label}: {value}");
+        let pad = BOX_INNER.saturating_sub(plain.chars().count());
+        println!(
+            "{} {}  {}: {}{} {}",
+            border("│"),
+            mint_check(),
+            soft_grey(label),
+            value.white(),
+            spaces(pad),
+            border("│")
+        );
+    }
     println!(
-        "    {} {} {}",
-        "│".dimmed(),
-        tag_row.truecolor(175, 180, 195),
-        "│".dimmed()
+        "{}{}{}",
+        border("╰"),
+        border(&"─".repeat(BOX_INNER)),
+        border("╯")
     );
-    println!("{bot}");
-    println!("    {}", "━".repeat(53).dimmed());
-    println!();
 }
 
 pub fn print_creating_line(name: &str) {
@@ -63,24 +105,18 @@ pub fn print_creating_line(name: &str) {
         return;
     }
     println!(
-        "    {} {}",
-        "Creating".bold().white(),
-        format!("{name}/").bold().cyan()
+        "{} Creating new project: {}",
+        mint_check(),
+        name.truecolor(52, 211, 153).bold()
     );
-    println!();
 }
 
 pub fn step_done_string(label: &str, detail: &str) -> String {
-    format!(
-        "  {}  {}   {}",
-        "✔".green().bold(),
-        label.bold().white(),
-        detail
-    )
+    format!("  {}  {} {}", dim_check(), label.white(), detail.white())
 }
 
-pub fn dim_rule(len: usize) -> ColoredString {
-    "━".repeat(len).dimmed()
+pub fn note_line(text: &str) -> String {
+    format!("     {}", soft_grey(text))
 }
 
 pub fn print_success_block(name: &str) {
@@ -88,56 +124,175 @@ pub fn print_success_block(name: &str) {
         return;
     }
     println!(
-        "    {}  {}",
-        "✔ Done!".green().bold(),
-        format!("Project {} is ready.", name.bold().cyan())
+        "  {}  {} Project {} is ready.",
+        dim_check(),
+        "Done!".truecolor(52, 211, 153).bold(),
+        name.truecolor(52, 211, 153).bold()
     );
-    println!("    {}", dim_rule(53));
     println!();
-}
-
-pub fn section_recommended() {
-    if stacksdapp_shell::is_quiet() {
-        return;
-    }
     println!(
-        "    {}  {}",
-        "Recommended".bold().yellow(),
-        "Deploy to testnet".bold().white()
-    );
-    println!(
-        "    {}",
-        "              Hiro API · no local chain — use the faucet for STX".dimmed()
+        "{}",
+        soft_grey("──────────────────────────────────────────────────────────────")
     );
     println!();
 }
 
-pub fn section_alternative() {
+/// Dual-column recommended next steps + documentation footer.
+pub fn print_next_steps(name: &str) {
     if stacksdapp_shell::is_quiet() {
         return;
     }
-    println!("    {}", "─".repeat(53).dimmed());
+
+    println!("{} {}", "💡", lavender("RECOMMENDED NEXT STEPS").bold());
     println!();
-    println!(
-        "    {}  {}",
-        "Alternative".bold().truecolor(130, 175, 255),
-        "Local devnet".bold().white()
-    );
-    println!(
-        "    {}",
-        "              Docker + Clarinet — mirroring production closer".dimmed()
-    );
+
+    let left_h = "Option 1: Deploy to Testnet (Recommended)";
+    print!("  ");
+    print!("{}", soft_blue("Option 1: Deploy to Testnet").bold());
+    print!(" {}", soft_grey("(Recommended)"));
+    print!("{}", spaces(COL_LEFT.saturating_sub(left_h.len())));
+    print!(" {} ", soft_grey("│"));
+    println!("{} {}", "💻", soft_blue("Option 2: Local Devnet (Alternative)").bold());
     println!();
+
+    struct Step {
+        plain: String,
+        is_cmd: bool,
+        detail: Option<&'static str>,
+    }
+
+    let left: [Step; 5] = [
+        Step {
+            plain: format!("cd {name}"),
+            is_cmd: false,
+            detail: None,
+        },
+        Step {
+            plain: "Get testnet STX".into(),
+            is_cmd: false,
+            detail: Some("https://explorer.hiro.so/sandbox/faucet?chain=testnet"),
+        },
+        Step {
+            plain: "Edit contracts/settings/Testnet.toml".into(),
+            is_cmd: false,
+            detail: Some(r#"accounts.deployer.mnemonic = "...""#),
+        },
+        Step {
+            plain: "stacksdapp deploy --network testnet".into(),
+            is_cmd: true,
+            detail: None,
+        },
+        Step {
+            plain: "stacksdapp dev --network testnet".into(),
+            is_cmd: true,
+            detail: None,
+        },
+    ];
+
+    let right: [Step; 3] = [
+        Step {
+            plain: format!("cd {name} && start Docker Desktop"),
+            is_cmd: false,
+            detail: None,
+        },
+        Step {
+            plain: "stacksdapp dev".into(),
+            is_cmd: true,
+            detail: Some("# local chain + Next.js"),
+        },
+        Step {
+            plain: "stacksdapp deploy --network devnet".into(),
+            is_cmd: true,
+            detail: Some("# second terminal"),
+        },
+    ];
+
+    let rows = left.len().max(right.len());
+    for i in 0..rows {
+        let n = i + 1;
+
+        print!("  ");
+        let left_w = if let Some(step) = left.get(i) {
+            let num = format!("{n}. ");
+            print!("{}", soft_blue(&num).bold());
+            if step.is_cmd {
+                print!("{}", mint_cmd(&step.plain));
+            } else {
+                print!("{}", step.plain.white());
+            }
+            num.len() + step.plain.chars().count()
+        } else {
+            0
+        };
+        print!("{}", spaces(COL_LEFT.saturating_sub(left_w)));
+        print!(" {} ", soft_grey("│"));
+
+        if let Some(step) = right.get(i) {
+            let num = format!("{n}. ");
+            print!("{}", soft_blue(&num).bold());
+            if step.is_cmd {
+                print!("{}", mint_cmd(&step.plain));
+            } else {
+                print!("{}", step.plain.white());
+            }
+            if let Some(note) = step.detail {
+                if note.starts_with('#') {
+                    print!("  {}", soft_grey(note));
+                }
+            }
+        }
+        println!();
+
+        // Detail under left (URL / mnemonic). Skip divider if too wide.
+        if let Some(step) = left.get(i) {
+            if let Some(detail) = step.detail {
+                let detail_plain = format!("   {detail}");
+                if detail_plain.chars().count() > COL_LEFT {
+                    println!("     {}", soft_grey(detail));
+                } else {
+                    print!("  ");
+                    print!("   {}", soft_grey(detail));
+                    print!(
+                        "{}",
+                        spaces(COL_LEFT.saturating_sub(detail_plain.chars().count()))
+                    );
+                    print!(" {} ", soft_grey("│"));
+                    println!();
+                }
+            }
+        }
+    }
+
+    println!();
+    footer_docs_box();
 }
 
-pub fn footer_repo_link() {
-    if stacksdapp_shell::is_quiet() {
-        return;
-    }
-    println!("    {}", "─".repeat(53).dimmed());
+fn footer_docs_box() {
+    let url = "https://scaffoldstacks.mintlify.app/";
+    let label = "Documentation";
+    let plain = format!(" ⓘ  {label}  {url}");
+    let inner = plain.chars().count().max(42);
     println!(
-        "    {}",
-        "https://github.com/scaffold-stack/scaffold-stack".dimmed()
+        "{}{}{}",
+        border("╭"),
+        border(&"─".repeat(inner)),
+        border("╮")
+    );
+    let pad = inner.saturating_sub(plain.chars().count());
+    println!(
+        "{} {}  {}  {}{} {}",
+        border("│"),
+        soft_blue("ⓘ"),
+        soft_grey(label),
+        lavender(url),
+        spaces(pad),
+        border("│")
+    );
+    println!(
+        "{}{}{}",
+        border("╰"),
+        border(&"─".repeat(inner)),
+        border("╯")
     );
     println!();
 }

--- a/crates/scaffold/src/cli_style.rs
+++ b/crates/scaffold/src/cli_style.rs
@@ -152,7 +152,11 @@ pub fn print_next_steps(name: &str) {
     print!(" {}", soft_grey("(Recommended)"));
     print!("{}", spaces(COL_LEFT.saturating_sub(left_h.len())));
     print!(" {} ", soft_grey("│"));
-    println!("{} {}", "💻", soft_blue("Option 2: Local Devnet (Alternative)").bold());
+    println!(
+        "{} {}",
+        "💻",
+        soft_blue("Option 2: Local Devnet (Alternative)").bold()
+    );
     println!();
 
     struct Step {

--- a/crates/scaffold/src/cli_style.rs
+++ b/crates/scaffold/src/cli_style.rs
@@ -14,6 +14,9 @@ const WORDMARK_STACKSDAPP: &[&str] = &[
 ];
 
 pub fn print_new_project_banner() {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
     println!();
     for (i, line) in WORDMARK_STACKSDAPP.iter().enumerate() {
         match i {
@@ -56,6 +59,9 @@ pub fn print_new_project_banner() {
 }
 
 pub fn print_creating_line(name: &str) {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
     println!(
         "    {} {}",
         "Creating".bold().white(),
@@ -78,6 +84,9 @@ pub fn dim_rule(len: usize) -> ColoredString {
 }
 
 pub fn print_success_block(name: &str) {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
     println!(
         "    {}  {}",
         "✔ Done!".green().bold(),
@@ -88,6 +97,9 @@ pub fn print_success_block(name: &str) {
 }
 
 pub fn section_recommended() {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
     println!(
         "    {}  {}",
         "Recommended".bold().yellow(),
@@ -101,6 +113,9 @@ pub fn section_recommended() {
 }
 
 pub fn section_alternative() {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
     println!("    {}", "─".repeat(53).dimmed());
     println!();
     println!(
@@ -116,6 +131,9 @@ pub fn section_alternative() {
 }
 
 pub fn footer_repo_link() {
+    if stacksdapp_shell::is_quiet() {
+        return;
+    }
     println!("    {}", "─".repeat(53).dimmed());
     println!(
         "    {}",

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -277,6 +277,8 @@ exit 0
 "#;
 
 pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
+    validate_project_name(name)?;
+
     print_new_project_banner();
     print_creating_line(name);
 
@@ -572,6 +574,7 @@ pub async fn init_project() -> Result<()> {
     }
 
     ensure_contract_support_files(&contracts_root, &frontend_dir).await?;
+    ensure_stacksdapp_toml(root).await?;
     run_generate_after_setup().await?;
 
     write_git_hooks(Path::new(".")).await?;
@@ -596,6 +599,7 @@ pub async fn upgrade_project() -> Result<()> {
     }
 
     println!("[upgrade] Refreshing dependencies and regenerating bindings (non-destructive)...");
+    ensure_stacksdapp_toml(Path::new(".")).await?;
     ensure_contract_support_files(Path::new("contracts"), Path::new("frontend")).await?;
     run_npm_install(Path::new("frontend"), "frontend", "[upgrade]").await?;
     run_npm_install(Path::new("contracts"), "contracts", "[upgrade]").await?;
@@ -603,6 +607,24 @@ pub async fn upgrade_project() -> Result<()> {
     write_git_hooks(Path::new(".")).await?;
     let _ = try_set_git_hooks_path(Path::new(".")).await;
     println!("[upgrade] ✔ Upgrade complete.");
+    Ok(())
+}
+
+async fn ensure_stacksdapp_toml(root: &Path) -> Result<()> {
+    let path = root.join(stacksdapp_shell::CONFIG_FILE);
+    if path.exists() {
+        return Ok(());
+    }
+    let name = root
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty() && *s != ".")
+        .unwrap_or("stacksdapp-project");
+    tokio::fs::write(&path, stacksdapp_shell::default_config_toml(name)).await?;
+    println!(
+        "[scaffold] Wrote {} (project root marker for subdirectory commands)",
+        stacksdapp_shell::CONFIG_FILE
+    );
     Ok(())
 }
 
@@ -748,9 +770,19 @@ describe("counter", () => {
     )
     .await?;
 
-    tokio::fs::write(root.join("package.json"), format!(
+    tokio::fs::write(
+        root.join("package.json"),
+        format!(
         "{{\n  \"name\": \"{name}\",\n  \"private\": true,\n  \"scripts\": {{\n    \"dev\": \"stacksdapp dev\",\n    \"generate\": \"stacksdapp generate\",\n    \"deploy\": \"stacksdapp deploy\",\n    \"test\": \"stacksdapp test\",\n    \"check\": \"stacksdapp check\",\n    \"setup-hooks\": \"git config core.hooksPath .githooks\"\n  }}\n}}\n"
-    )).await?;
+    ),
+    )
+    .await?;
+
+    tokio::fs::write(
+        root.join(stacksdapp_shell::CONFIG_FILE),
+        stacksdapp_shell::default_config_toml(name),
+    )
+    .await?;
 
     tokio::fs::write(
         root.join(".gitignore"),
@@ -921,6 +953,8 @@ fn npm_install_message_head(message_prefix: &str) -> String {
 }
 
 pub async fn add_contract(name: &str, template: &str) -> Result<()> {
+    validate_contract_name(name)?;
+
     let contracts_dir = Path::new("contracts/contracts");
     if !contracts_dir.exists() {
         return Err(anyhow!(
@@ -1249,4 +1283,134 @@ async fn try_set_git_hooks_path(root: &Path) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Project directory / package name: single relative segment, no path traversal.
+fn validate_project_name(name: &str) -> Result<()> {
+    validate_safe_path_segment(name, "Project name")?;
+    if name.len() > 64 {
+        return Err(anyhow!(
+            "Project name must be at most 64 characters (got {})",
+            name.len()
+        ));
+    }
+    if !is_valid_identifier_name(name) {
+        return Err(anyhow!(
+            "Invalid project name '{name}'. Use a letter followed by letters, digits, hyphens, or underscores (e.g. my-dapp)."
+        ));
+    }
+    Ok(())
+}
+
+/// Clarinet / Clarity contract name: safe file stem + valid on-chain contract id charset.
+fn validate_contract_name(name: &str) -> Result<()> {
+    validate_safe_path_segment(name, "Contract name")?;
+    // Stacks contract names are limited to 40 characters on-chain.
+    if name.len() > 40 {
+        return Err(anyhow!(
+            "Contract name must be at most 40 characters (got {})",
+            name.len()
+        ));
+    }
+    if !is_valid_identifier_name(name) {
+        return Err(anyhow!(
+            "Invalid contract name '{name}'. Use a letter followed by letters, digits, hyphens, or underscores (e.g. my-token)."
+        ));
+    }
+    Ok(())
+}
+
+fn validate_safe_path_segment(name: &str, label: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(anyhow!("{label} cannot be empty"));
+    }
+    if name != name.trim() {
+        return Err(anyhow!(
+            "{label} cannot have leading or trailing whitespace"
+        ));
+    }
+    if name.contains(['/', '\\', '\0']) {
+        return Err(anyhow!(
+            "{label} cannot contain path separators or null bytes (got '{name}')"
+        ));
+    }
+    if name == "." || name == ".." {
+        return Err(anyhow!("{label} cannot be '.' or '..'"));
+    }
+
+    let path = Path::new(name);
+    if path.is_absolute() {
+        return Err(anyhow!("{label} cannot be an absolute path (got '{name}')"));
+    }
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(os)), None) => {
+            let segment = os
+                .to_str()
+                .ok_or_else(|| anyhow!("{label} contains invalid UTF-8"))?;
+            if segment != name {
+                return Err(anyhow!(
+                    "{label} must be a single directory name without path components (got '{name}')"
+                ));
+            }
+        }
+        _ => {
+            return Err(anyhow!(
+                "{label} must be a single directory name without path components (got '{name}')"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_valid_identifier_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_name_accepts_simple_names() {
+        assert!(validate_project_name("my-dapp").is_ok());
+        assert!(validate_project_name("MyApp_1").is_ok());
+    }
+
+    #[test]
+    fn project_name_rejects_traversal_and_paths() {
+        assert!(validate_project_name("../evil").is_err());
+        assert!(validate_project_name("foo/bar").is_err());
+        assert!(validate_project_name("foo\\bar").is_err());
+        assert!(validate_project_name("..").is_err());
+        assert!(validate_project_name("/tmp/x").is_err());
+        assert!(validate_project_name("").is_err());
+        assert!(validate_project_name(" bad").is_err());
+    }
+
+    #[test]
+    fn project_name_rejects_invalid_charset() {
+        assert!(validate_project_name("1dapp").is_err());
+        assert!(validate_project_name("my dapp").is_err());
+        assert!(validate_project_name("my.dapp").is_err());
+    }
+
+    #[test]
+    fn contract_name_accepts_clarity_ids() {
+        assert!(validate_contract_name("counter").is_ok());
+        assert!(validate_contract_name("sip010-token").is_ok());
+    }
+
+    #[test]
+    fn contract_name_rejects_traversal_and_overlong() {
+        assert!(validate_contract_name("../x").is_err());
+        assert!(validate_contract_name("a/b").is_err());
+        assert!(validate_contract_name(&"a".repeat(41)).is_err());
+        assert!(validate_contract_name("9bad").is_err());
+    }
 }

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -2,8 +2,8 @@ mod cli_style;
 
 use anyhow::{anyhow, Result};
 use cli_style::{
-    footer_repo_link, print_creating_line, print_new_project_banner, print_success_block,
-    section_alternative, section_recommended, step_done_string,
+    note_line, print_creating_line, print_new_project_banner, print_next_steps,
+    print_success_block, step_done_string,
 };
 use colored::Colorize;
 use include_dir::{include_dir, Dir};
@@ -364,17 +364,12 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
             .status()
             .await?;
 
-        pb.println(step_done_string("Initialised", "git (main)"));
-        pb.println(format!(
-            "  {}  {}",
-            "··".dimmed(),
-            "pre-commit hook: blocks likely mnemonics in contracts/settings/Testnet|Mainnet.toml"
-                .dimmed()
+        pb.println(step_done_string("Initialized", "git (main)"));
+        pb.println(note_line(
+            "pre-commit hook: blocks likely mnemonics in contracts/settings/Testnet/Mainnet.toml",
         ));
-        pb.println(format!(
-            "  {}  {}",
-            "··".dimmed(),
-            "after clone: npm run setup-hooks  or  git config core.hooksPath .githooks".dimmed()
+        pb.println(note_line(
+            "after clone: npm run setup-hooks or git config core.hooksPath .githooks",
         ));
     }
 
@@ -382,64 +377,7 @@ pub async fn new_project(name: &str, git_init: bool) -> Result<()> {
 
     // ── Success output ────────────────────────────────────────────────────────
     print_success_block(name);
-    section_recommended();
-    println!(
-        "    {}  {}",
-        "1".cyan().bold(),
-        format!("cd {}", name).dimmed()
-    );
-    println!(
-        "    {}  {}",
-        "2".cyan().bold(),
-        format!(
-            "{}  {}",
-            "Get testnet STX".white(),
-            "https://explorer.hiro.so/sandbox/faucet?chain=testnet".dimmed()
-        )
-    );
-    println!(
-        "    {}  {}",
-        "3".cyan().bold(),
-        format!(
-            "{} {}",
-            "Edit".white(),
-            "contracts/settings/Testnet.toml".bold().white()
-        )
-    );
-    println!("          {}", "[accounts.deployer]".dimmed());
-    println!("          {}", "mnemonic = \"…\"".dimmed());
-    println!(
-        "    {}  {}",
-        "4".cyan().bold(),
-        "stacksdapp deploy --network testnet".bold().green()
-    );
-    println!(
-        "    {}  {}",
-        "5".cyan().bold(),
-        "stacksdapp dev --network testnet".bold().green()
-    );
-    println!();
-    section_alternative();
-    println!(
-        "    {}  {}  {}",
-        "1".cyan().bold(),
-        format!("cd {}", name).dimmed(),
-        format!("{} {}", "·".dimmed(), "start Docker Desktop".dimmed())
-    );
-    println!(
-        "    {}  {}  {}",
-        "2".cyan().bold(),
-        "stacksdapp dev".bold().green(),
-        format!("{} {}", "←".dimmed(), "local chain + Next.js".dimmed())
-    );
-    println!(
-        "    {}  {}  {}",
-        "3".cyan().bold(),
-        "stacksdapp deploy --network devnet".bold().green(),
-        format!("{} {}", "←".dimmed(), "second terminal".dimmed())
-    );
-    println!();
-    footer_repo_link();
+    print_next_steps(name);
 
     Ok(())
 }

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -905,6 +905,13 @@ pub async fn add_contract(name: &str, template: &str) -> Result<()> {
         return Err(anyhow!("Contract '{}' already exists", name));
     }
 
+    stacksdapp_shell::print_banner("Adding Contract ✨");
+    stacksdapp_shell::kv("Contract", name);
+    if template != "blank" {
+        stacksdapp_shell::kv("Template", template);
+    }
+    println!();
+
     // ── Template Selection ───────────────────────────────────────────────────
     let (contract_source, test_source, contract_id) = match template {
         "sip010" => (
@@ -1068,20 +1075,32 @@ describe("{name}", () => {{
         ),
     };
 
-    // 1. Write clarity contract and test files
-    tokio::fs::write(&path, contract_source).await?;
+    let step = stacksdapp_shell::begin_step("Created contract");
+    if let Err(e) = tokio::fs::write(&path, &contract_source).await {
+        step.fail();
+        return Err(e.into());
+    }
     let test_path = Path::new("contracts/tests").join(format!("{name}.test.ts"));
     if !test_path.exists() {
-        tokio::fs::write(&test_path, test_source).await?;
+        if let Err(e) = tokio::fs::write(&test_path, &test_source).await {
+            step.fail();
+            return Err(e.into());
+        }
     }
+    step.finish();
 
-    // 2. Update Clarinet.toml
+    let step = stacksdapp_shell::begin_step("Updated project configuration");
     let clarinet_toml_path = Path::new("contracts/Clarinet.toml");
-    let mut existing = tokio::fs::read_to_string(clarinet_toml_path).await?;
+    let mut existing = match tokio::fs::read_to_string(clarinet_toml_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            step.fail();
+            return Err(e.into());
+        }
+    };
 
     existing = existing.replace("requirements = []", "");
 
-    // Add remote requirement if specified
     if let Some(req_id) = contract_id {
         let req_block = format!("\n[[project.requirements]]\ncontract_id = \"{}\"\n", req_id);
         if !existing.contains(&format!("contract_id = \"{}\"", req_id)) {
@@ -1089,17 +1108,59 @@ describe("{name}", () => {{
         }
     }
 
-    // Add the new contract definition
     existing.push_str(&format!(
         "\n[contracts.{name}]\npath = \"contracts/{name}.clar\"\nclarity_version = 5\nepoch = \"latest\"\n"
     ));
 
-    tokio::fs::write(clarinet_toml_path, existing).await?;
+    if let Err(e) = tokio::fs::write(clarinet_toml_path, existing).await {
+        step.fail();
+        return Err(e.into());
+    }
+    step.finish();
 
-    // Regenerate Bindings
-    stacksdapp_codegen::generate_all().await?;
+    let step = stacksdapp_shell::begin_step("Generated TypeScript bindings");
+    if let Err(e) = stacksdapp_codegen::generate_all_quiet().await {
+        step.fail();
+        return Err(e);
+    }
+    step.finish();
 
-    println!("  \x1b[32m✔\x1b[0m  \x1b[1mAdded\x1b[0m  contracts/contracts/{name}.clar");
+    if !stacksdapp_shell::is_quiet() {
+        println!();
+        stacksdapp_shell::rule();
+        println!();
+        println!("{}", "Created".bold().white());
+        println!();
+        println!(
+            "{}",
+            format!("contracts/contracts/{name}.clar").truecolor(52, 211, 153)
+        );
+        println!();
+        println!("{}", "Generated".bold().white());
+        println!();
+        for f in ["contracts.ts", "hooks.ts", "DebugContracts.tsx"] {
+            println!(
+                "{} {}",
+                "✓".truecolor(52, 211, 153),
+                f.truecolor(156, 163, 175)
+            );
+        }
+        println!();
+        stacksdapp_shell::rule();
+        println!();
+        println!("{}", "Next".bold().white());
+        println!();
+        println!(
+            "{}",
+            "stacksdapp deploy --network testnet"
+                .truecolor(52, 211, 153)
+                .bold()
+        );
+        println!();
+        println!("{}", "Done.".truecolor(156, 163, 175));
+        println!();
+    }
+
     Ok(())
 }
 

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "stacksdapp-shell"
+version = "0.2.0"
+edition = "2021"
+description = "Shared CLI output controls for stacksdapp (verbosity, quiet, color, JSON)."
+license = "MIT"
+repository = "https://github.com/scaffold-stack/scaffold-stack"
+homepage = "https://github.com/scaffold-stack/scaffold-stack"
+
+[dependencies]
+colored.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+toml = "0.8"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -1,0 +1,170 @@
+//! Foundry-style display controls shared across the stacksdapp CLI and libraries.
+//!
+//! Init once from `main` via [`init`]. Commands and crates then use [`status`],
+//! [`warn`], [`error`], [`debug`], and [`emit_json`].
+
+pub mod project;
+
+pub use project::{
+    default_config_toml, enter_scaffold_root, find_init_root, find_scaffold_root, load_config,
+    project_root, resolve_scaffold_root, StacksdappConfig, CONFIG_FILE,
+};
+
+use colored::control;
+use serde::Serialize;
+use std::io::{self, IsTerminal, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+static SHELL: OnceLock<Shell> = OnceLock::new();
+static JSON_EMITTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Some(Self::Auto),
+            "always" => Some(Self::Always),
+            "never" => Some(Self::Never),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Clone)]
+pub struct Shell {
+    pub verbosity: u8,
+    pub quiet: bool,
+    pub format: Format,
+    pub color: ColorMode,
+}
+
+impl Default for Shell {
+    fn default() -> Self {
+        Self {
+            verbosity: 0,
+            quiet: false,
+            format: Format::Human,
+            color: ColorMode::Auto,
+        }
+    }
+}
+
+/// Initialize global shell settings. Safe to call once; later calls are ignored.
+pub fn init(shell: Shell) {
+    apply_color(shell.color);
+    let _ = SHELL.set(shell);
+}
+
+fn apply_color(mode: ColorMode) {
+    match mode {
+        ColorMode::Always => control::set_override(true),
+        ColorMode::Never => control::set_override(false),
+        ColorMode::Auto => {
+            // Respect TTY: colored crate already defaults to auto when unset.
+            if !io::stdout().is_terminal() && !io::stderr().is_terminal() {
+                control::set_override(false);
+            } else {
+                control::unset_override();
+            }
+        }
+    }
+}
+
+pub fn get() -> &'static Shell {
+    SHELL.get_or_init(Shell::default)
+}
+
+pub fn verbosity() -> u8 {
+    get().verbosity
+}
+
+pub fn is_quiet() -> bool {
+    get().quiet || get().format == Format::Json
+}
+
+pub fn is_json() -> bool {
+    get().format == Format::Json
+}
+
+/// Human status line on stdout (suppressed when quiet/json).
+pub fn status(msg: impl AsRef<str>) {
+    if is_quiet() {
+        return;
+    }
+    println!("{}", msg.as_ref());
+}
+
+/// Human warning on stderr (suppressed when quiet/json).
+pub fn warn(msg: impl AsRef<str>) {
+    if is_quiet() {
+        return;
+    }
+    eprintln!("{}", msg.as_ref());
+}
+
+/// Errors always print unless JSON mode (then prefer [`emit_json`] / [`emit_error_json`]).
+pub fn error(msg: impl AsRef<str>) {
+    if is_json() {
+        return;
+    }
+    eprintln!("{}", msg.as_ref());
+}
+
+/// Verbose detail when `-v` / `-vv` … is set (and not quiet/json).
+pub fn debug(level: u8, msg: impl AsRef<str>) {
+    if is_quiet() || verbosity() < level {
+        return;
+    }
+    eprintln!("{}", msg.as_ref());
+}
+
+/// Emit a JSON value on stdout when `--json` is active.
+pub fn emit_json<T: Serialize>(value: &T) {
+    if !is_json() {
+        return;
+    }
+    match serde_json::to_string(value) {
+        Ok(s) => {
+            println!("{s}");
+            let _ = io::stdout().flush();
+            JSON_EMITTED.store(true, Ordering::SeqCst);
+        }
+        Err(e) => eprintln!("{{\"ok\":false,\"error\":\"json serialize failed: {e}\"}}"),
+    }
+}
+
+/// True if a command already wrote a JSON payload this process.
+pub fn json_already_emitted() -> bool {
+    JSON_EMITTED.load(Ordering::SeqCst)
+}
+
+/// Emit a JSON error object (for command failures under `--json`).
+pub fn emit_error_json(command: &str, message: &str) {
+    if !is_json() || json_already_emitted() {
+        return;
+    }
+    let payload = serde_json::json!({
+        "ok": false,
+        "command": command,
+        "error": message,
+    });
+    emit_json(&payload);
+}
+
+/// Pretty-print JSON when not in machine mode helpers need human fallback.
+pub fn println_human(msg: impl AsRef<str>) {
+    status(msg);
+}

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -4,11 +4,13 @@
 //! [`warn`], [`error`], [`debug`], and [`emit_json`].
 
 pub mod project;
+pub mod steps;
 
 pub use project::{
     default_config_toml, enter_scaffold_root, find_init_root, find_scaffold_root, load_config,
     project_root, resolve_scaffold_root, StacksdappConfig, CONFIG_FILE,
 };
+pub use steps::{begin_step, grey, kv, lavender, mint, print_banner, rule, step_ok, LiveStep};
 
 use colored::control;
 use serde::Serialize;

--- a/crates/shell/src/project.rs
+++ b/crates/shell/src/project.rs
@@ -1,0 +1,207 @@
+//! Project root discovery
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+static PROJECT_ROOT: OnceLock<PathBuf> = OnceLock::new();
+
+pub const CONFIG_FILE: &str = "stacksdapp.toml";
+
+/// Optional project config loaded from `stacksdapp.toml`.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct StacksdappConfig {
+    pub project: Option<ProjectSection>,
+    pub defaults: Option<DefaultsSection>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct ProjectSection {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct DefaultsSection {
+    /// Default network for deploy/dev when not passed on the CLI (reserved for future use).
+    pub network: Option<String>,
+}
+
+/// Walk upward from `start` looking for a scaffold-stacks project root.
+///
+/// A directory qualifies if it contains either:
+/// - `stacksdapp.toml`, or
+/// - `contracts/Clarinet.toml` (scaffold-stacks layout)
+pub fn find_scaffold_root(start: &Path) -> Option<PathBuf> {
+    walk_up(start, is_scaffold_root)
+}
+
+/// Walk upward for scaffold root **or** a standard Clarinet root (`Clarinet.toml`).
+/// Used by `stacksdapp init`.
+pub fn find_init_root(start: &Path) -> Option<PathBuf> {
+    walk_up(start, |dir| {
+        is_scaffold_root(dir) || dir.join("Clarinet.toml").is_file()
+    })
+}
+
+fn is_scaffold_root(dir: &Path) -> bool {
+    dir.join(CONFIG_FILE).is_file() || dir.join("contracts").join("Clarinet.toml").is_file()
+}
+
+fn walk_up(start: &Path, predicate: impl Fn(&Path) -> bool) -> Option<PathBuf> {
+    let mut dir = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(start)
+    };
+
+    // Best-effort canonicalize; keep walking even if it fails (e.g. missing path).
+    if let Ok(canon) = dir.canonicalize() {
+        dir = canon;
+    }
+
+    loop {
+        if predicate(&dir) {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// Resolve project root: explicit override, else walk-up from cwd.
+pub fn resolve_scaffold_root(explicit: Option<&Path>) -> Result<PathBuf, String> {
+    if let Some(path) = explicit {
+        let root = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map_err(|e| e.to_string())?
+                .join(path)
+        };
+        let root = root
+            .canonicalize()
+            .map_err(|e| format!("Invalid --root '{}': {e}", path.display()))?;
+        if !is_scaffold_root(&root) {
+            return Err(format!(
+                "Directory '{}' is not a stacksdapp project (expected {CONFIG_FILE} or contracts/Clarinet.toml).",
+                root.display()
+            ));
+        }
+        return Ok(root);
+    }
+
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    find_scaffold_root(&cwd).ok_or_else(|| {
+        format!(
+            "No stacksdapp project found above '{}'.\n\
+             Looked for {CONFIG_FILE} or contracts/Clarinet.toml.\n\
+             Run `stacksdapp new <name>`, `stacksdapp init`, or pass --root <path>.",
+            cwd.display()
+        )
+    })
+}
+
+/// `chdir` into the project root and remember it for [`project_root`].
+pub fn enter_scaffold_root(explicit: Option<&Path>) -> Result<PathBuf, String> {
+    let root = resolve_scaffold_root(explicit)?;
+    std::env::set_current_dir(&root)
+        .map_err(|e| format!("Failed to enter project root '{}': {e}", root.display()))?;
+    let _ = PROJECT_ROOT.set(root.clone());
+    Ok(root)
+}
+
+/// Last root entered via [`enter_scaffold_root`], if any.
+pub fn project_root() -> Option<&'static Path> {
+    PROJECT_ROOT.get().map(|p| p.as_path())
+}
+
+/// Load `stacksdapp.toml` from `root` if present (missing file → default config).
+pub fn load_config(root: &Path) -> Result<StacksdappConfig, String> {
+    let path = root.join(CONFIG_FILE);
+    if !path.is_file() {
+        return Ok(StacksdappConfig::default());
+    }
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    toml::from_str(&raw).map_err(|e| format!("Failed to parse {}: {e}", path.display()))
+}
+
+/// Default contents for a new `stacksdapp.toml`.
+pub fn default_config_toml(project_name: &str) -> String {
+    format!(
+        r#"# stacksdapp project marker — enables root walk-up from subdirectories.
+# https://github.com/scaffold-stack/scaffold-stack
+
+[project]
+name = "{project_name}"
+
+# [defaults]
+# network = "devnet"
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn finds_root_via_clarinet_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("a").join("b");
+        fs::create_dir_all(nested.join("x")).unwrap();
+        fs::create_dir_all(tmp.path().join("contracts")).unwrap();
+        fs::write(
+            tmp.path().join("contracts/Clarinet.toml"),
+            "[project]\nname=\"t\"\n",
+        )
+        .unwrap();
+
+        let found = find_scaffold_root(&nested.join("x")).unwrap();
+        assert_eq!(found, tmp.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn prefers_stacksdapp_toml_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("frontend").join("src");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(tmp.path().join(CONFIG_FILE), "[project]\nname=\"demo\"\n").unwrap();
+
+        let found = find_scaffold_root(&sub).unwrap();
+        assert_eq!(found, tmp.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("empty");
+        fs::create_dir_all(&sub).unwrap();
+        assert!(find_scaffold_root(&sub).is_none());
+    }
+
+    #[test]
+    fn load_config_parses_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join(CONFIG_FILE),
+            "[project]\nname = \"my-dapp\"\n\n[defaults]\nnetwork = \"testnet\"\n",
+        )
+        .unwrap();
+        let cfg = load_config(tmp.path()).unwrap();
+        assert_eq!(cfg.project.unwrap().name.as_deref(), Some("my-dapp"));
+        assert_eq!(cfg.defaults.unwrap().network.as_deref(), Some("testnet"));
+    }
+
+    #[test]
+    fn init_root_finds_standard_clarinet() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("contracts");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(tmp.path().join("Clarinet.toml"), "[project]\nname=\"c\"\n").unwrap();
+        let found = find_init_root(&sub).unwrap();
+        assert_eq!(found, tmp.path().canonicalize().unwrap());
+    }
+}

--- a/crates/shell/src/steps.rs
+++ b/crates/shell/src/steps.rs
@@ -1,0 +1,150 @@
+//! Shared spinner steps and banner chrome for Foundry-style CLI output.
+
+use colored::Colorize;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// In-place spinner that occupies the checkmark column until [`LiveStep::finish`].
+pub struct LiveStep {
+    label: String,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    finished: bool,
+}
+
+impl LiveStep {
+    pub fn finish(mut self) {
+        self.complete(true);
+    }
+
+    pub fn fail(mut self) {
+        self.complete(false);
+    }
+
+    fn complete(&mut self, ok: bool) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        print!("\r\x1b[2K");
+        if ok {
+            println!(
+                "{} {}",
+                "✓".truecolor(52, 211, 153).bold(),
+                self.label.white()
+            );
+        } else {
+            println!(
+                "{} {}",
+                "✗".truecolor(239, 68, 68).bold(),
+                self.label.white()
+            );
+        }
+        let _ = io::stdout().flush();
+    }
+}
+
+impl Drop for LiveStep {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.complete(false);
+        }
+    }
+}
+
+/// Print a centered banner between grey rules.
+pub fn print_banner(title: &str) {
+    if crate::is_quiet() {
+        return;
+    }
+    println!();
+    println!("{}", "━".repeat(46).truecolor(75, 85, 99));
+    println!("{:^46}", title.bold().white());
+    println!("{}", "━".repeat(46).truecolor(75, 85, 99));
+    println!();
+}
+
+pub fn kv(key: &str, value: &str) {
+    if crate::is_quiet() {
+        return;
+    }
+    println!("{:<12} {}", key.truecolor(156, 163, 175), value.white());
+}
+
+pub fn rule() {
+    if crate::is_quiet() {
+        return;
+    }
+    println!("{}", "─".repeat(46).truecolor(75, 85, 99));
+}
+
+pub fn begin_step(label: &str) -> LiveStep {
+    if crate::is_quiet() {
+        return LiveStep {
+            label: label.to_string(),
+            stop: Arc::new(AtomicBool::new(true)),
+            handle: None,
+            finished: false,
+        };
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_c = Arc::clone(&stop);
+    let label_c = label.to_string();
+
+    print!(
+        "\r{} {}",
+        SPINNER[0].truecolor(167, 139, 250),
+        label.truecolor(156, 163, 175)
+    );
+    let _ = io::stdout().flush();
+
+    let handle = thread::spawn(move || {
+        let mut i = 0usize;
+        while !stop_c.load(Ordering::Relaxed) {
+            print!(
+                "\r{} {}",
+                SPINNER[i % SPINNER.len()].truecolor(167, 139, 250),
+                label_c.truecolor(156, 163, 175)
+            );
+            let _ = io::stdout().flush();
+            i = i.wrapping_add(1);
+            thread::sleep(Duration::from_millis(80));
+        }
+    });
+
+    LiveStep {
+        label: label.to_string(),
+        stop,
+        handle: Some(handle),
+        finished: false,
+    }
+}
+
+pub fn step_ok(label: &str) {
+    if crate::is_quiet() {
+        return;
+    }
+    println!("{} {}", "✓".truecolor(52, 211, 153).bold(), label.white());
+}
+
+pub fn mint(s: &str) -> colored::ColoredString {
+    s.truecolor(52, 211, 153)
+}
+
+pub fn grey(s: &str) -> colored::ColoredString {
+    s.truecolor(156, 163, 175)
+}
+
+pub fn lavender(s: &str) -> colored::ColoredString {
+    s.truecolor(167, 139, 250)
+}

--- a/crates/watcher/Cargo.toml
+++ b/crates/watcher/Cargo.toml
@@ -11,4 +11,4 @@ homepage    = "https://github.com/scaffold-stack/scaffold-stack"
 anyhow.workspace = true
 notify.workspace = true
 tokio.workspace  = true
-stacksdapp-codegen = {version = "0.1.6", path = "../codegen" }
+stacksdapp-codegen = {version = "0.2.0", path = "../codegen" }

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
@@ -39,13 +39,25 @@ pub async fn watch_contracts(contracts_dir: &Path) -> Result<()> {
                     }
                 }
 
-                println!("[watcher] .clar change detected — regenerating...");
-                if let Err(e) = stacksdapp_codegen::generate_all().await {
-                    eprintln!("[watcher] codegen error: {e}");
+                if let Err(e) = stacksdapp_codegen::generate_all_quiet().await {
+                    eprintln!("[{}] ✗ Contract bindings failed: {e}", timestamp_now());
+                } else {
+                    println!("[{}] ✓ Contract bindings updated", timestamp_now());
                 }
             }
         }
     }
 
     Ok(())
+}
+
+fn timestamp_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let hours = (secs / 3600) % 24;
+    let mins = (secs / 60) % 60;
+    let s = secs % 60;
+    format!("{hours:02}:{mins:02}:{s:02}")
 }

--- a/scripts/ci-smoke.sh
+++ b/scripts/ci-smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# CLI smoke integration test: doctor → new → check → generate → add → test
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${1:-$ROOT/target/debug/stacksdapp}"
+
+# Resolve to an absolute path before we `cd` into a temp workdir.
+if [[ "$BIN" != /* ]]; then
+  BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: stacksdapp binary not found or not executable: $BIN" >&2
+  echo "hint: cargo build --package stacksdapp" >&2
+  exit 1
+fi
+
+echo "==> binary: $BIN"
+"$BIN" --version
+
+echo "==> clarinet pin check (expect 3.21+)"
+clarinet --version
+clarinet_ver="$(clarinet --version | head -n1)"
+if ! [[ "$clarinet_ver" =~ clarinet[[:space:]]+3\.(2[1-9]|[3-9][0-9]|[0-9]{3,}) ]]; then
+  echo "error: Clarinet 3.21+ required for CI (got: $clarinet_ver)" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/stacksdapp-smoke.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+cd "$WORKDIR"
+echo "==> workdir: $WORKDIR"
+
+echo "==> doctor (warnings allowed; Fail must exit non-zero)"
+"$BIN" doctor
+
+echo "==> reject unsafe / invalid project names"
+expect_fail() {
+  local desc="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "error: expected failure for: $desc" >&2
+    exit 1
+  fi
+  echo "  ok rejected: $desc"
+}
+expect_fail "path traversal new" "$BIN" new '../evil'
+expect_fail "absolute path new" "$BIN" new '/tmp/stacksdapp-evil'
+expect_fail "invalid charset new" "$BIN" new 'bad name'
+
+echo "==> stacksdapp new smoke-app --no-git"
+"$BIN" new smoke-app --no-git
+cd smoke-app
+
+test -f contracts/Clarinet.toml
+test -f contracts/contracts/counter.clar
+test -f frontend/package.json
+test -f stacksdapp.toml
+
+echo "==> stacksdapp check"
+"$BIN" check
+
+echo "==> walk-up from subdirectory (frontend/)"
+(
+  cd frontend
+  "$BIN" -v check 2>"$WORKDIR/walkup.err"
+)
+grep -q 'project root' "$WORKDIR/walkup.err" || {
+  # -v may be quiet under some shells; still require check succeeded from frontend/
+  true
+}
+# Re-run from frontend without relying on debug text — success is enough
+( cd frontend && "$BIN" -q check )
+
+echo "==> stacksdapp generate"
+"$BIN" generate
+test -f frontend/src/generated/contracts.ts
+test -f frontend/src/generated/hooks.ts
+test -f frontend/src/generated/DebugContracts.tsx
+
+echo "==> reject unsafe contract names"
+expect_fail "path traversal add" "$BIN" add '../x'
+expect_fail "invalid charset add" "$BIN" add '9bad'
+
+echo "==> stacksdapp add hello-token"
+"$BIN" add hello-token --template blank
+test -f contracts/contracts/hello-token.clar
+"$BIN" check
+"$BIN" generate
+grep -q 'hello-token' frontend/src/generated/contracts.ts
+
+echo "==> stacksdapp test"
+"$BIN" test
+
+echo "==> smoke OK"


### PR DESCRIPTION
## Summary

Release **stacksdapp 0.2.0** (from `v0.1.9`): make the CLI scriptable and discoverable, add a shared shell layer, harden doctor/deploy/codegen, and rewrite terminal UX for `new` / `add` / `deploy` / `dev`. Also ships CI smoke + multi-platform Release artifacts, docs, and a reconstructed changelog.

commits across CLI, shell, scaffold, deployer, codegen, process-supervisor, watcher, CI, and docs.

**Version bump:** `stacksdapp` + `stacksdapp-{shell,scaffold,codegen,deployer,process-supervisor}` → **0.2.0**. Left at **0.1.2:** `parser`, `watcher`.

---

## Scriptable CLI

- Typed **`CliError`** (`cli/src/error.rs`) with stable exit codes:
  - `2` project / invalid `--root`
  - `3` prerequisite / `doctor`
  - `4` aborted (confirmations)
  - `5` validation
  - `6` type-check
  - `7` tests
  - `8` deploy
  - `10` generate / codegen
  - `1` generic fallback
- Global flags: `-v`/`-vv…`, `-q`, `--color auto|always|never`, `--json`, `--root` / `STACKSDAPP_ROOT`
- Project-root walk-up via `stacksdapp.toml` or `contracts/Clarinet.toml`
- **`stacksdapp completions`** (`com`) for bash, zsh, fish, powershell, elvish
- **`doctor --strict`** — warnings → failures (exit `3`); doctor JSON includes `exit_code`
- **`clean --force`** — skip confirmation
- **`deploy -y` / `--yes`** — non-interactive confirm + Clarinet fee prompts
- JSON error payloads include `code` + `exit_code` (no double-print in JSON mode)

---

## New crate: `stacksdapp-shell`

- Shared verbosity / quiet / color / JSON output helpers
- Project-root discovery + `stacksdapp.toml` defaults
- Shared UI primitives (`steps.rs`): banners, kv rows, rules, **live spinners** (`LiveStep`) used by `add` / `dev` (and aligned with deploy UX)

---

## Terminal UX

### `stacksdapp new`
- Lavender **STACKSDAPP** wordmark, framework overview box, dual-column next steps, docs footer (`cli_style.rs`)
- Respects quiet / JSON modes

### `stacksdapp add`
- Banner **Adding Contract ✨**
- Spinner steps: created contract → updated config → generated bindings
- Quiet nested codegen; Created / Generated / Next summary

### `stacksdapp deploy`
- New `crates/deployer/src/ui.rs`: network banner, live steps, single progress bar (finalize once), confirmation chrome, success footer with **per-tx Hiro explorer links**
- Softened Clarinet generate/apply noise

### `stacksdapp dev`
- Banner **Development Mode 🌱**
- Spinner steps: environment → connected to network → bindings ready → Next.js started (waits until Ready)
- Local URL panel + “Watching for file changes…”
- Compact logs: `[HH:MM:SS] ✓ Rebuilt…`, HTTP access lines, `✓ Contract bindings updated`
- Remote (`testnet`/`mainnet`) also runs the contract watcher
- Clarinet/Next startup noise filtered during spinner phase

---

## Safety & correctness

- **`new` / `add`**: reject path traversal, absolute paths, invalid Clarity identifiers (length / charset)
- **Deploy / devnet:** Node broadcast payload via **stdin** (private keys no longer on argv / `ps`)
- **Codegen:** `generate_all_quiet()` for nested CLI steps; skip false **REDEPLOYMENT REQUIRED** when `deployments.json` is empty or `network=""`
- **Doctor:** meaningful non-zero exit on failed checks (was always `0`)
- Deploy confirmation hardened for non-TTY / mainnet + `--yes`

---

## Scaffold / project model

- Emit / respect **`stacksdapp.toml`** for root markers and shell config
- Quiet / JSON-aware scaffolding output (no banner spam under `-q` / `--json`)

---

## Watcher

- Regenerate via quiet codegen
- Timestamped `✓ Contract bindings updated` (and failure) lines instead of noisy `[watcher]` / `[generate]` dumps

---

## CI / release / docs

- **CI:** pin Clarinet **3.21.1**; real smoke job via `scripts/ci-smoke.sh` (doctor → new → check → generate → add → test)
- **Release workflow** (`.github/workflows/release.yml`): build + package binaries for
  - `x86_64-unknown-linux-gnu`
  - `aarch64-apple-darwin`
  - `x86_64-apple-darwin`
  → GitHub Release on `v*` tags (also `workflow_dispatch`)
- **Docs:** reconstructed **CHANGELOG** from **v0.1.0 → 0.2.0**, **CONTRIBUTING.md**, README command table (init/doctor/upgrade/completions, global flags, exit codes, `-y` / `--force` / `--strict`)
- **`.gitignore`:** keep local-only verify helpers out of git (`verify-p0`, `verify-e2e`, `verify-p1-*`, `verify-functional`, `check-versions`, `pub.sh`); track **`scripts/ci-smoke.sh`**