### PR TITLE
Release 0.2.0: CLI hardening, audit fixes, and reliable Devnet boot/deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Version history is reconstructed from git tags, `cli/Cargo.toml` version bumps, and commit messages.
 
-> **Note:** Only **`v0.1.9`** is git-tagged today. Intermediate versions (`0.1.0`–`0.1.8`) were published to crates.io
+> **Note:** Only **`v0.1.9`** is git-tagged today. Intermediate versions (`0.1.0`–`0.1.8`) were published to crates.io without tags in this repository.
 
 ---
 
-## [0.2.0] — 2026-07-20 [Unreleased]
-
-### Fixed
-- Production audit remediation: deploy dry-run snapshot/restore, fail-closed txid parsing, init/add rollback, quiet/json output in deploy UI and watcher, partial deploy state recovery (devnet + remote Clarinet apply).
-- `defaults.network` validation from `stacksdapp.toml`; invalid values rejected at CLI dispatch.
-- Human error output uses `{e:#}` instead of Debug formatting.
-- `--json` success payloads for `new`, `init`, `add`, `deploy`, `dev`, and `upgrade`.
-- `reorder_clarinet_toml` restores `Clarinet.toml` on deploy pipeline failure.
-- Release scripts (`check-versions.sh`, `pub.sh`) and `LICENSE` tracked in git.
-- Workspace crate versions aligned to `0.2.0`.
+## [0.2.0] - Unreleased
 
 ### Added
 
-- CI: `cargo clippy`, `verify-e2e.sh`, production hardening and frontend build/typecheck jobs.
-- Parser unit tests, scaffold proptest fuzz on name validation, init rollback tests.
-
-## [0.2.0] — 2026-07-14 [Unreleased]
-
-### Added
-
-- Stable CLI exit codes via typed `CliError` (`thiserror`):
-  - `2` project not found / invalid `--root`
-  - `3` prerequisite / `doctor` failure
-  - `4` user aborted (confirmations)
-  - `5` validation (names, args)
-  - `6` type-check failed
-  - `7` tests failed
-  - `8` deploy failed
-  - `10` generate / codegen failed
-- New crate **`stacksdapp-shell`**: shared `-v` / `-q` / `--color` / `--json` output and project-root discovery.
+- Stable CLI exit codes via typed `CliError` (`thiserror`): `2` project not found, `3` prerequisite/doctor, `4` user aborted, `5` validation, `6` type-check, `7` tests, `8` deploy, `10` generate.
+- New crate **`stacksdapp-shell`**: shared `-v` / `-q` / `--color` / `--json` output, project-root discovery, and spinner-safe `println_human_safe`.
 - Global flags: `-v` / `-vv…`, `-q`, `--color auto|always|never`, `--json`, `--root` (`STACKSDAPP_ROOT`).
 - Project root walk-up via `stacksdapp.toml` or `contracts/Clarinet.toml`.
 - `stacksdapp completions <shell>` (alias `com`) for bash, zsh, fish, powershell, elvish.
@@ -48,14 +24,24 @@ Version history is reconstructed from git tags, `cli/Cargo.toml` version bumps, 
 - `clean --force` — skip confirmation prompt.
 - `deploy -y` / `--yes` — non-interactive deploy and Clarinet fee prompts.
 - GitHub Actions **Release** workflow (multi-target binaries + GitHub Release on `v*` tags).
-- `scripts/check-versions.sh`, `CONTRIBUTING.md`, and local verify scripts under `scripts/`.
-- CI Clarinet pin **3.21.1** and real smoke integration job (`scripts/ci-smoke.sh`).
+- CI: Clarinet pin **3.21.1**, `cargo clippy`, `verify-e2e.sh`, audit-fix regression checks, frontend build/typecheck, and smoke integration (`scripts/ci-smoke.sh`).
+- `scripts/check-versions.sh`, `CONTRIBUTING.md`, MIT `LICENSE`, and local verify scripts under `scripts/`.
+- `--json` success payloads for `new`, `init`, `add`, `deploy`, `dev`, and `upgrade`.
+- Parser unit tests, scaffold proptest fuzz on name validation, and init rollback tests.
+- Devnet readiness panel: local URL, tip height, and deploy hint after `stacksdapp dev`.
+- Devnet deploy waits for Clarinet epoch burn height before broadcasting Clarity 5 contracts (epoch 3.4 / burn ≥ 150).
+- Devnet deploy success points to the running local app (`http://localhost:3000` or `:3001`) instead of restarting dev.
 
 ### Changed
 
 - `pub.sh` resolves repo root from script path, publishes `stacksdapp-shell`, requires clean git worktree by default (`--allow-dirty` opt-in).
 - README command table: `init`, `doctor`, `upgrade`, `completions`, global flags, exit codes.
 - JSON error payloads include `code` and `exit_code`; doctor JSON includes `exit_code`.
+- Default scaffold `Devnet.toml`: snapshot-friendly (no PoX stacking orders, explorers off, `bitcoin_controller_block_time = 15_000` for stable Nakamoto block production).
+- `stacksdapp dev` starts Clarinet with `--no-dashboard` and `--from-genesis` to avoid snapshot stalls and Clarinet 3.21 / stacks-core 3.4 config skew.
+- Devnet deploy uses `@stacks/transactions` v7 `broadcastTransaction` against stacks core (`:20443`) instead of removed `broadcastRawTransaction`.
+- Devnet node readiness and deploy confirmation poll stacks core (`:20443`), not stacks-api alone.
+- Workspace crate versions aligned to `0.2.0`.
 
 ### Fixed
 
@@ -64,6 +50,14 @@ Version history is reconstructed from git tags, `cli/Cargo.toml` version bumps, 
 - Devnet Node broadcast no longer passes private keys on argv (stdin payload).
 - False `REDEPLOYMENT REQUIRED` when `deployments.json` is empty or `network=""`.
 - JSON mode avoids double-printing error objects.
+- Production audit remediation: deploy dry-run snapshot/restore, fail-closed txid parsing, init/add rollback, quiet/json output in deploy UI and watcher, partial deploy state recovery (devnet + remote Clarinet apply).
+- Testnet deploy no longer hangs after broadcast — exit Clarinet once all contracts are in the mempool when confirmation is not required.
+- `defaults.network` validation from `stacksdapp.toml`; invalid values rejected at CLI dispatch.
+- Human error output uses `{e:#}` instead of Debug formatting.
+- `reorder_clarinet_toml` restores `Clarinet.toml` on deploy pipeline failure.
+- **Devnet boot:** auto-answer Clarinet snapshot “continue? (y/N)” prompt; strip incompatible `pox_5_*` keys from generated `Stacks.toml`; fail fast when stacks-node container exits; stop stale Clarinet Docker on `dev` and `clean`.
+- **Devnet UX:** spinner no longer corrupted by Clarinet/codegen logs (`STACKSDAPP_QUIET`, stdout lock); wait for sustained tip advancement before “ready”.
+- **Devnet deploy:** epoch-gated publishes no longer accepted to mempool then left unmined; skip re-broadcast when contract already on core; reject broadcast API error responses; omit misleading Hiro explorer link on devnet success.
 
 ---
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -633,6 +633,8 @@ async fn run_clean(force: bool) -> Result<()> {
     }
 
     if targets.is_empty() {
+        // Still stop leftover containers — common when only Docker state remains.
+        stacksdapp_process_supervisor::stop_stale_devnet_docker();
         status("[clean] Nothing to remove.".green().to_string());
         if shell::is_json() {
             shell::emit_json(&json!({
@@ -672,6 +674,9 @@ async fn run_clean(force: bool) -> Result<()> {
             .cyan()
             .to_string(),
     );
+
+    // Free Clarinet Docker ports (5432/20445/…) — file cleanup alone is not enough.
+    stacksdapp_process_supervisor::stop_stale_devnet_docker();
 
     let mut removed = Vec::new();
     for (path, kind) in &targets {

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -91,6 +91,11 @@ async fn generate_all_impl(quiet: bool) -> Result<()> {
         );
     }
 
+    // Silence nested export-abi status lines while a parent spinner owns the TTY.
+    if quiet {
+        std::env::set_var("STACKSDAPP_QUIET", "1");
+    }
+
     let log = |msg: String| {
         if !quiet {
             println!("{msg}");

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -62,6 +62,10 @@ struct DeploymentPlan {
 #[derive(Debug, Deserialize, Serialize)]
 struct DeploymentBatch {
     transactions: Vec<DeploymentTransaction>,
+    /// Clarinet epoch gate for this batch (e.g. "3.4"). Publishes before this
+    /// burn height are accepted to mempool then never mined.
+    #[serde(default)]
+    epoch: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -76,6 +80,12 @@ struct DeploymentTransaction {
     path: Option<String>,
     #[serde(rename = "clarity-version")]
     clarity_version: Option<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedPublish {
+    tx: DeploymentTransaction,
+    epoch: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -112,7 +122,45 @@ struct PlannedRename {
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 pub async fn wait_for_devnet_node() -> Result<()> {
-    wait_for_node("http://localhost:3999").await
+    // Prefer stacks core (:20443). The indexer API (:3999) can look healthy while
+    // core is still booting or stalled — which breaks broadcast/deploy.
+    wait_for_devnet_core_ready().await
+}
+
+async fn wait_for_devnet_core_ready() -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()?;
+    let mut first_tip: Option<u64> = None;
+    for attempt in 1..=90 {
+        if let Ok(Some(height)) = fetch_core_tip_height(&client).await {
+            match first_tip {
+                None => first_tip = Some(height),
+                Some(first) if height > first => return Ok(()),
+                // Tip already advanced before we started watching — core is live.
+                Some(_) if attempt >= 3 => return Ok(()),
+                _ => {}
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+    Err(anyhow!(
+        "Local Stacks core at http://localhost:20443 did not become ready after 180s.\n\
+         Make sure `stacksdapp dev` is running, Docker is started, and the tip is advancing.\n\
+         If ports conflict or the tip stalls: stacksdapp clean --force && stacksdapp dev"
+    ))
+}
+
+async fn fetch_core_tip_height(client: &reqwest::Client) -> Result<Option<u64>> {
+    let response = client
+        .get("http://localhost:20443/v2/info")
+        .send()
+        .await?;
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    let json: serde_json::Value = response.json().await?;
+    Ok(json.get("stacks_tip_height").and_then(|v| v.as_u64()))
 }
 
 pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: bool) -> Result<()> {
@@ -130,7 +178,7 @@ pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: b
     let ui = DeployUi::start(network, &config.stacks_node);
 
     if network == "devnet" {
-        wait_for_node(&config.stacks_node).await?;
+        wait_for_devnet_node().await?;
     }
 
     deploy_via_clarinet(&ui, network, contract, dry_run, yes).await
@@ -776,27 +824,55 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
 
     let expected_sender = transactions
         .first()
-        .and_then(|tx| tx.expected_sender.clone())
+        .and_then(|item| item.tx.expected_sender.clone())
         .ok_or_else(|| anyhow!("No expected sender found in the devnet deployment plan."))?;
-    let mut nonce = fetch_local_core_nonce(&expected_sender).await?;
     let script_path = write_devnet_broadcast_script()?;
     let mut captured_stdout = String::new();
+
+    // Clarity 5 / epoch 3.4 publishes must wait until burn height unlocks that epoch.
+    // Broadcasting earlier returns a txid, then the tx sits unmined forever (nonce stays put).
+    let required_burn = transactions
+        .iter()
+        .map(|item| min_burn_height_for_publish(item.epoch.as_deref(), item.tx.clarity_version))
+        .max()
+        .unwrap_or(0);
+    if required_burn > 0 {
+        wait_for_burn_height(required_burn).await?;
+    }
 
     ui.broadcasting_start();
     let expected = transactions.len().max(1);
     ui.render_bar(0, expected);
 
-    for (i, tx) in transactions.into_iter().enumerate() {
+    let mut broadcast_count = 0usize;
+    for item in transactions.into_iter() {
+        let tx = item.tx;
         let contract_name = tx
             .contract_name
             .clone()
             .ok_or_else(|| anyhow!("Missing contract name in deployment plan."))?;
+
+        if contract_source_exists(&expected_sender, &contract_name).await? {
+            stacksdapp_shell::println_human_safe(format!(
+                "[deploy] {contract_name} already on core — skipping broadcast."
+            ));
+            // Still record a synthetic success marker so deployments.json is written.
+            captured_stdout.push_str(&format!(
+                "Broadcasted ContractPublish(StandardPrincipalData({}), ContractName(\"{contract_name}\"), \"already-deployed\")\n",
+                expected_sender,
+            ));
+            broadcast_count += 1;
+            ui.render_bar(broadcast_count, expected);
+            ui.contract_broadcast_ok(&contract_name, "already-deployed");
+            continue;
+        }
+
         let contract_path = tx.path.clone().ok_or_else(|| {
             anyhow!("Missing contract path for {contract_name} in deployment plan.")
         })?;
-        let fee = tx.cost.unwrap_or(0);
-        // Non-secret metadata only on the wire via stdin
-        // (visible in `ps`). The Node bridge reads one JSON object from stdin.
+        let fee = tx.cost.unwrap_or(10_000).max(1);
+        // Always read nonce from core so skips / prior confirms stay consistent.
+        let nonce = fetch_local_core_nonce(&expected_sender).await?;
         let args = serde_json::json!({
             "contractName": contract_name,
             "codePath": contract_path,
@@ -821,7 +897,6 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
                 .take()
                 .ok_or_else(|| anyhow!("Failed to open node stdin for devnet broadcast"))?;
             stdin.write_all(args.to_string().as_bytes()).await?;
-            // Closing stdin signals EOF so the Node script can finish reading.
         }
 
         let output = child
@@ -832,12 +907,11 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if i > 0 {
+            if broadcast_count > 0 {
                 write_partial_deployments_from_output(ui, network, &captured_stdout, None).await?;
                 return Err(anyhow!(
-                    "Partial devnet deployment: {}/{expected} contracts broadcast and recorded in deployments.json.\n\
+                    "Partial devnet deployment: {broadcast_count}/{expected} contracts broadcast and recorded in deployments.json.\n\
                      Failed on {contract_name}.\nstdout:\n{}\nstderr:\n{}",
-                    i,
                     stdout.trim(),
                     stderr.trim()
                 ));
@@ -853,7 +927,7 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
         let result: serde_json::Value = match serde_json::from_str(stdout.trim()) {
             Ok(value) => value,
             Err(e) => {
-                if i > 0 {
+                if broadcast_count > 0 {
                     write_partial_deployments_from_output(ui, network, &captured_stdout, None)
                         .await?;
                 }
@@ -863,10 +937,19 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
                 ));
             }
         };
+        if result.get("error").is_some() || result.get("reason").is_some() {
+            if broadcast_count > 0 {
+                write_partial_deployments_from_output(ui, network, &captured_stdout, None).await?;
+            }
+            return Err(anyhow!(
+                "Devnet broadcast rejected for {contract_name}: {}",
+                stdout.trim()
+            ));
+        }
         let txid = match result.get("txid").and_then(|value| value.as_str()) {
             Some(txid) => txid,
             None => {
-                if i > 0 {
+                if broadcast_count > 0 {
                     write_partial_deployments_from_output(ui, network, &captured_stdout, None)
                         .await?;
                 }
@@ -883,9 +966,9 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
             tx.contract_name.as_deref().unwrap_or(""),
             txid,
         ));
-        ui.render_bar(i + 1, expected);
+        broadcast_count += 1;
+        ui.render_bar(broadcast_count, expected);
         ui.contract_broadcast_ok(tx.contract_name.as_deref().unwrap_or(""), txid);
-        nonce += 1;
     }
 
     Ok(captured_stdout)
@@ -909,14 +992,107 @@ async fn read_deployment_plan(network: &str) -> Result<DeploymentPlanFile> {
         .map_err(|e| anyhow!("Failed to parse deployment plan at {plan_path}: {e}"))
 }
 
-fn flatten_contract_publishes(plan: &DeploymentPlanFile) -> Vec<DeploymentTransaction> {
+fn flatten_contract_publishes(plan: &DeploymentPlanFile) -> Vec<PlannedPublish> {
     plan.plan
         .batches
         .iter()
-        .flat_map(|batch| batch.transactions.iter())
-        .filter(|tx| tx.transaction_type == "contract-publish")
-        .cloned()
+        .flat_map(|batch| {
+            batch
+                .transactions
+                .iter()
+                .filter(|tx| tx.transaction_type == "contract-publish")
+                .map(|tx| PlannedPublish {
+                    tx: tx.clone(),
+                    epoch: batch.epoch.clone(),
+                })
+        })
         .collect()
+}
+
+/// Clarinet's default Devnet epoch activation burn heights (Stacks.toml).
+fn clarinet_default_epoch_start(epoch: &str) -> Option<u64> {
+    match epoch.trim() {
+        "2.0" | "2.05" => Some(100),
+        "2.1" => Some(101),
+        "2.2" => Some(102),
+        "2.3" => Some(103),
+        "2.4" => Some(104),
+        "2.5" => Some(108),
+        "3.0" => Some(142),
+        "3.1" => Some(144),
+        "3.2" => Some(146),
+        "3.3" => Some(148),
+        "3.4" => Some(150),
+        "4.0" => Some(152),
+        _ => None,
+    }
+}
+
+fn min_burn_height_for_publish(epoch: Option<&str>, clarity_version: Option<u8>) -> u64 {
+    if let Some(epoch) = epoch {
+        if let Some(height) = clarinet_default_epoch_start(epoch) {
+            return height;
+        }
+    }
+    match clarity_version {
+        // Clarity 5 activates with epoch 3.4 on Clarinet's default Devnet schedule.
+        Some(v) if v >= 5 => 150,
+        Some(v) if v >= 4 => 142,
+        _ => 0,
+    }
+}
+
+async fn wait_for_burn_height(min_burn: u64) -> Result<()> {
+    let mut last_log = std::time::Instant::now() - std::time::Duration::from_secs(30);
+    for _ in 0..120 {
+        match fetch_local_core_info().await {
+            Ok(info) if info.burn_block_height >= min_burn => {
+                stacksdapp_shell::println_human_safe(format!(
+                    "[deploy] Burn height {} reached (needed ≥ {min_burn} for plan epoch) — broadcasting.",
+                    info.burn_block_height
+                ));
+                return Ok(());
+            }
+            Ok(info) => {
+                if last_log.elapsed() >= std::time::Duration::from_secs(8) {
+                    stacksdapp_shell::println_human_safe(format!(
+                        "[deploy] Waiting for epoch burn height {min_burn} (currently {})...",
+                        info.burn_block_height
+                    ));
+                    last_log = std::time::Instant::now();
+                }
+            }
+            Err(_) => {
+                if last_log.elapsed() >= std::time::Duration::from_secs(8) {
+                    stacksdapp_shell::println_human_safe(
+                        "[deploy] Waiting for local stacks-node before epoch check...",
+                    );
+                    last_log = std::time::Instant::now();
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+    Err(anyhow!(
+        "Timed out waiting for burn height ≥ {min_burn}.\n\
+         Clarity 5 / epoch 3.4 contracts cannot mine before that height on Clarinet Devnet.\n\
+         Keep `stacksdapp dev` running and retry deploy once burn height catches up."
+    ))
+}
+
+async fn contract_source_exists(deployer: &str, contract_name: &str) -> Result<bool> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()?;
+    let url = format!(
+        "http://localhost:20443/v2/contracts/source/{deployer}/{contract_name}?proof=0"
+    );
+    Ok(client
+        .get(&url)
+        .send()
+        .await
+        .map(|response| response.status().is_success())
+        .unwrap_or(false))
 }
 
 fn write_devnet_broadcast_script() -> Result<std::path::PathBuf> {
@@ -929,17 +1105,36 @@ fn write_devnet_broadcast_script() -> Result<std::path::PathBuf> {
 
 /// Node bridge for direct devnet publishes. Payload (including senderKey) is read
 /// from stdin — never from argv — so keys do not appear in `ps`.
+///
+/// Uses `broadcastTransaction` (@stacks/transactions v6+/v7) — `broadcastRawTransaction`
+/// was removed and must not be used. Testnet/mainnet still go through Clarinet apply.
 const DEVNET_BROADCAST_SCRIPT: &str = r#"
 import fs from 'fs';
+import path from 'path';
 import { createRequire } from 'module';
 
-const require = createRequire(`${process.cwd()}/package.json`);
+function loadStacksTransactions() {
+  const roots = [process.cwd(), path.join(process.cwd(), '..', 'frontend')];
+  const errors = [];
+  for (const root of roots) {
+    try {
+      const require = createRequire(path.join(root, 'package.json'));
+      return require('@stacks/transactions');
+    } catch (err) {
+      errors.push(`${root}: ${err?.message || err}`);
+    }
+  }
+  throw new Error(
+    `Unable to load @stacks/transactions. Tried contracts/ and frontend/. ${errors.join(' | ')}`
+  );
+}
+
 const {
   makeContractDeploy,
   AnchorMode,
   PostConditionMode,
-  broadcastRawTransaction,
-} = require('@stacks/transactions');
+  broadcastTransaction,
+} = loadStacksTransactions();
 
 // Read deploy payload from stdin so the private key never appears in process argv.
 const chunks = [];
@@ -955,21 +1150,24 @@ const transaction = await makeContractDeploy({
   senderKey: input.senderKey,
   fee: BigInt(input.fee),
   nonce: BigInt(input.nonce),
-  network: 'testnet',
+  network: 'devnet',
   anchorMode: AnchorMode.OnChainOnly,
   postConditionMode: PostConditionMode.Deny,
   ...(typeof input.clarityVersion === 'number' ? { clarityVersion: input.clarityVersion } : {}),
 });
 
-const response = await broadcastRawTransaction(
-  transaction.serialize(),
-  'http://localhost:20443/v2/transactions',
-);
+// Prefer core RPC (:20443) so deploy works even if stacks-api is lagging on new_block.
+const response = await broadcastTransaction({
+  transaction,
+  client: { baseUrl: 'http://localhost:20443' },
+});
 
-console.log(JSON.stringify(response));
-if (!response?.txid) {
+// @stacks/transactions returns error JSON (no throw) on non-2xx — treat as failure.
+if (response?.error || response?.reason || !response?.txid) {
+  console.log(JSON.stringify(response));
   process.exit(1);
 }
+console.log(JSON.stringify(response));
 "#;
 
 async fn fetch_local_core_nonce(address: &str) -> Result<u64> {
@@ -1361,31 +1559,6 @@ fn replace_contract_reference(source: &str, old_name: &str, new_name: &str) -> S
     out
 }
 
-async fn wait_for_node(url: &str) -> Result<()> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
-        .build()?;
-    for attempt in 1..=60 {
-        if client
-            .get(format!("{url}/v2/info"))
-            .send()
-            .await
-            .map(|r| r.status().is_success())
-            .unwrap_or(false)
-        {
-            return Ok(());
-        }
-        if attempt % 10 == 0 {
-            // Quiet wait — only fail after timeout.
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    }
-    Err(anyhow!(
-        "Stacks node at {url} did not become ready after 60s.\n\
-         Make sure `stacksdapp dev` is running and Docker is started."
-    ))
-}
-
 fn parse_broadcast_line(line: &str) -> Option<(String, String)> {
     let cn_marker = "ContractName(\"";
     let name = {
@@ -1394,11 +1567,17 @@ fn parse_broadcast_line(line: &str) -> Option<(String, String)> {
         let end = rest.find('"')?;
         rest[..end].to_string()
     };
-    let txid = line
+    if let Some(txid) = line
         .split('"')
-        .find(|part| part.len() == 64 && part.chars().all(|c| c.is_ascii_hexdigit()))?
-        .to_string();
-    Some((name, txid))
+        .find(|part| part.len() == 64 && part.chars().all(|c| c.is_ascii_hexdigit()))
+    {
+        return Some((name, txid.to_string()));
+    }
+    // Direct-deploy skip when the contract is already live on local core.
+    if line.contains("\"already-deployed\"") {
+        return Some((name, "already-deployed".to_string()));
+    }
+    None
 }
 
 async fn write_deployments_json_from_output(
@@ -1463,6 +1642,7 @@ async fn write_deployments_json_from_output(
             .lines()
             .any(|line| line.contains("Broadcasted") && line.contains(&broadcast_marker));
         let txid = match txid_map.get(name) {
+            Some(t) if t == "already-deployed" => String::new(),
             Some(t) => {
                 if t.starts_with("0x") {
                     t.clone()
@@ -1606,7 +1786,7 @@ async fn deployment_contract_names_from_plan(network: &str) -> Result<Vec<String
     let plan = read_deployment_plan(network).await?;
     let names = flatten_contract_publishes(&plan)
         .into_iter()
-        .filter_map(|tx| tx.contract_name)
+        .filter_map(|item| item.tx.contract_name)
         .collect::<Vec<_>>();
     if names.is_empty() {
         return Err(anyhow!(
@@ -1628,7 +1808,8 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
     let initial_info = fetch_local_core_info().await.ok();
 
     // Quietly wait for local core to expose published contracts.
-    for attempt in 1..=30 {
+    // 15s block times need more than 30s; epoch-gated publishes may confirm a bit later.
+    for attempt in 1..=90 {
         let mut pending = Vec::new();
 
         for contract_name in contract_names {
@@ -1666,7 +1847,9 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
                 end.burn_block_height, end.stacks_tip_height
             )
         }
-        _ => "Local devnet tip did move during the wait, so the publish appears to be stuck independently of tip progression.".to_string(),
+        _ => "Local devnet tip did move during the wait, so the publish appears to be stuck independently of tip progression.\n\
+              Common cause: Clarity 5 contracts were broadcast before burn height 150 (epoch 3.4) — they sit unmined. Re-run deploy after the latest stacksdapp fix (it waits for that epoch)."
+            .to_string(),
     };
 
     Err(anyhow!(
@@ -1890,6 +2073,45 @@ mod tests {
             super::DEVNET_BROADCAST_SCRIPT.contains("process.stdin"),
             "deploy payload must be read from stdin"
         );
+        assert!(
+            super::DEVNET_BROADCAST_SCRIPT.contains("broadcastTransaction"),
+            "must use @stacks/transactions broadcastTransaction (v7+)"
+        );
+        assert!(
+            !super::DEVNET_BROADCAST_SCRIPT.contains("broadcastRawTransaction"),
+            "broadcastRawTransaction was removed from @stacks/transactions v7"
+        );
+    }
+
+    #[test]
+    fn min_burn_height_gates_clarity5_and_epoch_34() {
+        assert_eq!(super::min_burn_height_for_publish(Some("3.4"), Some(5)), 150);
+        assert_eq!(super::min_burn_height_for_publish(None, Some(5)), 150);
+        assert_eq!(super::min_burn_height_for_publish(Some("3.0"), Some(3)), 142);
+        assert_eq!(super::min_burn_height_for_publish(None, Some(2)), 0);
+    }
+
+    #[test]
+    fn flatten_publishes_keeps_batch_epoch() {
+        let plan = super::DeploymentPlanFile {
+            plan: super::DeploymentPlan {
+                batches: vec![super::DeploymentBatch {
+                    epoch: Some("3.4".into()),
+                    transactions: vec![super::DeploymentTransaction {
+                        transaction_type: "contract-publish".into(),
+                        contract_name: Some("counter".into()),
+                        expected_sender: Some("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into()),
+                        cost: Some(4850),
+                        path: Some("contracts/counter.clar".into()),
+                        clarity_version: Some(5),
+                    }],
+                }],
+            },
+        };
+        let pubs = super::flatten_contract_publishes(&plan);
+        assert_eq!(pubs.len(), 1);
+        assert_eq!(pubs[0].epoch.as_deref(), Some("3.4"));
+        assert_eq!(pubs[0].tx.contract_name.as_deref(), Some("counter"));
     }
 
     #[test]

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -152,10 +152,7 @@ async fn wait_for_devnet_core_ready() -> Result<()> {
 }
 
 async fn fetch_core_tip_height(client: &reqwest::Client) -> Result<Option<u64>> {
-    let response = client
-        .get("http://localhost:20443/v2/info")
-        .send()
-        .await?;
+    let response = client.get("http://localhost:20443/v2/info").send().await?;
     if !response.status().is_success() {
         return Ok(None);
     }
@@ -1084,9 +1081,8 @@ async fn contract_source_exists(deployer: &str, contract_name: &str) -> Result<b
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
-    let url = format!(
-        "http://localhost:20443/v2/contracts/source/{deployer}/{contract_name}?proof=0"
-    );
+    let url =
+        format!("http://localhost:20443/v2/contracts/source/{deployer}/{contract_name}?proof=0");
     Ok(client
         .get(&url)
         .send()
@@ -2085,9 +2081,15 @@ mod tests {
 
     #[test]
     fn min_burn_height_gates_clarity5_and_epoch_34() {
-        assert_eq!(super::min_burn_height_for_publish(Some("3.4"), Some(5)), 150);
+        assert_eq!(
+            super::min_burn_height_for_publish(Some("3.4"), Some(5)),
+            150
+        );
         assert_eq!(super::min_burn_height_for_publish(None, Some(5)), 150);
-        assert_eq!(super::min_burn_height_for_publish(Some("3.0"), Some(3)), 142);
+        assert_eq!(
+            super::min_burn_height_for_publish(Some("3.0"), Some(3)),
+            142
+        );
         assert_eq!(super::min_burn_height_for_publish(None, Some(2)), 0);
     }
 

--- a/crates/deployer/src/ui.rs
+++ b/crates/deployer/src/ui.rs
@@ -2,6 +2,7 @@
 
 use colored::Colorize;
 use std::io::{self, Write};
+use std::net::{SocketAddr, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -346,43 +347,59 @@ impl DeployUi {
 
         println!("{}", "Next".bold().white());
         println!();
-        println!(
-            "{}",
-            format!("stacksdapp dev --network {}", self.network)
-                .truecolor(52, 211, 153)
-                .bold()
-        );
-        println!();
-
-        let chain = match self.network.as_str() {
-            "mainnet" => "mainnet",
-            "devnet" => "devnet",
-            _ => "testnet",
-        };
-        let explorer_urls: Vec<String> = entries
-            .iter()
-            .filter(|(_, _, txid)| !txid.is_empty())
-            .map(|(_, _, txid)| {
-                format!(
-                    "https://explorer.hiro.so/txid/{}?chain={chain}",
-                    txid.trim_start_matches("0x")
-                )
-            })
-            .collect();
-
-        if !explorer_urls.is_empty() {
-            println!("{}", "Explorer".bold().white());
-            println!();
-            for url in explorer_urls {
-                println!("{}", url.truecolor(167, 139, 250));
-            }
-            println!();
+        if self.network == "devnet" {
+            let local_url = detect_local_frontend_url();
             println!(
                 "{}",
-                "Note: the explorer link may take 10–15 seconds to show the transaction while it indexes."
+                format!("Open {local_url} in your browser")
+                    .truecolor(52, 211, 153)
+                    .bold()
+            );
+            println!(
+                "{}",
+                "(Devnet is already running from `stacksdapp dev` — use the Debug Contracts panel to interact.)"
                     .truecolor(156, 163, 175)
             );
-            println!();
+        } else {
+            println!(
+                "{}",
+                format!("stacksdapp dev --network {}", self.network)
+                    .truecolor(52, 211, 153)
+                    .bold()
+            );
+        }
+        println!();
+
+        if self.network != "devnet" {
+            let chain = match self.network.as_str() {
+                "mainnet" => "mainnet",
+                _ => "testnet",
+            };
+            let explorer_urls: Vec<String> = entries
+                .iter()
+                .filter(|(_, _, txid)| !txid.is_empty() && *txid != "already-deployed")
+                .map(|(_, _, txid)| {
+                    format!(
+                        "https://explorer.hiro.so/txid/{}?chain={chain}",
+                        txid.trim_start_matches("0x")
+                    )
+                })
+                .collect();
+
+            if !explorer_urls.is_empty() {
+                println!("{}", "Explorer".bold().white());
+                println!();
+                for url in explorer_urls {
+                    println!("{}", url.truecolor(167, 139, 250));
+                }
+                println!();
+                println!(
+                    "{}",
+                    "Note: the explorer link may take 10–15 seconds to show the transaction while it indexes."
+                        .truecolor(156, 163, 175)
+                );
+                println!();
+            }
         }
 
         let secs = self.start.elapsed().as_secs_f64();
@@ -433,6 +450,19 @@ pub fn short_txid(txid: &str) -> String {
         return txid.to_string();
     }
     format!("{}...{}", &t[..8], &t[t.len().saturating_sub(7)..])
+}
+
+/// Best-effort detect where `stacksdapp dev` is serving the Next.js app.
+fn detect_local_frontend_url() -> String {
+    for port in [3000u16, 3001] {
+        let Ok(addr) = format!("127.0.0.1:{port}").parse::<SocketAddr>() else {
+            continue;
+        };
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(250)).is_ok() {
+            return format!("http://localhost:{port}");
+        }
+    }
+    "http://localhost:3000".to_string()
 }
 
 #[cfg(test)]

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -176,8 +176,9 @@ pub async fn parse_project(contracts_dir: &Path) -> Result<Vec<ContractAbi>> {
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // Print stderr always so the developer sees what the script actually said
-    if !stderr.trim().is_empty() {
+    // Keep nested quiet generates clean (e.g. `stacksdapp dev` spinner steps).
+    let quiet = std::env::var_os("STACKSDAPP_QUIET").is_some();
+    if !quiet && !stderr.trim().is_empty() {
         eprintln!("[export-abi] {}", stderr.trim());
     }
 

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -113,20 +113,14 @@ fn print_ready_panel(network: &str, local_url: &str, tip_height: Option<u64>) {
     }
     println!();
     if network == "devnet" {
-        stacksdapp_shell::kv(
-            "Deploy",
-            "stacksdapp deploy --network devnet",
-        );
+        stacksdapp_shell::kv("Deploy", "stacksdapp deploy --network devnet");
         println!(
             "{}",
             "  Tip must keep advancing before deploy; stalled tips need: stacksdapp clean && stacksdapp dev"
                 .truecolor(156, 163, 175)
         );
     } else {
-        stacksdapp_shell::kv(
-            "Deploy",
-            &format!("stacksdapp deploy --network {network}"),
-        );
+        stacksdapp_shell::kv("Deploy", &format!("stacksdapp deploy --network {network}"));
     }
     println!();
     stacksdapp_shell::rule();
@@ -182,7 +176,11 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
 
     let mut clarinet = spawn_clarinet_devnet()?;
     let fatal = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
-    attach_filtered_output(&mut clarinet, OutputStyle::Clarinet, std::sync::Arc::clone(&fatal));
+    attach_filtered_output(
+        &mut clarinet,
+        OutputStyle::Clarinet,
+        std::sync::Arc::clone(&fatal),
+    );
 
     // Clarinet 3.21.x writes pox_5_* keys into Stacks.toml that stacks-core 3.4
     // (Clarinet's default image) rejects, so stacks-node dies instantly. Patch the
@@ -803,17 +801,13 @@ fn attach_filtered_output(
     // Clarinet 3.2+ may prompt: "Do you want to continue? (y/N)" when the default
     // snapshot is incompatible with built-in PoX stacking defaults. Without an answer,
     // Docker never starts and we hang forever waiting for :20443.
-    let stdin = child.stdin.take().map(|s| {
-        std::sync::Arc::new(tokio::sync::Mutex::new(Some(s)))
-    });
+    let stdin = child
+        .stdin
+        .take()
+        .map(|s| std::sync::Arc::new(tokio::sync::Mutex::new(Some(s))));
 
     if let Some(stdout) = child.stdout.take() {
-        spawn_filtered_stream(
-            stdout,
-            style,
-            std::sync::Arc::clone(&fatal),
-            stdin.clone(),
-        );
+        spawn_filtered_stream(stdout, style, std::sync::Arc::clone(&fatal), stdin.clone());
     }
     if let Some(stderr) = child.stderr.take() {
         spawn_filtered_stream(stderr, style, fatal, stdin);

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -33,7 +33,11 @@ async fn prefetch_requirements() -> Result<()> {
             )
         })?;
 
-    attach_filtered_output(&mut child, OutputStyle::Clarinet);
+    attach_filtered_output(
+        &mut child,
+        OutputStyle::Clarinet,
+        std::sync::Arc::new(std::sync::Mutex::new(None)),
+    );
 
     let status = child.wait().await?;
     if !status.success() {
@@ -96,7 +100,7 @@ fn network_display(network: &str) -> &'static str {
     }
 }
 
-fn print_ready_panel(local_url: &str) {
+fn print_ready_panel(network: &str, local_url: &str, tip_height: Option<u64>) {
     if stacksdapp_shell::is_quiet() {
         return;
     }
@@ -104,6 +108,26 @@ fn print_ready_panel(local_url: &str) {
     stacksdapp_shell::rule();
     println!();
     stacksdapp_shell::kv("Local", local_url);
+    if let Some(height) = tip_height {
+        stacksdapp_shell::kv("Devnet tip", &format!("#{height}"));
+    }
+    println!();
+    if network == "devnet" {
+        stacksdapp_shell::kv(
+            "Deploy",
+            "stacksdapp deploy --network devnet",
+        );
+        println!(
+            "{}",
+            "  Tip must keep advancing before deploy; stalled tips need: stacksdapp clean && stacksdapp dev"
+                .truecolor(156, 163, 175)
+        );
+    } else {
+        stacksdapp_shell::kv(
+            "Deploy",
+            &format!("stacksdapp deploy --network {network}"),
+        );
+    }
     println!();
     stacksdapp_shell::rule();
     println!();
@@ -120,6 +144,12 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
 
     let step = stacksdapp_shell::begin_step("Environment configured");
     if let Err(e) = ensure_docker() {
+        step.fail();
+        return Err(e);
+    }
+    // Free ports held by leftover Clarinet Docker from other projects before we start.
+    stop_stale_devnet_docker();
+    if let Err(e) = ensure_devnet_fast_boot_settings().await {
         step.fail();
         return Err(e);
     }
@@ -151,7 +181,40 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
     step.finish();
 
     let mut clarinet = spawn_clarinet_devnet()?;
-    attach_filtered_output(&mut clarinet, OutputStyle::Clarinet);
+    let fatal = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    attach_filtered_output(&mut clarinet, OutputStyle::Clarinet, std::sync::Arc::clone(&fatal));
+
+    // Clarinet 3.21.x writes pox_5_* keys into Stacks.toml that stacks-core 3.4
+    // (Clarinet's default image) rejects, so stacks-node dies instantly. Patch the
+    // generated config as soon as it appears, before Clarinet starts that container.
+    let stacks_toml_patcher = tokio::spawn(patch_generated_stacks_toml_until_ready(
+        std::sync::Arc::clone(&fatal),
+    ));
+
+    let step = stacksdapp_shell::begin_step("Devnet nodes starting (bitcoin + stacks)");
+    let tip_height = match wait_for_devnet_chain_ready(
+        Duration::from_secs(300),
+        &mut clarinet,
+        std::sync::Arc::clone(&fatal),
+    )
+    .await
+    {
+        Ok(height) => {
+            stacks_toml_patcher.abort();
+            let _ = stacks_toml_patcher.await;
+            step.finish();
+            stacksdapp_shell::step_ok(&format!("Devnet ready — stacks tip #{height}"));
+            Some(height)
+        }
+        Err(e) => {
+            stacks_toml_patcher.abort();
+            let _ = stacks_toml_patcher.await;
+            step.fail();
+            let _ = clarinet.start_kill();
+            let _ = clarinet.wait().await;
+            return Err(e);
+        }
+    };
 
     let health_monitor = tokio::spawn(monitor_devnet_chain_health());
 
@@ -174,7 +237,7 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
     match tokio::time::timeout(Duration::from_secs(120), ready_rx).await {
         Ok(Ok(url)) => {
             step.finish();
-            print_ready_panel(&url);
+            print_ready_panel("devnet", &url, tip_height);
         }
         Ok(Err(_)) => {
             step.fail();
@@ -183,7 +246,7 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
         Err(_) => {
             step.fail();
             return Err(anyhow!(
-                "Frontend did not become ready within 120s. Check that port 3000 is free."
+                "Frontend did not become ready within 120s. Check that ports 3000/3001 are free."
             ));
         }
     }
@@ -276,7 +339,7 @@ async fn dev_remote(network: &str) -> Result<()> {
     match tokio::time::timeout(Duration::from_secs(120), ready_rx).await {
         Ok(Ok(url)) => {
             step.finish();
-            print_ready_panel(&url);
+            print_ready_panel(network, &url, None);
         }
         Ok(Err(_)) => {
             step.fail();
@@ -329,16 +392,344 @@ async fn run_auto_deploy() {
     match stacksdapp_deployer::wait_for_devnet_node().await {
         Ok(()) => {
             if let Err(e) = stacksdapp_deployer::deploy("devnet", None, false, false).await {
-                eprintln!("[dev] Auto-deploy failed: {e:#}");
-                eprintln!(
-                    "[dev] You can deploy manually in another terminal: stacksdapp deploy --network devnet"
+                stacksdapp_shell::println_human_safe(format!("[dev] Auto-deploy failed: {e:#}"));
+                stacksdapp_shell::println_human_safe(
+                    "[dev] You can deploy manually in another terminal: stacksdapp deploy --network devnet",
                 );
             }
         }
         Err(e) => {
-            eprintln!("[dev] Devnet did not become ready for auto-deploy: {e:#}");
+            stacksdapp_shell::println_human_safe(format!(
+                "[dev] Devnet did not become ready for auto-deploy: {e:#}"
+            ));
         }
     }
+}
+
+/// Poll local stacks core until tip advances at least twice (proves blocks keep
+/// producing under Nakamoto, not just a single tenure after boot).
+async fn wait_for_devnet_chain_ready(
+    timeout: Duration,
+    clarinet: &mut Child,
+    fatal: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+) -> Result<u64> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()?;
+    let started = Instant::now();
+    let mut first_tip: Option<u64> = None;
+    let mut second_tip: Option<u64> = None;
+    let mut last_status = Instant::now() - Duration::from_secs(30);
+
+    loop {
+        if let Ok(guard) = fatal.lock() {
+            if let Some(msg) = guard.as_ref() {
+                return Err(anyhow!("{msg}"));
+            }
+        }
+
+        match clarinet.try_wait() {
+            Ok(Some(status)) => {
+                let detail = fatal
+                    .lock()
+                    .ok()
+                    .and_then(|g| g.clone())
+                    .unwrap_or_else(|| {
+                        format!("Clarinet exited early with status {status} before stacks-node was ready.")
+                    });
+                return Err(anyhow!(
+                    "{detail}\n\
+                     Free leftover Devnet ports/containers, then retry:\n\
+                       docker ps --filter name=devnet\n\
+                       docker stop $(docker ps -q --filter name=devnet) 2>/dev/null\n\
+                       pkill -f 'clarinet devnet' 2>/dev/null\n\
+                       stacksdapp clean --force && stacksdapp dev"
+                ));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                return Err(anyhow!("Failed to poll Clarinet process: {e}"));
+            }
+        }
+
+        // Only check for crashes after Clarinet has had time to create containers
+        // (avoids false positives from unrelated leftover names; clean already stopped ours).
+        if started.elapsed() >= Duration::from_secs(15) {
+            if let Some(crash) = detect_stacks_node_crash().await {
+                if let Ok(mut slot) = fatal.lock() {
+                    if slot.is_none() {
+                        *slot = Some(crash.clone());
+                    }
+                }
+                return Err(anyhow!("{crash}"));
+            }
+        }
+
+        if started.elapsed() > timeout {
+            return Err(anyhow!(
+                "Devnet did not become ready within {}s.\n\
+                 Stacks core at http://localhost:20443 never kept producing blocks.\n\
+                 Common causes:\n\
+                 • bitcoin_controller_block_time too aggressive (signer cannot keep up)\n\
+                 • Clarinet/stacks-core image mismatch (stacks-node exits on bad Stacks.toml)\n\
+                 • Port conflict (e.g. 20445 / 5432 already in use) — leftover Clarinet/Docker from another project\n\
+                 • Docker low on RAM/CPU — give Docker Desktop more resources\n\
+                 • Stale state — try `stacksdapp clean --force` then `stacksdapp dev`\n\
+                 Fix ports:\n\
+                   docker stop $(docker ps -q --filter name=devnet) 2>/dev/null\n\
+                   pkill -f 'clarinet devnet' 2>/dev/null",
+                timeout.as_secs()
+            ));
+        }
+
+        match fetch_local_stacks_tip(&client).await {
+            Some(height) => match (first_tip, second_tip) {
+                (None, _) => {
+                    first_tip = Some(height);
+                    if last_status.elapsed() >= Duration::from_secs(8) {
+                        stacksdapp_shell::println_human_safe(format!(
+                            "[devnet] stacks core up — tip #{height}, waiting for next block..."
+                        ));
+                        last_status = Instant::now();
+                    }
+                }
+                (Some(first), None) if height > first => {
+                    second_tip = Some(height);
+                    stacksdapp_shell::println_human_safe(format!(
+                        "[devnet] tip advanced to #{height} — confirming sustained block production..."
+                    ));
+                    last_status = Instant::now();
+                }
+                (Some(_), Some(second)) if height > second => return Ok(height),
+                (Some(_), Some(second)) => {
+                    if last_status.elapsed() >= Duration::from_secs(15) {
+                        stacksdapp_shell::println_human_safe(format!(
+                            "[devnet] waiting for tip to keep advancing (still #{second})..."
+                        ));
+                        last_status = Instant::now();
+                    }
+                }
+                (Some(first), None) => {
+                    if last_status.elapsed() >= Duration::from_secs(15) {
+                        stacksdapp_shell::println_human_safe(format!(
+                            "[devnet] waiting for tip to advance (still #{first})..."
+                        ));
+                        last_status = Instant::now();
+                    }
+                }
+            },
+            None => {
+                if last_status.elapsed() >= Duration::from_secs(12) {
+                    stacksdapp_shell::println_human_safe(
+                        "[devnet] waiting for bitcoin-node / stacks-node (this can take 1–3 min)...",
+                    );
+                    last_status = Instant::now();
+                }
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+/// Clarinet 3.21 writes `pox_5_*` under `[node]` for PoX-5 / Epoch 4, but its default
+/// Docker image is still stacks-core 3.4.x which rejects those keys and exits immediately.
+/// Strip them from every generated `Stacks.toml` until the tip is reachable.
+async fn patch_generated_stacks_toml_until_ready(
+    fatal: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+) {
+    let mut announced = false;
+    loop {
+        if fatal.lock().ok().and_then(|g| g.clone()).is_some() {
+            return;
+        }
+        match patch_pox5_fields_in_cache().await {
+            Ok(n) if n > 0 && !announced => {
+                stacksdapp_shell::println_human_safe(
+                    "[devnet] Patched Stacks.toml (removed Clarinet pox_5_* keys incompatible with stacks-core 3.4).",
+                );
+                announced = true;
+            }
+            Ok(_) => {}
+            Err(_) => {}
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn patch_pox5_fields_in_cache() -> Result<usize> {
+    let cache = Path::new("contracts/.cache");
+    if !cache.is_dir() {
+        return Ok(0);
+    }
+    let mut patched = 0usize;
+    let mut entries = fs::read_dir(cache).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("stacks-devnet-") {
+            continue;
+        }
+        let stacks_toml = entry.path().join("conf/Stacks.toml");
+        if !stacks_toml.is_file() {
+            continue;
+        }
+        if patch_stacks_toml_file(&stacks_toml).await? {
+            patched += 1;
+        }
+    }
+    Ok(patched)
+}
+
+/// Returns true when the file was rewritten.
+async fn patch_stacks_toml_file(path: &Path) -> Result<bool> {
+    let raw = fs::read_to_string(path).await?;
+    let (updated, changed) = strip_pox5_node_fields(&raw);
+    if changed {
+        fs::write(path, updated).await?;
+    }
+    Ok(changed)
+}
+
+/// Pure helper: drop Clarinet-injected `pox_5_*` keys that stacks-core 3.4 rejects.
+pub fn strip_pox5_node_fields(raw: &str) -> (String, bool) {
+    let mut out = Vec::new();
+    let mut removed = false;
+    for line in raw.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("pox_5_") {
+            removed = true;
+            continue;
+        }
+        out.push(line);
+    }
+    if !removed {
+        return (raw.to_string(), false);
+    }
+    let mut updated = out.join("\n");
+    if raw.ends_with('\n') && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    (updated, true)
+}
+
+/// Fail fast when Clarinet starts stacks-node and the container exits (bad config, OOM, etc.).
+async fn detect_stacks_node_crash() -> Option<String> {
+    let list = tokio::process::Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "name=stacks-node",
+            "--format",
+            "{{.Names}}\t{{.Status}}\t{{.ID}}",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .ok()?;
+
+    if !list.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&list.stdout);
+    let mut crashed_id: Option<String> = None;
+    for line in text.lines() {
+        let lower = line.to_ascii_lowercase();
+        if !lower.contains("stacks-node") || !lower.contains("devnet") {
+            continue;
+        }
+        if lower.contains("exited") || lower.contains("dead") {
+            let id = line.split('\t').nth(2).unwrap_or("").trim().to_string();
+            if !id.is_empty() {
+                crashed_id = Some(id);
+            }
+        }
+    }
+
+    let id = crashed_id?;
+    let logs = tokio::process::Command::new("docker")
+        .args(["logs", "--tail", "40", &id])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .ok()?;
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&logs.stdout),
+        String::from_utf8_lossy(&logs.stderr)
+    );
+    let lower = combined.to_ascii_lowercase();
+    if lower.contains("pox_5_sbtc") || lower.contains("unknown field `pox_5") {
+        // Host conf is usually bind-mounted — patch + restart can recover this boot.
+        let _ = patch_pox5_fields_in_cache().await;
+        let _ = tokio::process::Command::new("docker")
+            .args(["start", &id])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        // If restart worked, tip poll will succeed; only fail if still dead.
+        let still_dead = tokio::process::Command::new("docker")
+            .args([
+                "ps",
+                "-a",
+                "--filter",
+                &format!("id={id}"),
+                "--format",
+                "{{.Status}}",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .await
+            .ok()
+            .map(|o| {
+                let s = String::from_utf8_lossy(&o.stdout).to_ascii_lowercase();
+                s.contains("exited") || s.contains("dead")
+            })
+            .unwrap_or(true);
+        if !still_dead {
+            stacksdapp_shell::println_human_safe(
+                "[devnet] Restarted stacks-node after patching incompatible pox_5_* config keys.",
+            );
+            return None;
+        }
+        return Some(
+            "Devnet stacks-node crashed: Clarinet wrote pox_5_* keys that stacks-core 3.4 rejects.\n\
+             stacksdapp patches Stacks.toml automatically — retry after `stacksdapp clean --force`.\n\
+             Or upgrade Clarinet (`brew upgrade clarinet`) once a fix release is available."
+                .to_string(),
+        );
+    }
+    if lower.contains("invalid config")
+        || lower.contains("process abort")
+        || lower.contains("fatal:")
+        || lower.contains("invalid toml")
+    {
+        let snippet = combined
+            .lines()
+            .rev()
+            .take(8)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Some(format!(
+            "Devnet stacks-node container exited.\n{snippet}\n\
+             Try: stacksdapp clean --force && stacksdapp dev"
+        ));
+    }
+    Some(
+        "Devnet stacks-node container exited before becoming ready.\n\
+         Check: docker logs $(docker ps -aq --filter name=stacks-node | head -1)\n\
+         Then: stacksdapp clean --force && stacksdapp dev"
+            .to_string(),
+    )
 }
 
 /// Poll local devnet tip height and warn if the chain appears stalled.
@@ -365,15 +756,14 @@ async fn monitor_devnet_chain_health() {
                 if unchanged_since.elapsed() >= Duration::from_secs(45)
                     && last_warning.elapsed() >= Duration::from_secs(60)
                 {
-                    eprintln!(
-                        "\n[devnet] Warning: local chain tip stalled at height {height} for 45s+."
+                    stacksdapp_shell::println_human_safe(format!(
+                        "[devnet] Warning: local chain tip stalled at height {height} for 45s+."
+                    ));
+                    stacksdapp_shell::println_human_safe(
+                        "  Deployments may hang until blocks advance. This is often a Clarinet/Docker issue.",
                     );
-                    eprintln!(
-                        "  Deployments may hang until blocks advance. This is often a Clarinet/Docker devnet issue."
-                    );
-                    eprintln!("  Try: stacksdapp clean && stacksdapp dev");
-                    eprintln!(
-                        "  Track upstream: https://github.com/scaffold-stack/scaffold-stack/issues/53\n"
+                    stacksdapp_shell::println_human_safe(
+                        "  Try: stacksdapp clean --force && stacksdapp dev",
                     );
                     last_warning = Instant::now();
                 }
@@ -405,17 +795,37 @@ enum OutputStyle {
     Clarinet,
 }
 
-fn attach_filtered_output(child: &mut Child, style: OutputStyle) {
+fn attach_filtered_output(
+    child: &mut Child,
+    style: OutputStyle,
+    fatal: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+) {
+    // Clarinet 3.2+ may prompt: "Do you want to continue? (y/N)" when the default
+    // snapshot is incompatible with built-in PoX stacking defaults. Without an answer,
+    // Docker never starts and we hang forever waiting for :20443.
+    let stdin = child.stdin.take().map(|s| {
+        std::sync::Arc::new(tokio::sync::Mutex::new(Some(s)))
+    });
+
     if let Some(stdout) = child.stdout.take() {
-        spawn_filtered_stream(stdout, style, false);
+        spawn_filtered_stream(
+            stdout,
+            style,
+            std::sync::Arc::clone(&fatal),
+            stdin.clone(),
+        );
     }
     if let Some(stderr) = child.stderr.take() {
-        spawn_filtered_stream(stderr, style, true);
+        spawn_filtered_stream(stderr, style, fatal, stdin);
     }
 }
 
-fn spawn_filtered_stream<R>(reader: R, style: OutputStyle, is_stderr: bool)
-where
+fn spawn_filtered_stream<R>(
+    reader: R,
+    style: OutputStyle,
+    fatal: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    stdin: Option<std::sync::Arc<tokio::sync::Mutex<Option<tokio::process::ChildStdin>>>>,
+) where
     R: AsyncRead + Unpin + Send + 'static,
 {
     tokio::spawn(async move {
@@ -423,19 +833,121 @@ where
         while let Ok(Some(line)) = lines.next_line().await {
             match style {
                 OutputStyle::Clarinet => {
-                    // Keep Clarinet noise down during startup; surface failures.
-                    let lower = line.to_ascii_lowercase();
-                    if lower.contains("error")
-                        || lower.contains("failed")
-                        || lower.contains("panic")
-                        || is_stderr && !line.trim().is_empty()
+                    if clarinet_needs_continue_answer(&line) {
+                        stacksdapp_shell::println_human_safe(
+                            "[devnet] Clarinet snapshot skipped (default PoX stacking) — continuing boot...",
+                        );
+                        if let Some(stdin) = &stdin {
+                            let mut guard = stdin.lock().await;
+                            if let Some(pipe) = guard.as_mut() {
+                                use tokio::io::AsyncWriteExt;
+                                let _ = pipe.write_all(b"y\n").await;
+                                let _ = pipe.flush().await;
+                            }
+                        }
+                        continue;
+                    }
+                    if let Some(fatal_msg) = clarinet_fatal_message(&line) {
+                        stacksdapp_shell::println_human_safe(format!("[devnet] {fatal_msg}"));
+                        if let Ok(mut slot) = fatal.lock() {
+                            if slot.is_none() {
+                                *slot = Some(fatal_msg);
+                            }
+                        }
+                        continue;
+                    }
+                    // Clarinet may rewrite Stacks.toml immediately before starting
+                    // stacks-node — force another strip as soon as we see that log line.
+                    let lower = strip_ansi(&line).to_ascii_lowercase();
+                    if lower.contains("starting stacks-node")
+                        || lower.contains("initiating devnet boot")
+                        || lower.contains("copying stacks snapshot")
                     {
-                        eprintln!("{}", line);
+                        let _ = patch_pox5_fields_in_cache().await;
+                    }
+                    if let Some(msg) = format_clarinet_line(&line) {
+                        stacksdapp_shell::println_human_safe(msg);
                     }
                 }
             }
         }
     });
+}
+
+fn clarinet_needs_continue_answer(line: &str) -> bool {
+    let lower = strip_ansi(line).to_ascii_lowercase();
+    lower.contains("do you want to continue?")
+        || (lower.contains("(y/n)") && lower.contains("continue"))
+}
+
+fn clarinet_fatal_message(line: &str) -> Option<String> {
+    let plain = strip_ansi(line);
+    let lower = plain.to_ascii_lowercase();
+    if lower.contains("address already in use")
+        || lower.contains("os error 48")
+        || lower.contains("port is already allocated")
+        || (lower.contains("bind for 0.0.0.0:") && lower.contains("failed"))
+        || lower.contains("fatal:")
+        || lower.contains("unable to start postgres")
+        || (lower.contains("unable to start") && lower.contains("container"))
+    {
+        Some(format!(
+            "Devnet failed to start: {plain}\n\
+             Another Clarinet/Docker Devnet is still holding ports (often 20445 or 5432).\n\
+             Free them, then retry:\n\
+               docker stop $(docker ps -q --filter name=devnet) 2>/dev/null\n\
+               pkill -f 'clarinet devnet' 2>/dev/null\n\
+               stacksdapp clean --force && stacksdapp dev"
+        ))
+    } else {
+        None
+    }
+}
+
+fn strip_ansi(line: &str) -> String {
+    let t = line.trim();
+    t.chars()
+        .filter(|c| *c == '\t' || (*c >= ' ' && *c != '\u{007f}'))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+fn format_clarinet_line(line: &str) -> Option<String> {
+    let plain = strip_ansi(line);
+    if plain.is_empty() {
+        return None;
+    }
+    let lower = plain.to_ascii_lowercase();
+
+    // Boot progress — keep the spinner row from looking stuck.
+    if lower.contains("initiating devnet boot")
+        || lower.contains("starting bitcoin-node")
+        || lower.contains("starting stacks-node")
+        || lower.contains("starting postgres")
+        || lower.contains("starting stacks-api")
+        || lower.contains("starting stacks-signer")
+        || lower.contains("copying bitcoin snapshot")
+        || lower.contains("copying stacks snapshot")
+        || lower.contains("snapshot copied")
+        || lower.contains("continuing with startup")
+        || lower.contains("default snapshot can not be used")
+        || lower.contains("local devnet network ready")
+        || lower.contains("stacks block #")
+        || lower.contains("bitcoin-node - mining")
+        || lower.contains("stacks-node - mining")
+        || lower.contains("blockchain verification completed")
+    {
+        return Some(format!("[devnet] {plain}"));
+    }
+    if lower.contains("error")
+        || lower.contains("failed")
+        || lower.contains("panic")
+        || lower.contains("unable to")
+    {
+        return Some(format!("[devnet] {plain}"));
+    }
+    None
 }
 
 fn attach_next_output(child: &mut Child, ready: Option<oneshot::Sender<String>>) {
@@ -479,7 +991,7 @@ fn spawn_next_stream<R>(
             }
 
             if let Some(formatted) = format_next_line(&line) {
-                println!("{formatted}");
+                stacksdapp_shell::println_human_safe(formatted);
             }
         }
     });
@@ -715,10 +1227,174 @@ fn ensure_docker() -> Result<()> {
     Ok(())
 }
 
+/// Stop leftover Clarinet Devnet containers that hold ports (5432, 20445, 3999, …).
+/// Safe for testnet/mainnet: only matches Docker names containing `devnet`.
+pub fn stop_stale_devnet_docker() {
+    let Ok(output) = std::process::Command::new("docker")
+        .args(["ps", "-q", "--filter", "name=devnet"])
+        .output()
+    else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let ids = String::from_utf8_lossy(&output.stdout);
+    let ids: Vec<&str> = ids.split_whitespace().collect();
+    if ids.is_empty() {
+        return;
+    }
+    stacksdapp_shell::println_human_safe(format!(
+        "[devnet] Stopping {} leftover Devnet container(s) to free ports...",
+        ids.len()
+    ));
+    let mut cmd = std::process::Command::new("docker");
+    cmd.arg("stop").args(&ids);
+    let _ = cmd
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Rewrite `contracts/settings/Devnet.toml` for Clarinet 3.2+ snapshot fast-boot.
+/// Preserves accounts and other custom keys; only strips PoX stacking orders and
+/// ensures explorers are off / API on / faster block time. Does not touch Testnet/Mainnet.
+async fn ensure_devnet_fast_boot_settings() -> Result<()> {
+    let path = Path::new("contracts/settings/Devnet.toml");
+    if !path.is_file() {
+        return Ok(());
+    }
+    let raw = fs::read_to_string(path).await?;
+    let (updated, changed) = optimize_devnet_toml_for_fast_boot(&raw);
+    if changed {
+        fs::write(path, updated).await?;
+        stacksdapp_shell::println_human_safe(
+            "[devnet] Applied fast-boot settings (snapshot-friendly; explorers off).",
+        );
+    }
+    Ok(())
+}
+
+/// Pure rewrite helper (unit-tested). Returns `(new_contents, did_change)`.
+pub fn optimize_devnet_toml_for_fast_boot(raw: &str) -> (String, bool) {
+    let mut out: Vec<String> = Vec::new();
+    let mut skipping_pox = false;
+    let mut in_devnet = false;
+    let mut saw_devnet = false;
+    let mut has_btc_explorer = false;
+    let mut has_stacks_explorer = false;
+    let mut has_stacks_api = false;
+    let mut has_block_time = false;
+    let mut removed_pox = false;
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') {
+            skipping_pox = false;
+            in_devnet = trimmed == "[devnet]";
+            if in_devnet {
+                saw_devnet = true;
+            }
+            if trimmed == "[[devnet.pox_stacking_orders]]" {
+                skipping_pox = true;
+                removed_pox = true;
+                continue;
+            }
+        }
+
+        if skipping_pox {
+            // Drop the whole array-of-tables block (keys until next [section]).
+            continue;
+        }
+
+        if in_devnet {
+            if trimmed.starts_with("disable_bitcoin_explorer") {
+                has_btc_explorer = true;
+                out.push("disable_bitcoin_explorer = true".to_string());
+                continue;
+            }
+            if trimmed.starts_with("disable_stacks_explorer") {
+                has_stacks_explorer = true;
+                out.push("disable_stacks_explorer = true".to_string());
+                continue;
+            }
+            if trimmed.starts_with("disable_stacks_api") {
+                has_stacks_api = true;
+                // Keep API enabled — frontend / deploy tooling may use :3999.
+                out.push("disable_stacks_api = false".to_string());
+                continue;
+            }
+            if trimmed.starts_with("bitcoin_controller_block_time") {
+                has_block_time = true;
+                // 15s: local UX stays usable; Nakamoto/signer can keep pace.
+                // 1s burns ahead of stacks-node and tips stall after the first tenure.
+                out.push("bitcoin_controller_block_time = 15_000".to_string());
+                continue;
+            }
+        }
+
+        out.push(line.to_string());
+    }
+
+    let mut injected = false;
+    if saw_devnet {
+        // Inject any missing keys just after the `[devnet]` header.
+        let mut final_out: Vec<String> = Vec::with_capacity(out.len() + 4);
+        for line in out {
+            final_out.push(line.clone());
+            if line.trim() == "[devnet]" {
+                if !has_btc_explorer {
+                    final_out.push("disable_bitcoin_explorer = true".to_string());
+                    injected = true;
+                }
+                if !has_stacks_explorer {
+                    final_out.push("disable_stacks_explorer = true".to_string());
+                    injected = true;
+                }
+                if !has_stacks_api {
+                    final_out.push("disable_stacks_api = false".to_string());
+                    injected = true;
+                }
+                if !has_block_time {
+                    final_out.push("bitcoin_controller_block_time = 15_000".to_string());
+                    injected = true;
+                }
+            }
+        }
+        out = final_out;
+    } else {
+        out.push(String::new());
+        out.push("[devnet]".to_string());
+        out.push("disable_bitcoin_explorer = true".to_string());
+        out.push("disable_stacks_explorer = true".to_string());
+        out.push("disable_stacks_api = false".to_string());
+        out.push("bitcoin_controller_block_time = 15_000".to_string());
+        injected = true;
+    }
+
+    let mut updated = out.join("\n");
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    let normalized_raw = if raw.ends_with('\n') {
+        raw.to_string()
+    } else {
+        format!("{raw}\n")
+    };
+    let changed = removed_pox || injected || updated != normalized_raw;
+    (updated, changed)
+}
+
 fn spawn_clarinet_devnet() -> Result<Child> {
+    // --no-dashboard is required: Clarinet's TUI corrupts our spinner/ready panel.
+    // --from-genesis avoids Clarinet's default snapshot path, which with Clarinet 3.21
+    // often boots a hybrid bitcoin/stacks snapshot that mines one Nakamoto tenure then stalls.
+    // stdin must be piped so we can answer the snapshot "continue? (y/N)" prompt if it still appears.
     let child = Command::new("clarinet")
-        .args(["devnet", "start"])
+        .args(["devnet", "start", "--no-dashboard", "--from-genesis"])
         .current_dir("contracts")
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -769,7 +1445,36 @@ async fn shutdown_child(name: &str, child: &mut Child) {
 
 #[cfg(test)]
 mod tests {
-    use super::upsert_env_assignment;
+    use super::{
+        optimize_devnet_toml_for_fast_boot, strip_pox5_node_fields, upsert_env_assignment,
+    };
+
+    #[test]
+    fn strip_pox5_node_fields_removes_clarinet_keys() {
+        let raw = r#"[node]
+working_dir = "/devnet"
+rpc_bind = "0.0.0.0:20443"
+pox_5_sbtc_contract = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-token"
+pox_5_sbtc_registry_contract = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-registry"
+pox_5_bond_admin = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+
+[connection_options]
+auth_token = "12345"
+"#;
+        let (updated, changed) = strip_pox5_node_fields(raw);
+        assert!(changed);
+        assert!(!updated.contains("pox_5_"));
+        assert!(updated.contains("rpc_bind = \"0.0.0.0:20443\""));
+        assert!(updated.contains("auth_token = \"12345\""));
+    }
+
+    #[test]
+    fn strip_pox5_node_fields_noop_when_absent() {
+        let raw = "[node]\nrpc_bind = \"0.0.0.0:20443\"\n";
+        let (updated, changed) = strip_pox5_node_fields(raw);
+        assert!(!changed);
+        assert_eq!(updated, raw);
+    }
 
     #[test]
     fn upsert_env_assignment_preserves_other_values() {
@@ -796,5 +1501,71 @@ mod tests {
         );
         assert!(updated.starts_with("# Auto-written by stacksdapp dev --network devnet"));
         assert!(updated.contains("NEXT_PUBLIC_NETWORK=devnet"));
+    }
+
+    #[test]
+    fn optimize_devnet_toml_strips_pox_and_disables_explorers() {
+        let raw = r#"# WARNING: public mnemonics
+
+[network]
+name = "devnet"
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip"
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+wallet = "wallet_1"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+wallet = "wallet_2"
+"#;
+        let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
+        assert!(changed);
+        assert!(!updated.contains("pox_stacking_orders"));
+        assert!(updated.contains("disable_bitcoin_explorer = true"));
+        assert!(updated.contains("disable_stacks_explorer = true"));
+        assert!(updated.contains("disable_stacks_api = false"));
+        assert!(updated.contains("bitcoin_controller_block_time = 15_000"));
+        assert!(updated.contains("[accounts.deployer]"));
+        assert!(updated.contains("mnemonic = \"twice kind fence tip\""));
+    }
+
+    #[test]
+    fn optimize_devnet_toml_is_idempotent_when_already_fast() {
+        let raw = r#"[network]
+name = "devnet"
+
+[devnet]
+disable_bitcoin_explorer = true
+disable_stacks_explorer = true
+disable_stacks_api = false
+bitcoin_controller_block_time = 15_000
+"#;
+        let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
+        assert!(!changed, "already optimized file should not rewrite");
+        assert_eq!(updated, raw);
+    }
+
+    #[test]
+    fn optimize_devnet_toml_upgrades_too_aggressive_block_time() {
+        let raw = r#"[network]
+name = "devnet"
+
+[devnet]
+disable_bitcoin_explorer = true
+disable_stacks_explorer = true
+disable_stacks_api = false
+bitcoin_controller_block_time = 1_000
+"#;
+        let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
+        assert!(changed);
+        assert!(updated.contains("bitcoin_controller_block_time = 15_000"));
+        assert!(!updated.contains("bitcoin_controller_block_time = 1_000"));
     }
 }

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -114,6 +114,15 @@ mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory c
 balance = 100_000_000_000_000
 sbtc_balance = 1_000_000_000
 derivation = "m/44'/5757'/0'/0/0"
+
+[devnet]
+# Clarinet 3.2+ snapshot fast-boot: keep this section free of [[devnet.pox_stacking_orders]]
+# and avoid custom images / early-epoch overrides (those force slow genesis mining).
+disable_bitcoin_explorer = true
+disable_stacks_explorer = true
+disable_stacks_api = false
+# 15s keeps Nakamoto + signer able to keep up; 1s races burn height and stalls tips.
+bitcoin_controller_block_time = 15_000
 "#;
 
 const DEFAULT_FULL_DEVNET_SETTINGS_BODY: &str = r#"[network]
@@ -181,32 +190,13 @@ sbtc_balance = 1_000_000_000
 derivation = "m/44'/5757'/0'/0/0"
 
 [devnet]
-disable_stacks_explorer = false
+# Clarinet 3.2+ snapshot fast-boot: no PoX stacking orders (those force slow genesis).
+# Explorers off by default — enable locally if you need http://localhost:8000 / :8001.
+disable_bitcoin_explorer = true
+disable_stacks_explorer = true
 disable_stacks_api = false
-
-[[devnet.pox_stacking_orders]]
-start_at_cycle = 1
-duration = 10
-auto_extend = true
-wallet = "wallet_1"
-slots = 2
-btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
-
-[[devnet.pox_stacking_orders]]
-start_at_cycle = 1
-duration = 10
-auto_extend = true
-wallet = "wallet_2"
-slots = 2
-btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
-
-[[devnet.pox_stacking_orders]]
-start_at_cycle = 1
-duration = 10
-auto_extend = true
-wallet = "wallet_3"
-slots = 2
-btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
+# 15s keeps Nakamoto + signer able to keep up; 1s races burn height and stalls tips.
+bitcoin_controller_block_time = 15_000
 "#;
 
 fn devnet_settings_with_warning(body: &str) -> String {

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -9,7 +9,9 @@ pub use project::{
     default_config_toml, enter_scaffold_root, find_init_root, find_scaffold_root, load_config,
     project_root, resolve_scaffold_root, validate_network, StacksdappConfig, CONFIG_FILE,
 };
-pub use steps::{begin_step, grey, kv, lavender, mint, print_banner, rule, step_ok, LiveStep};
+pub use steps::{
+    begin_step, grey, kv, lavender, mint, print_banner, println_human_safe, rule, step_ok, LiveStep,
+};
 
 use colored::control;
 use serde::Serialize;

--- a/crates/shell/src/steps.rs
+++ b/crates/shell/src/steps.rs
@@ -2,12 +2,34 @@
 
 use colored::Colorize;
 use std::io::{self, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Serializes human stdout so child-process logs cannot fight the live spinner.
+fn stdout_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// How many live spinners are currently active (for `\r` line clearing).
+static ACTIVE_SPINNERS: AtomicUsize = AtomicUsize::new(0);
+
+/// Print a human line without corrupting an active spinner row.
+pub fn println_human_safe(line: impl AsRef<str>) {
+    if crate::is_quiet() {
+        return;
+    }
+    let _guard = stdout_lock().lock().unwrap_or_else(|e| e.into_inner());
+    if ACTIVE_SPINNERS.load(Ordering::SeqCst) > 0 {
+        print!("\r\x1b[2K");
+    }
+    println!("{}", line.as_ref());
+    let _ = io::stdout().flush();
+}
 
 /// In-place spinner that occupies the checkmark column until [`LiveStep::finish`].
 pub struct LiveStep {
@@ -35,6 +57,8 @@ impl LiveStep {
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }
+        let _guard = stdout_lock().lock().unwrap_or_else(|e| e.into_inner());
+        ACTIVE_SPINNERS.fetch_sub(1, Ordering::SeqCst);
         print!("\r\x1b[2K");
         if ok {
             println!(
@@ -101,22 +125,29 @@ pub fn begin_step(label: &str) -> LiveStep {
     let stop_c = Arc::clone(&stop);
     let label_c = label.to_string();
 
-    print!(
-        "\r{} {}",
-        SPINNER[0].truecolor(167, 139, 250),
-        label.truecolor(156, 163, 175)
-    );
-    let _ = io::stdout().flush();
+    ACTIVE_SPINNERS.fetch_add(1, Ordering::SeqCst);
+    {
+        let _guard = stdout_lock().lock().unwrap_or_else(|e| e.into_inner());
+        print!(
+            "\r\x1b[2K{} {}",
+            SPINNER[0].truecolor(167, 139, 250),
+            label.truecolor(156, 163, 175)
+        );
+        let _ = io::stdout().flush();
+    }
 
     let handle = thread::spawn(move || {
         let mut i = 0usize;
         while !stop_c.load(Ordering::Relaxed) {
-            print!(
-                "\r{} {}",
-                SPINNER[i % SPINNER.len()].truecolor(167, 139, 250),
-                label_c.truecolor(156, 163, 175)
-            );
-            let _ = io::stdout().flush();
+            {
+                let _guard = stdout_lock().lock().unwrap_or_else(|e| e.into_inner());
+                print!(
+                    "\r\x1b[2K{} {}",
+                    SPINNER[i % SPINNER.len()].truecolor(167, 139, 250),
+                    label_c.truecolor(156, 163, 175)
+                );
+                let _ = io::stdout().flush();
+            }
             i = i.wrapping_add(1);
             thread::sleep(Duration::from_millis(80));
         }


### PR DESCRIPTION
## Summary

This PR further hardens **stacksdapp 0.2.0** — a production-hardening release that makes the CLI scriptable, closes internal audit findings, and fixes Devnet end-to-end (boot → deploy → frontend). also closes #53 

### CLI & shell (`stacksdapp-shell`)
- Stable exit codes via `CliError` (`2`–`10`) for scriptable failures
- Global flags: `-v`, `-q`, `--color`, `--json`, `--root`
- Shell completions, `doctor --strict`, `clean --force`, `deploy --yes`
- Shared terminal UI: spinners, banners, quiet/JSON mode, `println_human_safe` (no log/spinner corruption)

### Deploy & codegen
- Deploy UI with live progress and clearer success output
- Testnet deploy no longer hangs after broadcast (early Clarinet exit when txs are in mempool)
- Devnet direct deploy: `@stacks/transactions` v7 `broadcastTransaction` to `:20443`
- Epoch burn-height gating before Clarity 5 publishes (fixes “txid returned but nonce stays 0”)
- Readiness/confirmation poll stacks **core** (`:20443`), not stacks-api alone
- Audit fixes: dry-run snapshot/restore, fail-closed txid parsing, partial deploy recovery, stdin devnet keys (never argv)

### Devnet reliability
- Clarinet `--from-genesis` + snapshot-friendly `Devnet.toml` (no PoX stacking, explorers off, 15s block time)
- Patch Clarinet 3.21 `pox_5_*` keys incompatible with stacks-core 3.4
- Auto-answer snapshot “continue? (y/N)” prompt; fail fast on stacks-node crash
- Stop stale Clarinet Docker on `dev` and `clean`
- Wait for sustained tip advancement before “ready”
- Deploy success points to running localhost app; no misleading Hiro explorer link on devnet

### CI, docs, release
- CI: Clarinet 3.21.1 pin, clippy, smoke, e2e verify, audit-fix regression, frontend build/typecheck
- GitHub Release workflow; `check-versions.sh`, MIT LICENSE, CONTRIBUTING, consolidated CHANGELOG
- Workspace crates aligned to `0.2.0`

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `./scripts/ci-smoke.sh` (or `./scripts/verify-e2e.sh` if available)
- [x] `stacksdapp new myapp && cd myapp`
- [x] `stacksdapp dev` — Devnet reaches ready panel with advancing tip
- [x] `stacksdapp deploy --network devnet` — confirms on core; success shows localhost URL
- [x] `stacksdapp deploy --network testnet --dry-run` — no hang at broadcast
- [x] `stacksdapp doctor --strict`
- [x] `stacksdapp clean --force` — stops leftover Devnet containers
- [x] `--json` smoke on `new`, `dev`, `deploy` (no double errors / valid success payloads)

## Notes
- Testnet/mainnet deploy paths unchanged except hang fix and audit hardening
- CHANGELOG consolidated under `[0.2.0] - Unreleased`