### PR TITLE
Release 0.2.0: CLI hardening, Clarity 6, bundled agent skill, SIP templates

### DIFF
--- a/.cursor/skills/scaffold-stacks/SKILL.md
+++ b/.cursor/skills/scaffold-stacks/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: scaffold-stacks
+description: >-
+  Build, test, deploy, and debug full-stack Stacks (Bitcoin L2) dApps with the
+  stacksdapp CLI — Clarity contracts, auto-generated React hooks, TypeScript
+  bindings, Next.js custom frontend, testnet/mainnet/devnet deployment. Use when
+  the user mentions stacksdapp, Scaffold Stacks, Clarity, Stacks dApp, Clarinet,
+  generated hooks, custom frontend, SIP-010, SIP-009, devnet, testnet deploy, or
+  works in a project with stacksdapp.toml or contracts/Clarinet.toml.
+---
+
+# Scaffold Stacks
+
+Scaffold Stacks = **Rust CLI** (`stacksdapp`) + **monorepo** (Clarity + Next.js). Auto-generates TypeScript from contract ABIs, ships a debug UI, deploys to testnet/mainnet/devnet.
+
+**Docs:** https://scaffoldstacks.mintlify.app/ · **Index:** https://scaffoldstacks.mintlify.app/llms.txt
+
+## When to use this skill
+
+- User is in a `stacksdapp new` or `stacksdapp init` project
+- Tasks involve contracts, deploy, devnet, bindings, React hooks, or custom frontend UI
+- User asks about Clarity + frontend integration on Stacks
+- User asks about SIP-010, SIP-009, or Clarity language syntax
+
+**Deep language / spec detail:** [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md) · [Stacks docs](https://docs.stacks.co/llms.txt)
+
+## Project root
+
+Commands resolve the root by walking up for `stacksdapp.toml` or `contracts/Clarinet.toml`. From subdirs use `--root PATH` or `STACKSDAPP_ROOT`.
+
+```
+my-app/
+├── stacksdapp.toml              # project marker + defaults.network
+├── AGENTS.md                    # this project's agent pointer
+├── contracts/
+│   ├── Clarinet.toml            # registry, clarity_version, epoch per contract
+│   ├── contracts/*.clar         # EDIT HERE
+│   ├── settings/*.toml          # deployer mnemonics — never commit real seeds
+│   ├── tests/*.test.ts          # Vitest + initSimnet
+│   └── .cache/                  # ABI cache (gitignored)
+└── frontend/
+    ├── src/generated/           # AUTO-GENERATED — never hand-edit
+    └── .env.local               # NEXT_PUBLIC_NETWORK
+```
+
+Details: [project-layout.md](project-layout.md)
+
+## Command decision tree
+
+| User goal | Command |
+|-----------|---------|
+| New project | `stacksdapp new NAME` |
+| Adopt Clarinet repo | `stacksdapp init` |
+| Add contract | `stacksdapp add NAME [--template blank\|sip010\|sip009] [--clarity-version 4\|5\|6]` |
+| Type-check | `stacksdapp check` |
+| Regenerate TS | `stacksdapp generate [--watch]` |
+| Test | `stacksdapp test` |
+| Local full stack | `stacksdapp dev [--auto-deploy]` (Docker) |
+| Frontend only | `stacksdapp dev --network testnet\|mainnet` |
+| Deploy | `stacksdapp deploy --network devnet\|testnet\|mainnet [--contract X] [--yes] [--dry-run]` |
+| Reset generated/devnet | `stacksdapp clean [--force]` |
+| Health check | `stacksdapp doctor [--strict]` |
+| Refresh deps + skill | `stacksdapp upgrade` |
+
+Full flags and exit codes: [cli-reference.md](cli-reference.md)
+
+## Default workflow — testnet first
+
+Recommend testnet for deploy verification (no Docker, reliable):
+
+```bash
+stacksdapp doctor
+# Set mnemonic in contracts/settings/Testnet.toml (placeholder uses <YOUR...>)
+stacksdapp check && stacksdapp generate && stacksdapp test
+stacksdapp deploy --network testnet --yes
+stacksdapp dev --network testnet
+```
+
+For CI/automation always pass `--yes` on deploy. Use `--dry-run` to preview fees.
+
+After **any** `.clar` or `Clarinet.toml` change: `check` → `generate` → `test` → `deploy`.
+
+## Clarity versions
+
+| Version | Epoch | Notes |
+|---------|-------|-------|
+| **6** (default) | `4.0` | New projects; Clarinet **3.23+** for devnet |
+| **5** | `3.4` | Legacy; set **both** version and epoch |
+| **4** | `3.0` | Older contracts |
+
+`stacksdapp add --clarity-version 5` sets epoch automatically. Manual downgrades must update both fields in `Clarinet.toml`.
+
+Details: [clarity-versions.md](clarity-versions.md)
+
+## Agent rules
+
+### Do
+
+- Run from project root (or rely on walk-up / `--root`)
+- Run `stacksdapp doctor` when prerequisites are unclear
+- Edit only `contracts/contracts/*.clar` and app components under `frontend/src/`
+- Regenerate after contract changes: `stacksdapp generate`
+- Use `--yes` for non-interactive deploys
+- Prefer **testnet** for deploy CI and first-time verification
+- Warn before committing mnemonics; devnet seeds in template are **public burners**
+
+### Do not
+
+- Hand-edit `frontend/src/generated/*`
+- Commit real testnet/mainnet mnemonics
+- Run `clarinet devnet start` alongside `stacksdapp dev` (port conflicts)
+- Reuse devnet template mnemonics on testnet/mainnet
+- Assume devnet is production-like for long-running deploy tests
+- Hand-write SIP tokens with `(impl-trait 'sip-010-trait)` — use `stacksdapp add --template sip010|sip009` (full trait path required; see [sip-standards.md](sip-standards.md))
+- Call `BigInt(hook.data)` on read-only uint results — unwrap cvToJSON shapes first ([frontend.md](frontend.md))
+- Fire read-only hooks (`get-balance`, etc.) without checking deploy + network + wallet address — causes `Failed to fetch` ([frontend.md](frontend.md))
+- Run `stacksdapp dev` (devnet) when contracts were deployed to testnet — set `NEXT_PUBLIC_NETWORK=testnet` instead
+
+## Devnet (local Docker)
+
+```bash
+stacksdapp dev                  # devnet + frontend + watcher
+stacksdapp dev --auto-deploy    # deploy once chain is ready (recommended)
+```
+
+**Caveats:** Docker required. Long idle devnet sessions can stall around Stacks block ~71 (PoX). Prefer `--auto-deploy` or deploy soon after boot. For reliable deploy verification use testnet.
+
+If stuck booting: `stacksdapp clean --force`, stop leftover devnet containers, retry.
+
+Details: [workflows.md](workflows.md) · [troubleshooting.md](troubleshooting.md)
+
+## Deploy behavior
+
+- **Testnet/mainnet:** Direct broadcast via `@stacks/transactions`; auto-versioning on redeploy (`counter` → `counter-v2`) unless `--no-auto-version`
+- **Devnet:** Epoch burn gating for C5/C6; waits for core node `:20443`
+- **`--dry-run`:** Plan + fee estimate only
+- **`--wait-confirm`:** Poll until on-chain (testnet/mainnet; slower)
+
+## Code generation
+
+`stacksdapp generate` writes:
+
+- `frontend/src/generated/contracts.ts` — async contract call functions
+- `frontend/src/generated/hooks.ts` — React hooks
+- `frontend/src/generated/DebugContracts.tsx` — debug UI forms
+- `frontend/src/generated/deployments.json` — addresses after deploy
+
+ABI cache in `contracts/.cache/` speeds repeat generates.
+
+## Frontend (hooks & wallet)
+
+Generated bindings → React hooks → your components:
+
+- **`contracts.ts`** — async call functions (wallet on testnet/mainnet, burners on devnet)
+- **`hooks.ts`** — `useCounter_Increment()` etc. with `{ call, data, loading, txid, txStatus, … }`
+- **`deployments.json`** — contract addresses (requires deploy first)
+
+Wallet (`WalletConnect` + Jotai) is for **testnet/mainnet**. Devnet writes use public burner keys — no wallet popup.
+
+Full guide: [frontend.md](frontend.md)
+
+## Global CLI flags
+
+```
+-v, --verbosity    More diagnostic output (repeatable)
+-q, --quiet        Suppress non-errors
+--json             Machine-readable output (implies quiet logs)
+--color auto|always|never
+--root PATH        Project root (env: STACKSDAPP_ROOT)
+```
+
+## Exit codes (for scripts)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Project not found |
+| 3 | Prerequisite / doctor failure |
+| 4 | User aborted |
+| 5 | Validation error |
+| 6 | Clarity check failed |
+| 7 | Tests failed |
+| 8 | Deploy failed |
+| 10 | Generate failed |
+
+## Examples
+
+**Add token and deploy to testnet:**
+
+```bash
+stacksdapp add my-token --template sip010
+# edit contracts/contracts/my-token.clar
+stacksdapp check && stacksdapp generate && stacksdapp test
+stacksdapp deploy --network testnet --yes
+```
+
+**Adopt existing Clarinet project:**
+
+```bash
+cd existing-clarinet-repo
+stacksdapp init
+stacksdapp deploy --network testnet --yes
+```
+
+**Frontend against mainnet (no local chain):**
+
+```bash
+stacksdapp dev --network mainnet
+```
+
+## Additional resources
+
+- [frontend.md](frontend.md) — hooks, wallet, devnet signing, custom UI
+- [clarity-language.md](clarity-language.md) — Clarity cheat sheet + Stacks learning links
+- [sip-standards.md](sip-standards.md) — SIP-010/009 specs + scaffold templates
+- [cli-reference.md](cli-reference.md) — all commands, flags, config files
+- [workflows.md](workflows.md) — new, adopt, upgrade, CI patterns
+- [clarity-versions.md](clarity-versions.md) — C4/C5/C6 migration
+- [troubleshooting.md](troubleshooting.md) — doctor, Docker, deploy errors
+- [project-layout.md](project-layout.md) — directories and env vars

--- a/.cursor/skills/scaffold-stacks/clarity-language.md
+++ b/.cursor/skills/scaffold-stacks/clarity-language.md
@@ -1,0 +1,167 @@
+# Clarity language — learning path & scaffold cheat sheet
+
+Scaffold Stacks handles deploy, bindings, and frontend — **you still write Clarity** in `contracts/contracts/*.clar`. For language depth, use official docs; this file routes agents there and lists syntax you'll use daily in scaffold projects.
+
+## When to use which resource
+
+| Need | Resource |
+|------|----------|
+| First-time Clarity | [Clarity Crash Course](https://docs.stacks.co/get-started/clarity-crash-course.md) |
+| Structured book | [Clarity Book](https://book.clarity-lang.org/) |
+| Interactive course | [Clarity Universe](https://clarity-lang.org/universe) |
+| Browser REPL | [Clarity Playground](https://play.stackslabs.com/) |
+| Function/type reference | [Clarity Reference](https://docs.stacks.co/reference/clarity/functions.md) |
+| Full docs index | [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) |
+| Language spec (SIP-002) | [SIP-002 Smart Contract Language](https://github.com/stacksgov/sips/blob/main/sips/sip-002/sip-002-smart-contract-language.md) |
+| Ask docs a question | `GET https://docs.stacks.co/<page>.md?ask=<question>&goal=<goal>` |
+
+**Agent rule:** For Clarity language questions beyond this cheat sheet, fetch Stacks docs — do not invent syntax.
+
+## Scaffold project workflow (Clarity side)
+
+```bash
+# edit contracts/contracts/my-contract.clar
+stacksdapp check          # Clarinet type-check + check_checker
+stacksdapp test           # Vitest + initSimnet in contracts/tests/
+stacksdapp generate       # refresh frontend hooks
+stacksdapp deploy --network testnet --yes
+```
+
+Contract tests live in `contracts/tests/*.test.ts` — no Docker. See [Testing with Clarinet SDK](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md).
+
+## Syntax essentials (scaffold projects)
+
+Clarity is LISP-like: expressions in parentheses.
+
+### Data variables
+
+```clarity
+(define-data-var counter uint u0)
+(var-get counter)
+(var-set counter (+ (var-get counter) u1))
+```
+
+### Functions
+
+| Form | Who can call | Mutates state |
+|------|--------------|---------------|
+| `define-read-only` | Anyone | No |
+| `define-public` | Anyone | Yes (via ok path) |
+| `define-private` | Same contract only | Yes |
+
+```clarity
+(define-read-only (get-count)
+  (ok (var-get counter)))
+
+(define-public (increment)
+  (begin
+    (var-set counter (+ (var-get counter) u1))
+    (ok (var-get counter))))
+```
+
+### Responses (critical)
+
+Public functions return `(response T uint)` — success `(ok value)` or error `(err uint)`:
+
+```clarity
+(define-constant ERR_UNAUTHORIZED (err u401))
+
+(define-public (admin-only)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (ok true)))
+```
+
+- `asserts!` — aborts with err if condition false
+- `try!` — unwrap ok or propagate err
+
+### Built-in principals & context
+
+| Name | Meaning |
+|------|---------|
+| `tx-sender` | Principal that signed the transaction |
+| `contract-caller` | Immediate caller (another contract if applicable) |
+| `as-contract` | Run as current contract |
+
+### Fungible tokens (SIP-010 building blocks)
+
+```clarity
+(define-fungible-token my-token)
+(ft-mint? my-token amount recipient)
+(ft-transfer? my-token amount sender recipient)
+(ft-get-balance my-token who)
+(ft-get-supply my-token)
+```
+
+### Non-fungible tokens (SIP-009 building blocks)
+
+```clarity
+(define-non-fungible-token my-nft uint)
+(nft-mint? my-nft token-id recipient)
+(nft-transfer? my-nft token-id sender recipient)
+(nft-get-owner? my-nft token-id)
+```
+
+### Traits (standards)
+
+```clarity
+;; Always use the FULL deployed trait path on mainnet — see sip-standards.md
+;; WRONG: (impl-trait 'sip-010-trait)  → VM Error: use of undeclared trait
+;; Testnet: omit impl-trait (no standard trait deployed on testnet chain)
+;; Mainnet:
+(impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+(use-trait token-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+
+(define-public (call-token (token <token-trait>))
+  (contract-call? token transfer u100 tx-sender recipient none))
+```
+
+Scaffold SIP templates ship with correct `impl-trait` and `[[project.requirements]]` — prefer `stacksdapp add --template sip010|sip009` over hand-written tokens. See [sip-standards.md](sip-standards.md).
+
+### Maps, lists, optional
+
+```clarity
+(define-map balances principal uint)
+(map-set balances who amount)
+(map-get? balances who)
+
+(define-public (example (maybe-id (optional uint)))
+  (match maybe-id id (ok id) ERR_NONE))
+```
+
+## Testing in scaffold (TypeScript + simnet)
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const deployer = simnet.getAccounts().get("deployer")!;
+
+it("increments", () => {
+  const { result } = simnet.callPublicFn("counter", "increment", [], deployer);
+  expect(result).toBeOk(Cl.uint(1));
+});
+```
+
+- `simnet.callPublicFn(contract, fn, args, sender)`
+- `simnet.callReadOnlyFn(contract, fn, args, sender)`
+- Use `Cl.uint`, `Cl.standardPrincipal`, etc. for args
+
+More: [Clarinet testing guide](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) · [Rendezvous fuzz testing](https://docs.stacks.co/rendezvous/overview.md)
+
+## Security reminders
+
+- Contracts are **immutable** after deploy — test thoroughly first
+- Use `asserts!` / `try!` — never ignore error paths
+- Prefer explicit access control (`tx-sender`, `contract-owner`)
+- Run [check_checker](https://docs.stacks.co/clarinet/check-checker.md) — enabled in scaffold `Clarinet.toml` by default
+
+## Clarity versions in scaffold
+
+New projects default to **Clarity 6** (`epoch = "4.0"`). See [clarity-versions.md](clarity-versions.md) for C5/C4 downgrades.
+
+## Related skill files
+
+- Token standards (SIP-010 / SIP-009): [sip-standards.md](sip-standards.md)
+- Frontend hooks after deploy: [frontend.md](frontend.md)
+- CLI commands: [cli-reference.md](cli-reference.md)

--- a/.cursor/skills/scaffold-stacks/clarity-versions.md
+++ b/.cursor/skills/scaffold-stacks/clarity-versions.md
@@ -1,0 +1,91 @@
+# Clarity versions and epochs
+
+Scaffold Stacks supports Clarity 4, 5, and 6. **New projects default to Clarity 6.**
+
+## Version ↔ epoch mapping
+
+| clarity_version | epoch | Stacks epoch | Use case |
+|-----------------|-------|--------------|----------|
+| 6 | `"4.0"` | 4.0 (burn 163+) | Default for new contracts |
+| 5 | `"3.4"` | 3.4 | Legacy contracts, backward compat |
+| 4 | `"3.0"` | 3.0 | Older contracts |
+
+**Critical:** `clarity_version` and `epoch` must match. Clarinet 3.23+ treats ambiguous configs as epoch 4.0 — a C5 contract with `epoch = "4.0"` will misbehave on devnet deploy.
+
+## Adding contracts
+
+```bash
+# Default C6 + epoch 4.0
+stacksdapp add my-contract
+
+# Legacy C5 + epoch 3.4 (automatic)
+stacksdapp add legacy --clarity-version 5
+
+# C4 + epoch 3.0
+stacksdapp add old --clarity-version 4
+```
+
+The `add` command writes the correct epoch into `Clarinet.toml` for the new contract entry.
+
+## Downgrading an existing project
+
+If changing C6 → C5 manually:
+
+1. Set `clarity_version = 5` **and** `epoch = "3.4"` on each affected `[contracts.*]` entry
+2. Regenerate deployment plans:
+   ```bash
+   cd contracts
+   clarinet deployments generate --devnet
+   clarinet deployments generate --testnet
+   ```
+3. `stacksdapp check && stacksdapp test`
+4. Redeploy
+
+Never leave `clarity_version = 5` with `epoch = "4.0"`.
+
+## Deploy implications
+
+### Testnet / mainnet
+
+- Direct broadcast via `@stacks/transactions`
+- Works for C4, C5, C6 when node supports the epoch
+- No Docker required
+
+### Devnet
+
+- **Clarity 6** requires **Clarinet 3.23+** and epoch 4.0 devnet snapshot
+- C5/C6 deploys wait for epoch burn height before broadcasting
+- Devnet `settings/Devnet.toml` includes PoX stacking orders required for epoch 4.0 snapshot — do not remove them
+
+Run `stacksdapp doctor` to verify Clarinet version.
+
+## Templates
+
+| Template | Standard | Notes |
+|----------|----------|-------|
+| `blank` | — | Empty public/read-only stubs |
+| `sip010` | SIP-010 | Fungible token — full guide: [sip-standards.md](sip-standards.md) |
+| `sip009` | SIP-009 | NFT — full guide: [sip-standards.md](sip-standards.md) |
+
+Templates inherit `--clarity-version` (default 6). Adds trait **requirements** to `Clarinet.toml` automatically.
+
+## Testing
+
+Contract tests use `initSimnet()` via Vitest — no Docker. Simnet uses Clarinet's in-memory chain; epoch behavior differs from devnet but type-checking and logic tests are reliable.
+
+```bash
+stacksdapp test    # runs contracts/tests/*.test.ts
+```
+
+## When to use which version
+
+| Scenario | Recommendation |
+|----------|----------------|
+| New dApp | C6 (default) |
+| Porting existing C5 contract | `--clarity-version 5` or manual 3.4 epoch |
+| Audited C5 codebase | Keep C5; do not upgrade epoch without audit |
+| Mainnet production | Match deployed epoch; test on testnet first |
+
+## Codegen
+
+`stacksdapp generate` reads ABIs regardless of Clarity version. After version changes, always regenerate bindings.

--- a/.cursor/skills/scaffold-stacks/cli-reference.md
+++ b/.cursor/skills/scaffold-stacks/cli-reference.md
@@ -1,0 +1,150 @@
+# CLI reference — stacksdapp
+
+Syntax and flags for Scaffold Stacks 0.2.x. Walkthroughs: https://scaffoldstacks.mintlify.app/
+
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `-v`, `--verbosity` | Repeat for more debug (walk-up root, deploy steps) |
+| `-q`, `--quiet` | Suppress non-error output |
+| `--json` | JSON success/failure payloads; implies quiet human logs |
+| `--color auto\|always\|never` | Terminal colors (default `auto`) |
+| `--root PATH` | Project root; env `STACKSDAPP_ROOT` |
+
+## Exit codes
+
+| Code | `code` field (JSON) | When |
+|------|---------------------|------|
+| 0 | — | Success |
+| 1 | `error` | Generic / unexpected |
+| 2 | `project` | No project found, invalid `--root` |
+| 3 | `prerequisite` | `doctor` fail, missing clarinet/node/rust |
+| 4 | `aborted` | User declined confirmation |
+| 5 | `validation` | Invalid project/contract name, bad flags |
+| 6 | `check` | Clarity type-check failed |
+| 7 | `test` | Vitest failed |
+| 8 | `deploy` | Broadcast/plan/mnemonic failure |
+| 10 | `generate` | Codegen / ABI export failed |
+
+## Commands
+
+### `stacksdapp new <name>`
+
+Scaffold monorepo: contracts, frontend, git hooks, agent skill, default counter contract.
+
+| Flag | Description |
+|------|-------------|
+| `--no-git` | Skip `git init` |
+
+### `stacksdapp init`
+
+Adopt existing Clarinet project. Adds frontend (if missing), support files, bindings, git hooks, agent skill.
+
+Expects `Clarinet.toml` at repo root **or** `contracts/Clarinet.toml`. Normalizes standard Clarinet layout into scaffold layout.
+
+### `stacksdapp upgrade`
+
+Refresh npm deps, regenerate bindings, refresh git hooks and agent skill. Non-destructive to user contracts.
+
+### `stacksdapp doctor`
+
+Checks Rust 1.75+, Node 20+, Clarinet 3.23+ (C6 devnet), Docker (for devnet), git hooks path.
+
+| Flag | Description |
+|------|-------------|
+| `--strict` | Warnings → non-zero exit |
+
+### `stacksdapp add <name>`
+
+Add contract to `contracts/contracts/<name>.clar`, update `Clarinet.toml`, regenerate bindings.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--template` | `blank` | `blank`, `sip010`, `sip009` |
+| `--clarity-version` | `6` | `4`, `5`, or `6` — sets matching epoch |
+
+### `stacksdapp check`
+
+Run Clarinet type-checker on all contracts.
+
+### `stacksdapp generate`
+
+Export ABIs → TypeScript bindings + debug UI. Uses `contracts/.cache/` when sources unchanged.
+
+| Flag | Description |
+|------|-------------|
+| `--watch` | Regenerate on `.clar` changes |
+
+### `stacksdapp test`
+
+Run Vitest in `contracts/` (initSimnet) and frontend tests.
+
+### `stacksdapp clean`
+
+Remove `contracts/.cache/`, devnet state, generated frontend bindings.
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Skip confirmation |
+
+### `stacksdapp dev`
+
+| Flag | Description |
+|------|-------------|
+| `--network devnet\|testnet\|mainnet` | Default: devnet (Docker). Remote networks = frontend only |
+| `--auto-deploy` | Devnet only: deploy once chain healthy |
+| `--keep-state` | Devnet: preserve cache between runs |
+
+### `stacksdapp deploy`
+
+| Flag | Description |
+|------|-------------|
+| `--network` | `devnet`, `testnet`, `mainnet` (default from `stacksdapp.toml`) |
+| `--contract NAME` | Single contract |
+| `--dry-run` | Plan + fee, no broadcast |
+| `-y`, `--yes` | Non-interactive (required for CI/agents) |
+| `--wait-confirm` | Poll until confirmed on-chain (testnet/mainnet) |
+| `--no-auto-version` | Fail instead of renaming on collision |
+
+### `stacksdapp completions <shell>`
+
+Generate shell completions: bash, zsh, fish, powershell, elvish.
+
+## Configuration files
+
+| Path | Role |
+|------|------|
+| `stacksdapp.toml` | Project marker; `defaults.network` |
+| `contracts/Clarinet.toml` | Contract registry, clarity_version, epoch |
+| `contracts/settings/Devnet.toml` | Local devnet accounts (public test mnemonics) |
+| `contracts/settings/Testnet.toml` | Testnet deployer mnemonic |
+| `contracts/settings/Mainnet.toml` | Mainnet deployer mnemonic |
+| `frontend/.env.local` | `NEXT_PUBLIC_NETWORK`, optional node URL |
+| `contracts/.cache/` | Cached ABIs |
+| `frontend/src/generated/*` | Generated — do not edit |
+| `.githooks/pre-commit` | Blocks likely seed phrases in Testnet/Mainnet settings |
+| `.cursor/skills/scaffold-stacks/` | Bundled agent skill |
+
+## Name validation
+
+- **Project name:** single segment, letters/digits/`-`/`_`, no `..` or absolute paths
+- **Contract name:** Clarity identifier, letter first, max 40 chars
+
+## JSON output
+
+With `--json`, success payloads include `"ok": true` and command-specific fields. Failures include `"ok": false`, `"error"`, `"code"`, `"exit_code"`.
+
+Example: `stacksdapp doctor --json`
+
+## Prerequisites
+
+| Tool | Minimum |
+|------|---------|
+| Rust | 1.75+ |
+| Node.js | 20+ |
+| Clarinet | 3.23+ (C6 devnet) |
+| Docker | Devnet only |
+| Wallet | Leather or Xverse for testnet/mainnet UI |
+
+Install CLI: `cargo install stacksdapp`

--- a/.cursor/skills/scaffold-stacks/frontend.md
+++ b/.cursor/skills/scaffold-stacks/frontend.md
@@ -1,0 +1,593 @@
+# Frontend — hooks, wallet, and infra
+
+Next.js 15 + React 18 + Tailwind + Jotai + `@stacks/connect` v8 + `@stacks/transactions` v7.
+
+After `stacksdapp generate` and `stacksdapp deploy`, the frontend calls deployed contracts via **reusable generated hooks**.
+
+## Full-stack checklist (custom UI + hooks)
+
+Use this end-to-end when building a dApp with your own frontend (not only the debug panel):
+
+```
+1. stacksdapp new my-app && cd my-app
+2. Edit contracts/contracts/*.clar  (or stacksdapp add …)
+3. stacksdapp check && stacksdapp generate && stacksdapp test
+4. Set deployer mnemonic in contracts/settings/Testnet.toml
+5. stacksdapp deploy --network testnet --yes   → writes deployments.json
+6. Create frontend/src/components/YourFeature.tsx  ("use client", import hooks)
+7. Add <YourFeature /> to frontend/src/app/page.tsx (or a new app/*/page.tsx)
+8. stacksdapp dev --network testnet   # MUST match deploy network (not bare dev if deployed to testnet)
+9. Connect wallet (testnet/mainnet) → call public functions from your component
+```
+
+Keep `<DebugContracts />` on the home page while building — it validates hooks work; ship custom UI alongside or replace it later.
+
+## Architecture
+
+```
+contracts/*.clar
+    ↓ stacksdapp generate
+frontend/src/generated/
+    contracts.ts      ← low-level call functions
+    hooks.ts          ← React hooks wrapping contracts.ts
+    DebugContracts.tsx← debug UI (uses hooks)
+    deployments.json  ← on-chain addresses (written by deploy)
+         ↓
+frontend/src/components/   ← your custom UI (edit here)
+frontend/src/app/          ← Next.js pages
+frontend/src/lib/devnet.ts ← devnet burner signing (hand-edited)
+frontend/src/scaffold.config.ts ← network config (hand-edited)
+```
+
+**Rule:** Never edit `generated/*`. Build custom UI in `components/` and import from `@/generated/hooks` or `@/generated/contracts`.
+
+## Imports and paths
+
+`frontend/tsconfig.json` maps `@/*` → `./src/*`:
+
+```tsx
+import { useCounter_Increment } from '@/generated/hooks';
+import { counter_increment } from '@/generated/contracts';
+import { scaffoldConfig } from '@/scaffold.config';
+import { useAtomValue } from 'jotai';
+import { addressAtom } from '@/store/wallet';
+```
+
+## Discovering hooks after generate
+
+Each public/read-only function gets one hook in `frontend/src/generated/hooks.ts`:
+
+| Contract `counter` | Function `increment` | Hook `useCounter_Increment` |
+| Contract `my-token` | Function `transfer` | Hook `useMyToken_Transfer` |
+
+Naming: `use` + `{ContractPascalCase}` + `_` + `{FunctionPascalCase}`.
+
+After `stacksdapp add my-nft` → `stacksdapp generate` → new hooks appear automatically. Search `hooks.ts` or let TypeScript autocomplete imports.
+
+## deployments.json
+
+Contract calls resolve addresses from `frontend/src/generated/deployments.json`:
+
+```json
+{ "contracts": { "counter": { "contract_id": "ST....counter" } } }
+```
+
+- Written by `stacksdapp deploy`
+- If missing, `contracts.ts` logs a warning and calls return `undefined` / `null`
+- After redeploy with auto-versioning (`counter-v2`), regenerate is automatic via deploy; run `stacksdapp generate` if bindings drift
+
+## scaffold.config.ts
+
+Driven by `frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_NETWORK=devnet   # devnet | testnet | mainnet
+# NEXT_PUBLIC_STACKS_NODE_URL=...   # optional override
+# NEXT_PUBLIC_HIRO_API_KEY=...      # optional Hiro API key for read calls
+```
+
+Exports `scaffoldConfig`:
+
+| Field | Purpose |
+|-------|---------|
+| `network` | Active network |
+| `nodeUrl` | Hiro API (devnet: `http://localhost:3999`) |
+| `targetNetwork` | Wallet request network (`testnet` when UI is devnet) |
+| `isDevnet` / `isTestnet` / `isMainnet` | Branching helpers |
+| `getReadOnlyNetwork()` | Network object for read-only RPC calls |
+
+`stacksdapp dev --network testnet` updates `.env.local` automatically.
+
+## Signing model (critical)
+
+| Network | Public (write) calls | Read-only calls |
+|---------|----------------------|-----------------|
+| **devnet** | `lib/devnet.ts` — public burner keys, no wallet popup | `fetchCallReadOnlyFunction` via node |
+| **testnet/mainnet** | `@stacks/connect` `request('stx_callContract')` — **wallet popup** | `fetchCallReadOnlyFunction` via Hiro |
+
+**Do not** expect Leather/Xverse to sign devnet writes — devnet uses template burner mnemonics (same as `contracts/settings/Devnet.toml`). Wallet connect is for testnet/mainnet UX and display.
+
+## contracts.ts (generated)
+
+One async function per contract function:
+
+```ts
+// Naming: {contractCamel}_{functionCamel}
+counter_increment(functionArgs, postConditions?)
+counter_getCount(functionArgs, senderAddress?)
+```
+
+- **Public:** devnet → `callDevnetContract`; testnet/mainnet → wallet `request()`
+- **Read-only:** always RPC via `fetchCallReadOnlyFunction` + `cvToValue`
+- Import `Cl` from `@stacks/transactions` to build args (see table below)
+- Read-only `data` is JSON from `cvToValue` (numbers, booleans, objects, `(ok …)` / `(err …)` shapes)
+
+### Parsing hook `data` — avoid `BigInt([object Object])`
+
+Read-only hooks (e.g. `useMyToken_GetBalance`, `useMyToken_GetTotalSupply`) return **`cvToValue` output**, not plain JavaScript numbers.
+
+For Clarity `(response uint uint)` functions like SIP-010 `get-balance`, `data` is typically a **cvToJSON-shaped object**, not a `bigint`:
+
+```ts
+// hook.data after get-balance — NOT a bigint
+{ type: "uint", value: "1500000" }
+```
+
+**Wrong** (throws `Cannot convert [object Object] to a BigInt`):
+
+```tsx
+function formatTokenAmount(raw: unknown, decimals = 6): string {
+  const value = typeof raw === "bigint" ? raw : BigInt(String(raw)); // raw is { type, value }
+  // ...
+}
+```
+
+**Right** — unwrap cvToJSON shapes first, then format:
+
+```tsx
+/** Extract a Clarity uint/int from hook `data` (cvToValue / cvToJSON shapes). */
+function clarityUintToBigInt(raw: unknown): bigint | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "bigint") return raw;
+  if (typeof raw === "number" && Number.isFinite(raw)) return BigInt(Math.trunc(raw));
+  if (typeof raw === "string" && raw !== "") return BigInt(raw);
+
+  if (typeof raw === "object") {
+    const obj = raw as { type?: string; value?: unknown };
+    // (ok uint) / (ok int) from read-only calls
+    if (obj.type === "uint" || obj.type === "int") {
+      return BigInt(String(obj.value));
+    }
+    // (optional uint), nested some, etc.
+    if ("value" in obj && obj.value != null) {
+      return clarityUintToBigInt(obj.value);
+    }
+  }
+  return null;
+}
+
+function formatTokenAmount(raw: unknown, decimals = 6): string {
+  const value = clarityUintToBigInt(raw);
+  if (value === null) return "—";
+  const whole = value / BigInt(10 ** decimals);
+  const fraction = value % BigInt(10 ** decimals);
+  const fractionStr = fraction
+    .toString()
+    .padStart(decimals, "0")
+    .replace(/0+$/, "");
+  return fractionStr ? `${whole}.${fractionStr}` : String(whole);
+}
+```
+
+Usage with generated hooks:
+
+```tsx
+"use client";
+import { useEffect } from "react";
+import { useMyToken_GetBalance } from "@/generated/hooks";
+import { Cl } from "@stacks/transactions";
+import { useAtomValue } from "jotai";
+import { addressAtom } from "@/store/wallet";
+
+export function BalanceDisplay() {
+  const address = useAtomValue(addressAtom);
+  const { call, data, loading } = useMyToken_GetBalance();
+
+  useEffect(() => {
+    if (address) void call([Cl.principal(address)]);
+  }, [call, address]);
+
+  if (loading) return <p>Loading…</p>;
+  return <p>Balance: {formatTokenAmount(data)}</p>; // pass hook.data, not data.value blindly
+}
+```
+
+**Agent rules for display helpers:**
+
+| `data` shape | What to do |
+|--------------|------------|
+| `{ type: "uint", value: "123" }` | Use `BigInt(obj.value)` — SIP-010 amounts are **base units** (divide by `10**decimals` for display) |
+| `{ type: "(optional …)", value: … }` | Recurse into `.value` |
+| `{ type: "bool", value: true }` | Use `.value` directly — do not `BigInt()` |
+| `string` / `bigint` | `BigInt(raw)` after null check |
+| Unsure | `console.log(JSON.stringify(data))` once, then write extractor |
+
+**Never** `BigInt(hook.data)` or `BigInt(String(hook.data))` when `data` comes from a read-only hook — always unwrap first.
+
+### Read-only RPC — avoid `Failed to fetch`
+
+Generated read-only functions (e.g. `airdropTokenV2_getBalance` in `contracts.ts`) call Hiro / local node via `fetchCallReadOnlyFunction`. Browser `TypeError: Failed to fetch` means the **HTTP request never succeeded** — not a Clarity revert.
+
+Typical stack trace:
+
+```
+Failed to fetch
+src/generated/contracts.ts … fetchCallReadOnlyFunction({ … functionName: 'get-balance'
+```
+
+#### Root causes (check in order)
+
+| Cause | Symptom | Fix |
+|-------|---------|-----|
+| **Network env mismatch** | Deployed to testnet, app still on devnet (`localhost:3999`) | Set `NEXT_PUBLIC_NETWORK=testnet` in `frontend/.env.local`, or run `stacksdapp dev --network testnet` (updates env automatically). **Restart** Next.js after changing env. |
+| **Devnet node down** | Request to `http://localhost:3999/...` fails | Run `stacksdapp dev` (Docker). Do not use `npm run dev` alone on devnet without the stacks node. |
+| **Contract not deployed** | `deployments.json` missing entry; console warns `"airdrop-token-v2" not deployed` | `stacksdapp deploy --network testnet --contract airdrop-token-v2 --yes` |
+| **Wrong chain for address** | `deployments.json` has `ST…` contract but app points at mainnet (or vice versa) | Match `NEXT_PUBLIC_NETWORK` to deploy network; ST* = testnet, SP* = mainnet |
+| **Invalid / missing principal arg** | `get-balance` called with `undefined`, `""`, or before wallet connect | Guard: only call when address is a valid `ST…` / `SP…` principal |
+| **Hiro rate limit / blocker** | Intermittent failures to `api.testnet.hiro.so` | Add `NEXT_PUBLIC_HIRO_API_KEY=…` in `.env.local`; disable ad-blocker for Hiro domains |
+| **Calling from server** | Error during SSR / in non-client component | Read-only hooks only in `"use client"` components |
+
+**Agent rule:** After `stacksdapp deploy --network testnet`, always run `stacksdapp dev --network testnet` (not bare `stacksdapp dev` which defaults to devnet).
+
+#### Pre-flight before read-only hooks
+
+```bash
+# 1. Contract deployed on intended network
+cat frontend/src/generated/deployments.json   # must contain "airdrop-token-v2": { "contract_id": "ST…" }
+
+# 2. Frontend network matches deploy
+grep NEXT_PUBLIC_NETWORK frontend/.env.local  # testnet if contract_id starts with ST
+
+# 3. Node reachable (pick one)
+curl -s -o /dev/null -w "%{http_code}" https://api.testnet.hiro.so/v2/info   # expect 200
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3999/v2/info        # devnet only, expect 200 when stacksdapp dev is up
+```
+
+#### Safe read-only hook pattern (guards + error UI)
+
+Do **not** fire `get-balance` on mount unconditionally. Guard address, deployment, and network:
+
+```tsx
+"use client";
+import { useEffect } from "react";
+import { useAirdropTokenV2_GetBalance } from "@/generated/hooks";
+import { Cl } from "@stacks/transactions";
+import { useAtomValue } from "jotai";
+import { addressAtom } from "@/store/wallet";
+import { scaffoldConfig } from "@/scaffold.config";
+import deployments from "@/generated/deployments.json";
+
+const CONTRACT = "airdrop-token-v2";
+
+function isValidPrincipal(addr: string | null | undefined): addr is string {
+  return typeof addr === "string" && /^(ST|SP)[0-9A-HJ-NP-Z]{38,41}$/.test(addr);
+}
+
+export function TokenBalance() {
+  const walletAddress = useAtomValue(addressAtom);
+  const { call, data, loading, error } = useAirdropTokenV2_GetBalance();
+
+  const contractId = deployments?.contracts?.[CONTRACT]?.contract_id as string | undefined;
+  const isDeployed = Boolean(contractId);
+
+  useEffect(() => {
+    if (!isDeployed) return;
+    if (!isValidPrincipal(walletAddress)) return;
+    // Avoid unhandled rejection noise — hook sets `error`
+    void call([Cl.principal(walletAddress)]).catch(() => {});
+  }, [call, walletAddress, isDeployed]);
+
+  if (!isDeployed) {
+    return (
+      <p>
+        {CONTRACT} not deployed — run{" "}
+        <code>stacksdapp deploy --network testnet --contract {CONTRACT} --yes</code>
+      </p>
+    );
+  }
+
+  if (scaffoldConfig.isDevnet) {
+    return (
+      <p>
+        Devnet mode — ensure <code>stacksdapp dev</code> is running (node: {scaffoldConfig.nodeUrl})
+      </p>
+    );
+  }
+
+  if (!isValidPrincipal(walletAddress)) {
+    return <p>Connect wallet to view balance</p>;
+  }
+
+  if (loading) return <p>Loading balance…</p>;
+
+  if (error) {
+    return (
+      <p>
+        Could not load balance ({error.message}). Check{" "}
+        <code>NEXT_PUBLIC_NETWORK={scaffoldConfig.network}</code> matches deploy network and Hiro is
+        reachable.
+      </p>
+    );
+  }
+
+  return <p>Balance: {formatTokenAmount(data)}</p>;
+}
+```
+
+#### Debugging in browser DevTools
+
+1. **Network tab** — find the failed request URL:
+   - `localhost:3999` → devnet not running or wrong `NEXT_PUBLIC_NETWORK`
+   - `api.testnet.hiro.so` → Hiro outage, rate limit, or blocker
+2. **Console** — look for `[scaffold-stacks] "…" not deployed` before the fetch error
+3. **Compare** `deployments.json` `contract_id` prefix with `scaffoldConfig.network`
+
+#### Optional: Hiro API key (rate limits)
+
+In `frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_HIRO_API_KEY=your_hiro_platform_api_key
+```
+
+`scaffold.config.ts` passes this to `getReadOnlyNetwork()` for read-only calls.
+
+### Building `ClarityValue[]` arguments
+
+| Clarity type | TypeScript |
+|--------------|------------|
+| `uint` | `Cl.uint(n)` or `Cl.uint(BigInt(n))` |
+| `int` | `Cl.int(n)` |
+| `bool` | `Cl.bool(true)` |
+| `principal` | `Cl.principal('ST…')` |
+| `(string-ascii …)` | `Cl.stringAscii('hello')` |
+| `(string-utf8 …)` | `Cl.stringUtf8('hello')` |
+| `(buff …)` | `Cl.bufferFromHex('0x…')` |
+| `(tuple (field-a …) …)` | `Cl.tuple({ 'field-a': Cl.uint(1), … })` |
+| `(list …)` | `Cl.list([Cl.uint(1), Cl.uint(2)])` |
+| `(optional …)` | `Cl.none()` or `Cl.some(Cl.uint(1))` |
+
+Check the generated debug UI or contract ABI for exact field names. For complex args, reference `DebugContracts.tsx` form handling.
+
+### Post-conditions
+
+Generated **hooks** call public functions with default empty post-conditions (`[]`). Wallet requests use `postConditionMode: 'allow'`.
+
+For explicit post-conditions, call **`contracts.ts` directly**:
+
+```ts
+import { counter_increment } from '@/generated/contracts';
+import { Pc, PostConditionMode } from '@stacks/transactions';
+
+await counter_increment([Cl.uint(1)], [
+  Pc.principal('ST…').willSendLte(1000).ustx(),
+]);
+```
+
+Devnet path uses `PostConditionMode.Deny` in `lib/devnet.ts`.
+
+## hooks.ts (generated)
+
+One hook per public/read-only function:
+
+```ts
+// Naming: use{ContractPascal}_{FunctionPascal}
+import { useCounter_Increment } from '@/generated/hooks';
+
+function MyButton() {
+  const { call, data, loading, error, txid, txStatus, txStatusError, explorerUrl } =
+    useCounter_Increment();
+
+  return (
+    <button
+      disabled={loading}
+      onClick={() => call([])}  // ClarityValue[] — empty if no args
+    >
+      {loading ? '…' : 'Increment'}
+    </button>
+  );
+}
+```
+
+### Hook return values
+
+| Field | Meaning |
+|-------|---------|
+| `call(args)` | Invoke the contract function |
+| `data` | Last result |
+| `loading` | In-flight |
+| `error` | Thrown error |
+| `txid` | Public calls only — broadcast tx id |
+| `txStatus` | `pending` \| `success` \| `abort_by_response` \| `error` |
+| `txStatusError` | Revert message when aborted |
+| `explorerUrl` | Hiro explorer link for `txid` |
+
+Public hooks poll `${nodeUrl}/extended/v1/tx/{txid}` until success/abort (respects `NEXT_PUBLIC_HIRO_API_KEY`).
+
+Read-only hooks resolve on `call()` — no txid polling.
+
+### Composing multiple hooks
+
+Use several hooks in one client component — each manages its own loading/tx state:
+
+```tsx
+"use client";
+import { useCounter_GetCount, useCounter_Increment } from '@/generated/hooks';
+
+export function CounterPanel() {
+  const read = useCounter_GetCount();
+  const write = useCounter_Increment();
+  // call read.call([]) to refresh; write.call([]) to increment
+}
+```
+
+## Wallet infra (hand-edited)
+
+```
+app/layout.tsx
+  └── WalletProvider          # syncs @stacks/connect → Jotai
+        ├── Header            # WalletConnect + NetworkBadge
+        └── page content
+
+store/wallet.ts
+  addressAtom                 # persisted STX address (localStorage)
+  isMountedAtom               # SSR guard
+
+components/WalletConnect.tsx
+  connect() / disconnect()    # @stacks/connect v8
+```
+
+- `WalletConnect` shows connect button or truncated address
+- User must connect wallet on **testnet/mainnet** before public calls from custom UI
+- Debug UI on devnet works without wallet (burner keys)
+
+### Show connected address in custom UI
+
+```tsx
+"use client";
+import { useAtomValue } from 'jotai';
+import { addressAtom } from '@/store/wallet';
+
+export function MyPanel() {
+  const address = useAtomValue(addressAtom);
+  if (!address) return <p>Connect wallet to continue</p>;
+  return <p>Signed in as {address}</p>;
+}
+```
+
+## Debug UI
+
+```
+components/debug/DebugContracts.tsx   → re-exports @/generated/DebugContracts
+app/page.tsx                          → renders <DebugContracts />
+```
+
+Auto-generated debug panel: tabs per contract, forms per function, shows tx status. Use as reference for hook usage; customize by building your own components importing the same hooks.
+
+## Devnet burners (`lib/devnet.ts`)
+
+- Derives keys from public template mnemonics (`deployer`, `wallet_1`…)
+- `ensureDefaultBurner()` — default sender `wallet_1`
+- `getDevnetSenderAddress()` — used as read-only sender on devnet
+- `callDevnetContract()` — broadcasts with `PostConditionMode.Deny`
+
+**Never** reuse devnet burners on testnet/mainnet.
+
+## Custom UI workflow
+
+1. Edit / add contracts → `stacksdapp check && stacksdapp generate && stacksdapp test`
+2. Deploy → `stacksdapp deploy --network testnet --yes`
+3. Create component in `frontend/src/components/`:
+
+```tsx
+"use client";
+import { useCounter_GetCount } from '@/generated/hooks';
+import { useEffect } from 'react';
+
+export function CounterDisplay() {
+  const { call, data, loading } = useCounter_GetCount();
+
+  useEffect(() => { void call([]); }, [call]);
+
+  if (loading) return <p>Loading…</p>;
+  return <p>Count: {JSON.stringify(data)}</p>;
+}
+```
+
+4. Import into `app/page.tsx` or create `app/dashboard/page.tsx` (Next.js App Router)
+5. Run `stacksdapp dev --network testnet` (or devnet with Docker)
+
+### SIP-010 / SIP-009 in custom UI
+
+After `stacksdapp add my-token --template sip010` and deploy:
+
+```tsx
+"use client";
+import { useMyToken_GetBalance, useMyToken_Transfer } from '@/generated/hooks';
+import { Cl } from '@stacks/transactions';
+
+export function TokenPanel() {
+  const balance = useMyToken_GetBalance();
+  const transfer = useMyToken_Transfer();
+  // balance.call([Cl.principal('ST…')])
+  // transfer.call([Cl.uint(100), Cl.principal('ST…')])
+}
+```
+
+Same hook pattern for SIP-009 NFT contracts — see [sip-standards.md](sip-standards.md) for trait functions and hook arg examples.
+
+### Contract tests (backend)
+
+When adding functions, extend `contracts/tests/*.test.ts` using `simnet` + `Cl` from `@stacks/transactions`. Run `stacksdapp test` before deploy — no Docker required.
+
+## Live reload
+
+- **`stacksdapp dev`** (devnet): file watcher regenerates bindings when `.clar` files change
+- **`stacksdapp dev --network testnet`**: run `stacksdapp generate --watch` in a second terminal, or regenerate manually after edits
+- **`stacksdapp generate --watch`**: standalone ABI watcher from project root
+
+After regenerate, new hooks appear in `hooks.ts` — refresh imports in your components.
+
+## Direct contract calls (no hook)
+
+For non-React code or one-off scripts inside the app:
+
+```ts
+import { counter_increment } from '@/generated/contracts';
+import { Cl } from '@stacks/transactions';
+
+await counter_increment([]);
+```
+
+Prefer hooks in React components for loading/error/tx state.
+
+## Frontend scripts
+
+```bash
+cd frontend
+npm run dev          # or stacksdapp dev from project root
+npm run build
+npm run typecheck
+npm test             # vitest (optional frontend tests)
+```
+
+## Common agent mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Edit `generated/hooks.ts` | Run `stacksdapp generate` |
+| Expect wallet popup on devnet | Devnet uses burners in `lib/devnet.ts` |
+| Call contract before deploy | Deploy first; check `deployments.json` |
+| Wrong network in wallet vs app | Match wallet network to `NEXT_PUBLIC_NETWORK` |
+| Skip `"use client"` in hook components | Hooks require client components |
+| Build args as plain JS | Use `Cl.*` from `@stacks/transactions` |
+| `BigInt(hook.data)` on read-only uint | Unwrap cvToJSON shape first — see **Parsing hook data** above |
+| Pass `data` straight to `formatTokenAmount` without unwrapping | SIP-010 `get-balance` returns `{ type: "uint", value: "…" }`, not `bigint` |
+| Fire read-only hooks on mount without guards | Wait for valid wallet address + deployed contract; handle `hook.error` |
+| `stacksdapp dev` after testnet deploy | Use `stacksdapp dev --network testnet` so `.env.local` matches `deployments.json` |
+| `npm run dev` alone on devnet | Needs `stacksdapp dev` — local node at `localhost:3999` |
+| Remove DebugContracts too early | Keep it while validating new hooks |
+| Forget redeploy after new contract | `deploy` then verify `deployments.json` |
+
+## Skill coverage map
+
+| Full-stack need | Documented in |
+|-----------------|---------------|
+| CLI: new, add, check, generate, test, deploy | `SKILL.md`, `workflows.md`, `cli-reference.md` |
+| Clarity versions / epochs | `clarity-versions.md` |
+| Clarity language + learning links | `clarity-language.md` |
+| SIP-010 / SIP-009 specs + templates | `sip-standards.md` |
+| Generated hooks + custom components | `frontend.md` |
+| Wallet vs devnet signing | this file |
+| Project directories | `project-layout.md` |
+| Errors / devnet stall | `troubleshooting.md` |

--- a/.cursor/skills/scaffold-stacks/project-layout.md
+++ b/.cursor/skills/scaffold-stacks/project-layout.md
@@ -1,0 +1,129 @@
+# Project layout
+
+Scaffold Stacks monorepo structure after `stacksdapp new` or `stacksdapp init`.
+
+## Root
+
+```
+.
+├── stacksdapp.toml          # [project] name, [defaults] network = "devnet"
+├── AGENTS.md                # Pointer for non-Cursor agents
+├── package.json             # npm scripts wrapping stacksdapp commands
+├── .gitignore
+├── .githooks/
+│   └── pre-commit           # Mnemonic guard for Testnet/Mainnet settings
+└── .cursor/
+    └── skills/
+        └── scaffold-stacks/ # Agent skill (auto-installed)
+```
+
+## contracts/
+
+```
+contracts/
+├── Clarinet.toml            # [contracts.*] path, clarity_version, epoch
+├── contracts/
+│   └── *.clar               # Clarity source — primary edit surface
+├── settings/
+│   ├── Devnet.toml          # Public burner mnemonics (devnet only)
+│   ├── Testnet.toml         # User's testnet deployer
+│   └── Mainnet.toml         # User's mainnet deployer
+├── tests/
+│   └── *.test.ts            # Vitest + clarinet-sdk initSimnet
+├── deployments/             # Clarinet deployment plans (generated/updated on deploy)
+├── package.json             # @stacks/clarinet-sdk, vitest
+├── vitest.config.ts
+├── tsconfig.json
+├── .cache/                  # ABI export cache (gitignored)
+└── .devnet/                 # Local devnet state (gitignored)
+```
+
+### Clarinet.toml
+
+Each contract entry includes:
+
+```toml
+[contracts.counter]
+path = "contracts/counter.clar"
+clarity_version = 6
+epoch = "4.0"
+```
+
+Project-level `clarity_version` in `[project]` may also appear; per-contract settings take precedence for deploy.
+
+## frontend/
+
+```
+frontend/
+├── src/
+│   ├── app/                 # Next.js app router pages
+│   ├── components/          # UI components (editable)
+│   │   └── debug/           # Debug panel wrapper
+│   ├── generated/           # AUTO-GENERATED — run stacksdapp generate
+│   │   ├── contracts.ts
+│   │   ├── hooks.ts
+│   │   ├── DebugContracts.tsx
+│   │   └── deployments.json # Written on deploy
+│   ├── lib/devnet.ts        # devnet burner signing
+│   ├── store/wallet.ts      # Jotai wallet state
+│   └── scaffold.config.ts   # network / node URL config
+├── scripts/
+│   ├── export-abi.mjs       # Used by codegen pipeline
+│   └── build-tx.mjs
+├── .env.local               # NEXT_PUBLIC_NETWORK=devnet|testnet|mainnet
+└── package.json
+```
+
+## Edit matrix
+
+| Path | Edit? | Action on change |
+|------|-------|------------------|
+| `contracts/contracts/*.clar` | Yes | `check` → `generate` → `test` |
+| `contracts/Clarinet.toml` | Yes | May need redeploy plan regen |
+| `contracts/tests/*.test.ts` | Yes | `stacksdapp test` |
+| `frontend/src/components/**` | Yes | Normal frontend dev |
+| `frontend/src/generated/**` | **No** | `stacksdapp generate` |
+| `contracts/settings/Testnet.toml` | Yes (local) | Never commit real mnemonics |
+| `contracts/.cache/**` | No | Deleted by `stacksdapp clean` |
+
+## Environment variables
+
+### frontend/.env.local
+
+```bash
+NEXT_PUBLIC_NETWORK=devnet          # devnet | testnet | mainnet
+# NEXT_PUBLIC_STACKS_NODE_URL=...    # optional override
+# NEXT_PUBLIC_HIRO_API_KEY=...       # optional Hiro API key
+```
+
+`stacksdapp dev` and deploy update network-related env as needed.
+
+Frontend hooks, wallet, and signing: [frontend.md](frontend.md)
+
+### Agent / CI
+
+```bash
+STACKSDAPP_ROOT=/path/to/project    # Same as --root
+SCAFFOLD_ALLOW_COMMITTED_MNEMONIC=1 # Emergency only — bypass pre-commit hook
+```
+
+## Root discovery
+
+CLI walks up from CWD looking for:
+
+1. `stacksdapp.toml`, or
+2. `contracts/Clarinet.toml`
+
+Standard Clarinet repos (root `Clarinet.toml`) are normalized on `init`/`upgrade` to nested layout.
+
+## Git hooks
+
+After clone, enable mnemonic guard:
+
+```bash
+git config core.hooksPath .githooks
+# or
+npm run setup-hooks
+```
+
+`stacksdapp doctor --strict` warns if hooks are not configured.

--- a/.cursor/skills/scaffold-stacks/sip-standards.md
+++ b/.cursor/skills/scaffold-stacks/sip-standards.md
@@ -1,0 +1,195 @@
+# SIP-010 & SIP-009 — standards + scaffold templates
+
+Scaffold Stacks ships **starter contracts** for fungible tokens (SIP-010) and NFTs (SIP-009). This file maps the specs to `stacksdapp add` templates, Clarity functions, and generated frontend hooks.
+
+## Official specifications
+
+| Standard | Spec | Stacks docs |
+|----------|------|-------------|
+| **SIP-010** (fungible token) | [GitHub SIP-010](https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md) | [Create a fungible token](https://docs.stacks.co/get-started/create-a-token/fungible-tokens.md) |
+| **SIP-009** (NFT) | [GitHub SIP-009](https://github.com/stacksgov/sips/blob/main/sips/sip-009/sip-009-nft-standard.md) | [Create an NFT](https://docs.stacks.co/get-started/create-a-token/non-fungible-tokens.md) |
+| Clarity Book (FT) | [SIP010 chapter](https://book.clarity-lang.org/ch10-03-sip010-ft-standard.html) | — |
+| Clarity Book (NFT) | [SIP009 chapter](https://book.clarity-lang.org/ch10-01-sip009-nft-standard.html) | — |
+
+Metadata extensions: [SIP-016](https://github.com/stacksgov/sips/blob/main/sips/sip-016/sip-016-metadata-schema.md) · [SIP-019 metadata updates](https://github.com/stacksgov/sips/blob/main/sips/sip-019/sip-019-token-metadata-update-notifications.md)
+
+## Scaffold commands (prefer over hand-written tokens)
+
+```bash
+stacksdapp add my-token --template sip010
+stacksdapp add my-nft --template sip009
+stacksdapp add legacy-token --template sip010 --clarity-version 5   # if needed
+```
+
+**Do not** hand-write a token from blog snippets. Use the template — it includes SIP-compatible functions, tests, requirements, and hooks.
+
+Each command creates:
+
+- `contracts/contracts/<name>.clar` with all required SIP **functions** (see below)
+- `contracts/tests/<name>.test.ts` (if no test file exists)
+- `[contracts.<name>]` entry in `Clarinet.toml` with correct epoch
+- `[[project.requirements]]` for the mainnet trait (Clarinet simnet type-checking)
+- Regenerated hooks in `frontend/src/generated/hooks.ts`
+
+## `impl-trait` — testnet vs mainnet (critical)
+
+### Common mistake → explorer error
+
+```
+VM Error: use of undeclared trait <sip-010-trait>
+```
+
+**Cause:** `(impl-trait 'sip-010-trait)` or `(impl-trait '.sip-010-trait)` — a short name with no `(define-trait …)` in the same contract and no full `SP…` contract path.
+
+**Fix:**
+
+1. Prefer `stacksdapp add NAME --template sip010` (or `sip009`) instead of writing from scratch.
+2. Follow the network rules below — **never** paste a bare trait name.
+
+**Never:**
+
+```clarity
+(impl-trait 'sip-010-trait)           ;; WRONG — undeclared trait (most common AI mistake)
+(define-trait sip-010-trait ...)      ;; WRONG shortcut — use deployed mainnet trait for production
+(impl-trait 'SP3....sip-010-trait)    ;; WRONG on testnet — mainnet trait contract is not on testnet chain
+```
+
+### Network rules
+
+| Network | `impl-trait` in token contract | Notes |
+|---------|-------------------------------|-------|
+| **Testnet** | **Omit** `(impl-trait …)` | No standard SIP-010/SIP-009 trait contract is deployed on testnet today. Scaffold templates ship **without** `impl-trait` so testnet deploy succeeds. Functions (`get-name`, `transfer`, …) still match SIP-010. |
+| **Mainnet** | **Required** for wallet listing | Add before deploy: `(impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)` |
+| **Simnet / `stacksdapp test`** | Omit (template default) | Clarinet requirement pulls mainnet trait source for type-checking only |
+
+### Mainnet trait addresses
+
+| Standard | `impl-trait` (mainnet only) | `[[project.requirements]]` (scaffold default) |
+|----------|----------------------------|-----------------------------------------------|
+| SIP-010 | `'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait` | `SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard` |
+| SIP-009 | `'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait` | `SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait` |
+
+Scaffold templates include a **comment** with the exact mainnet `impl-trait` line to uncomment before mainnet deploy.
+
+## SIP-010 trait (required interface)
+
+Seven functions wallets and apps expect:
+
+| Function | Purpose |
+|----------|---------|
+| `transfer(amount, sender, recipient, memo)` | Move tokens |
+| `get-name` | Token name |
+| `get-symbol` | Ticker |
+| `get-decimals` | Display decimals |
+| `get-balance(who)` | Balance of principal |
+| `get-total-supply` | Circulating supply |
+| `get-token-uri` | Optional metadata URI |
+
+Trait definition: [SIP-010 trait section](https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md)
+
+### Scaffold SIP-010 template
+
+The template implements all SIP-010 functions plus:
+
+| Function | Access | Notes |
+|----------|--------|-------|
+| `mint(amount, recipient)` | public | Owner-only; initial supply |
+| `set-token-uri(value)` | public | Owner-only; emits SIP-019-style print |
+| `define-fungible-token` | — | Asset name = contract name |
+
+Default: **6 decimals**, owner = deployer at deploy time.
+
+### SIP-010 test (generated)
+
+```typescript
+simnet.callPublicFn("my-token", "mint", [Cl.uint(100), Cl.standardPrincipal(deployer)], deployer);
+```
+
+### SIP-010 frontend hooks (after generate + deploy)
+
+```tsx
+import { useMyToken_GetBalance, useMyToken_Transfer, useMyToken_Mint } from '@/generated/hooks';
+import { Cl } from '@stacks/transactions';
+
+// read:  useMyToken_GetBalance().call([Cl.principal('ST…')])
+// write: useMyToken_Transfer().call([Cl.uint(100), Cl.principal(sender), Cl.principal(recipient), Cl.none()])
+```
+
+Hook names follow `use{ContractPascal}_{FunctionPascal}` — see [frontend.md](frontend.md).
+
+---
+
+## SIP-009 trait (required interface)
+
+Four functions for NFT interoperability:
+
+| Function | Purpose |
+|----------|---------|
+| `get-last-token-id` | Highest minted id |
+| `get-token-uri(token-id)` | Metadata URI for id |
+| `get-owner(token-id)` | Current owner |
+| `transfer(token-id, sender, recipient)` | Change owner |
+
+Spec: [SIP-009 trait section](https://github.com/stacksgov/sips/blob/main/sips/sip-009/sip-009-nft-standard.md)
+
+### Scaffold SIP-009 template
+
+Implements all SIP-009 functions plus:
+
+| Function | Access | Notes |
+|----------|--------|-------|
+| `mint(recipient)` | public | Owner-only; auto-increments id |
+| `set-base-uri(value)` | public | Owner-only; metadata template with `{id}` |
+| `define-non-fungible-token` | — | Token ids are `uint` |
+| `COLLECTION_LIMIT` | constant | Default cap u1000 |
+
+### SIP-009 test (generated)
+
+```typescript
+simnet.callPublicFn("my-nft", "mint", [Cl.standardPrincipal(deployer)], deployer);
+// expect Cl.uint(1) — first token id
+```
+
+### SIP-009 frontend hooks
+
+```tsx
+import { useMyNft_GetOwner, useMyNft_Mint, useMyNft_Transfer } from '@/generated/hooks';
+
+// useMyNft_GetOwner().call([Cl.uint(1)])
+// useMyNft_Transfer().call([Cl.uint(1), Cl.principal(sender), Cl.principal(recipient)])
+```
+
+---
+
+## End-to-end: token/NFT dApp
+
+```bash
+stacksdapp add my-token --template sip010
+stacksdapp check && stacksdapp generate && stacksdapp test
+stacksdapp deploy --network testnet --contract my-token --yes   # no impl-trait needed
+# For mainnet: uncomment impl-trait line in .clar first, then deploy
+stacksdapp dev --network testnet
+```
+
+Same flow for `--template sip009`.
+
+## Customizing templates
+
+| Goal | Edit in `.clar` |
+|------|-----------------|
+| Change decimals / collection limit | constants at top |
+| Restrict mint | `asserts!` on `tx-sender` |
+| Royalties / marketplace | add functions; keep trait fns compatible |
+| Metadata | `set-token-uri` / `set-base-uri`; consider SIP-016 off-chain JSON |
+| Mainnet wallet listing | Uncomment/add mainnet `impl-trait` line before mainnet deploy |
+
+After edits: `check` → `generate` → `test` → `deploy`.
+
+## Agent rules
+
+- **Always** use `stacksdapp add --template sip010|sip009` for new tokens
+- **Never** add `(impl-trait 'sip-010-trait)` — use full mainnet path or omit for testnet
+- Read the **SIP spec** for interface contracts; read the **scaffold template** for what's already implemented
+- Do not break trait function signatures if wallet compatibility matters
+- Use generated hooks for frontend — do not reimplement transfer in raw `@stacks/transactions` unless necessary
+- Clarity language help: [clarity-language.md](clarity-language.md)

--- a/.cursor/skills/scaffold-stacks/troubleshooting.md
+++ b/.cursor/skills/scaffold-stacks/troubleshooting.md
@@ -1,0 +1,180 @@
+# Troubleshooting
+
+Common issues and agent actions for Scaffold Stacks projects.
+
+## Prerequisites
+
+Always start with:
+
+```bash
+stacksdapp doctor
+stacksdapp doctor --strict   # CI: fail on warnings
+```
+
+| Check fails | Fix |
+|-------------|-----|
+| Rust missing/old | Install via rustup.rs |
+| Node missing | Install Node 20+ |
+| Clarinet missing/old | `brew install clarinet` — need **3.23+** for C6 devnet |
+| Docker missing | Install Docker Desktop for devnet only |
+| Git hooks | `git config core.hooksPath .githooks` or `npm run setup-hooks` |
+
+## Project not found (exit 2)
+
+```
+No scaffold-stacks project found...
+```
+
+- `cd` to directory containing `stacksdapp.toml` or `contracts/Clarinet.toml`
+- Or: `stacksdapp --root /path/to/project <command>`
+- For raw Clarinet repos: run `stacksdapp init` first
+
+## Deploy failures (exit 8)
+
+### Testnet / mainnet
+
+| Symptom | Action |
+|---------|--------|
+| Placeholder mnemonic | Replace `<YOUR PRIVATE...>` in Testnet.toml |
+| Insufficient STX | Fund via testnet faucet |
+| Interactive prompt hangs | Add `--yes` |
+| Tx in mempool, not confirmed | Normal without `--wait-confirm`; check explorer |
+| Wrong network | Match `--network` to settings and wallet |
+
+### Devnet
+
+| Symptom | Action |
+|---------|--------|
+| Deploy never confirms | Chain may be stalled; use `--auto-deploy` or testnet |
+| Port in use | Stop parallel `clarinet devnet start`; `stacksdapp clean --force` |
+| Epoch burn wait | Expected for C5/C6; wait or use testnet |
+
+## Devnet boot stuck
+
+```
+waiting for bitcoin-node / stacks-node...
+```
+
+1. Ensure Docker is running
+2. Stop conflicting containers: `docker ps --filter name=devnet -q | xargs docker stop`
+3. `stacksdapp clean --force`
+4. Retry `stacksdapp dev --auto-deploy`
+5. Do not run manual `clarinet devnet start` alongside `stacksdapp dev`
+
+## Devnet stall after ~block 71
+
+Known issue with long-running local devnet (PoX / signer timeout).
+
+**Workarounds:**
+- Deploy early: `stacksdapp dev --auto-deploy`
+- Use testnet for deploy verification
+- Full reset: `stacksdapp clean --force`, restart Docker, retry
+
+Testnet/mainnet deploy is unaffected.
+
+## Clarity version / epoch mismatch
+
+- C5 requires `epoch = "3.4"` (not `"4.0"`)
+- C6 requires `epoch = "4.0"`
+- Regenerate plans: `cd contracts && clarinet deployments generate --devnet`
+
+Or: `stacksdapp add name --clarity-version 5`
+
+## Bindings out of sync
+
+```bash
+stacksdapp generate
+```
+
+Never patch `frontend/src/generated/*` manually.
+
+## Check failed (exit 6)
+
+Run `stacksdapp check` and fix Clarinet checker errors in `.clar` files.
+
+### `use of undeclared trait <sip-010-trait>` (or `<nft-trait>`)
+
+Explorer / deploy abort with this VM error when `impl-trait` uses a **short trait name** instead of a full on-chain contract path.
+
+| Bad (causes error) | Good |
+|--------------------|------|
+| `(impl-trait 'sip-010-trait)` | **Testnet:** omit `impl-trait` — use `stacksdapp add --template sip010` |
+| `(impl-trait 'SP3....sip-010-trait)` on testnet | **Mainnet only:** full `SP3FBR2…sip-010-trait` path (see [sip-standards.md](sip-standards.md)) |
+
+**Agent actions:**
+
+1. Run `stacksdapp add NAME --template sip010` (or `sip009`) — do not rewrite token from blog snippets
+2. Open [sip-standards.md](sip-standards.md) for the network trait table
+3. Match `[[project.requirements]]` in `Clarinet.toml` to the same network
+4. `stacksdapp check` → `stacksdapp test` → redeploy
+
+## Frontend: `Cannot convert [object Object] to a BigInt`
+
+Common in custom UI when formatting SIP-010 balances or other uint read-only results.
+
+```
+formatTokenAmount(raw) → BigInt(String(raw))
+Cannot convert [object Object] to a BigInt
+```
+
+**Cause:** `raw` is hook `data` from a read-only call. Scaffold uses `cvToValue`, which represents `(ok uint)` as `{ type: "uint", value: "1500000" }` — not a native `bigint`.
+
+**Fix:**
+
+1. Do not `BigInt(hook.data)` directly.
+2. Unwrap with a helper — full example in [frontend.md](frontend.md) (`clarityUintToBigInt` + `formatTokenAmount`).
+3. Remember SIP-010 amounts are **base units**; divide by `10**decimals` for human display.
+
+**Debug:** `console.log(JSON.stringify(data))` on the hook result to see the shape before writing formatters.
+
+## Frontend: `Failed to fetch` on read-only calls
+
+```
+TypeError: Failed to fetch
+src/generated/contracts.ts … fetchCallReadOnlyFunction({ … functionName: 'get-balance'
+```
+
+**Cause:** Browser could not reach the Stacks node — not a contract revert. Most often **network env mismatch** or **devnet node down**.
+
+| Failed request host | Fix |
+|---------------------|-----|
+| `localhost:3999` | Run `stacksdapp dev` (Docker), **or** switch to testnet: `NEXT_PUBLIC_NETWORK=testnet` + restart Next.js |
+| `api.testnet.hiro.so` | Check connectivity; add `NEXT_PUBLIC_HIRO_API_KEY`; disable ad-blocker |
+| Contract deployed but still fails | Verify `deployments.json` has the contract (e.g. `airdrop-token-v2`) and `ST…` prefix matches testnet |
+
+**Agent checklist:**
+
+1. `cat frontend/src/generated/deployments.json` — contract entry exists
+2. `grep NEXT_PUBLIC_NETWORK frontend/.env.local` — matches deploy network (`testnet` for `ST…` contracts)
+3. After testnet deploy: `stacksdapp dev --network testnet` (not default devnet)
+4. In custom UI: guard read-only `call()` until wallet address is valid; show `hook.error` — full pattern in [frontend.md](frontend.md)
+5. Restart Next.js after any `.env.local` change
+
+## Tests failed (exit 7)
+
+Run `stacksdapp test`. Contract tests use simnet — no Docker.
+
+## Generate failed (exit 10)
+
+- Validate `contracts/Clarinet.toml`
+- Run `npm install` in `contracts/` and `frontend/`
+- `stacksdapp clean --force` then `stacksdapp generate`
+
+## Init conflicts
+
+Merge duplicate `settings/`, `tests/`, or `deployments/` dirs before rerunning `stacksdapp init`.
+
+## Git hook blocked commit
+
+Unstage real mnemonics from Testnet/Mainnet settings. Emergency bypass: `SCAFFOLD_ALLOW_COMMITTED_MNEMONIC=1 git commit`
+
+## Mnemonic security
+
+- Devnet template mnemonics are public — devnet only
+- Pre-commit hook blocks likely seed phrases in Testnet/Mainnet.toml
+
+## Getting help
+
+- Docs: https://scaffoldstacks.mintlify.app/
+- Telegram: https://telegram.me/+CBp6wSIiXNhmMjZk
+- GitHub: https://github.com/scaffold-stack/scaffold-stack

--- a/.cursor/skills/scaffold-stacks/workflows.md
+++ b/.cursor/skills/scaffold-stacks/workflows.md
@@ -1,0 +1,177 @@
+# Workflows
+
+Step-by-step patterns for common Scaffold Stacks tasks.
+
+## New project → testnet deploy
+
+Recommended first path (no Docker):
+
+```bash
+stacksdapp new my-app && cd my-app
+stacksdapp doctor
+```
+
+1. Fund testnet STX: https://explorer.hiro.so/sandbox/faucet?chain=testnet
+2. Edit `contracts/settings/Testnet.toml` with deployer mnemonic (local only; never commit)
+3. Edit `contracts/contracts/counter.clar` as needed
+4. `stacksdapp check && stacksdapp generate && stacksdapp test`
+5. `stacksdapp deploy --network testnet --yes`
+6. `stacksdapp dev --network testnet` → http://localhost:3000
+
+Connect Leather/Xverse on testnet. Debug UI calls contract functions.
+
+## Full-stack: custom frontend + reusable hooks
+
+End-to-end path when the user wants their own UI (not just the debug panel):
+
+1. **Contracts** — edit `contracts/contracts/*.clar` or `stacksdapp add …`
+2. **Validate** — `stacksdapp check && stacksdapp generate && stacksdapp test`
+3. **Deploy** — `stacksdapp deploy --network testnet --yes` (populates `deployments.json`)
+4. **Custom UI** — create `frontend/src/components/Feature.tsx` with `"use client"`; import hooks from `@/generated/hooks`
+5. **Page** — add component to `app/page.tsx` or a new App Router route
+6. **Run** — `stacksdapp dev --network testnet`; connect wallet for public calls
+
+Hook naming, `Cl.*` args, wallet vs devnet signing, post-conditions: [frontend.md](frontend.md)
+
+Keep `<DebugContracts />` during development to compare behavior with your custom components.
+
+## Contract iteration loop
+
+```bash
+# edit contracts/contracts/*.clar
+stacksdapp check
+stacksdapp generate        # or stacksdapp dev (includes watcher)
+stacksdapp test
+stacksdapp deploy --network testnet --yes
+```
+
+With `stacksdapp dev --network testnet`, run `generate` manually or use `generate --watch` in a second terminal.
+
+## Add SIP-010 token
+
+```bash
+stacksdapp add my-token --template sip010
+```
+
+Customize `contracts/contracts/my-token.clar`, then check → generate → test → deploy. Trait functions, hooks, and spec links: [sip-standards.md](sip-standards.md).
+
+## Add SIP-009 NFT
+
+```bash
+stacksdapp add my-nft --template sip009
+```
+
+Same workflow — see [sip-standards.md](sip-standards.md) for trait table and hook examples.
+
+## Adopt existing Clarinet project
+
+From repo with `Clarinet.toml` (standard or nested layout):
+
+```bash
+stacksdapp init
+```
+
+Init will:
+- Normalize layout to `contracts/Clarinet.toml` + `contracts/contracts/*.clar`
+- Add frontend template (if missing)
+- Install npm deps, generate bindings, git hooks, agent skill
+- Write `stacksdapp.toml` if missing
+
+Then:
+
+```bash
+stacksdapp deploy --network testnet --yes
+stacksdapp dev --network testnet
+```
+
+Guide: https://scaffoldstacks.mintlify.app/adopt-existing.md
+
+## Local devnet
+
+Requires Docker Desktop.
+
+```bash
+stacksdapp doctor
+stacksdapp dev --auto-deploy
+```
+
+- Boots Clarinet devnet + Next.js + file watcher
+- `--auto-deploy` deploys contracts once `:20443` is healthy (recommended)
+- Devnet mnemonics in `settings/Devnet.toml` are public — devnet only
+
+**Deploy separately:**
+
+```bash
+stacksdapp dev                    # terminal 1
+stacksdapp deploy --network devnet --yes   # terminal 2, soon after boot
+```
+
+Guide: https://scaffoldstacks.mintlify.app/local-devnet.md
+
+## Mainnet deploy
+
+1. Audit contracts and test on testnet first
+2. Set `contracts/settings/Mainnet.toml` mnemonic (never commit)
+3. `stacksdapp deploy --network mainnet --dry-run` — review plan and fees
+4. `stacksdapp deploy --network mainnet --yes --wait-confirm`
+5. `stacksdapp dev --network mainnet`
+
+Guide: https://scaffoldstacks.mintlify.app/mainnet.md
+
+## Upgrade project
+
+```bash
+stacksdapp upgrade
+```
+
+Refreshes npm lockfiles, regenerates bindings, updates git hooks and agent skill. Safe to run after updating `stacksdapp` CLI.
+
+Guide: https://scaffoldstacks.mintlify.app/upgrade.md
+
+## CI pipeline
+
+```bash
+stacksdapp doctor --strict
+stacksdapp check
+stacksdapp generate
+stacksdapp test
+stacksdapp deploy --network testnet --yes
+```
+
+Use `--json` for machine-readable output. Rely on exit codes (see cli-reference.md).
+
+Do not run devnet in CI unless Docker is available and stall risk is acceptable.
+
+## Clean slate
+
+```bash
+stacksdapp clean --force
+```
+
+Removes `.cache/`, devnet state, generated bindings. Does not delete `.clar` sources.
+
+After clean: `stacksdapp generate` to restore bindings.
+
+## Redeploy / naming collisions
+
+By default, redeploying auto-versions (`counter` → `counter-v2`). To fail instead:
+
+```bash
+stacksdapp deploy --network testnet --no-auto-version --yes
+```
+
+## Frontend-only against remote network
+
+```bash
+stacksdapp dev --network testnet
+stacksdapp dev --network mainnet
+```
+
+## Subdirectory commands
+
+```bash
+cd frontend
+stacksdapp check    # walks up to project root
+
+stacksdapp --root /path/to/my-app deploy --network testnet --yes
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Keep in sync with README / stacksdapp doctor (Clarinet 3.21+).
-  CLARINET_VERSION: "3.21.1"
+  # Keep in sync with README / stacksdapp doctor / scripts/ci-smoke.sh (Clarinet 3.23+).
+  CLARINET_VERSION: "3.23.1"
 
 jobs:
   lint:
@@ -101,7 +101,7 @@ jobs:
             | tar xz
           sudo mv clarinet /usr/local/bin/
           clarinet --version
-          clarinet --version | head -n1 | grep -E "clarinet 3\\.21"
+          clarinet --version | head -n1 | grep -E "clarinet 3\\.23"
 
       - name: Build CLI binary
         run: cargo build --package stacksdapp

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ scripts/verify-p1-display.sh
 scripts/verify-p1-exit-codes.sh
 scripts/verify-functional.sh
 pub.sh
+file.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ scripts/verify-p0.sh
 scripts/verify-p1-display.sh
 scripts/verify-p1-exit-codes.sh
 scripts/verify-functional.sh
+scripts/integration-e2e.sh
+scripts/voting-e2e.sh
 pub.sh
 file.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Scaffold Stacks — AI agent guide (CLI repo)
+
+This repository builds the `stacksdapp` CLI. When helping users **build dApps**, read the bundled skill template — the same files installed into every scaffolded project.
+
+## Skill source (edit here)
+
+```
+crates/scaffold/agent-skill-template/
+├── AGENTS.md
+└── .cursor/skills/scaffold-stacks/
+    ├── SKILL.md
+    ├── frontend.md
+    ├── clarity-language.md
+    ├── sip-standards.md
+    ├── cli-reference.md
+    ├── project-layout.md
+    ├── clarity-versions.md
+    ├── workflows.md
+    └── troubleshooting.md
+```
+
+Changes here are copied into projects by `stacksdapp new`, `stacksdapp init`, and `stacksdapp upgrade`.
+
+After editing, sync the CLI repo Cursor copy:
+
+```bash
+cp crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/*.md .cursor/skills/scaffold-stacks/
+```
+
+## Working on this repo
+
+```bash
+cargo build -p stacksdapp
+cargo test --all
+bash scripts/ci-smoke.sh
+```
+
+## Working on a scaffolded dApp
+
+Read `.cursor/skills/scaffold-stacks/SKILL.md` (or the template above). For React/hooks/wallet work, see `frontend.md`.
+
+Docs: https://scaffoldstacks.mintlify.app/ · Index: https://scaffoldstacks.mintlify.app/llms.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Version history is reconstructed from git tags, `cli/Cargo.toml` version bumps, 
 - **Clarity 6** support: new projects default to `clarity_version = 6` (epoch 4.0 / burn ≥ 152 on devnet).
 - `stacksdapp add --clarity-version <4|5|6>` for explicit language version when adding contracts (default `6`).
 - Devnet deploy success points to the running local app (`http://localhost:3000` or `:3001`) instead of restarting dev.
+- **Bundled AI agent skill** — every `stacksdapp new` / `init` project gets `.cursor/skills/scaffold-stacks/` and root `AGENTS.md`; `upgrade` refreshes them. Source: `crates/scaffold/agent-skill-template/`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ Version history is reconstructed from git tags, `cli/Cargo.toml` version bumps, 
 - `--json` success payloads for `new`, `init`, `add`, `deploy`, `dev`, and `upgrade`.
 - Parser unit tests, scaffold proptest fuzz on name validation, and init rollback tests.
 - Devnet readiness panel: local URL, tip height, and deploy hint after `stacksdapp dev`.
-- Devnet deploy waits for Clarinet epoch burn height before broadcasting Clarity 5 contracts (epoch 3.4 / burn ≥ 150).
+- Devnet deploy waits for Clarinet epoch burn height before broadcasting Clarity 5/6 contracts (epoch 3.4 / burn ≥ 150, epoch 4.0 / burn ≥ 152).
+- **Clarity 6** support: new projects default to `clarity_version = 6` (epoch 4.0 / burn ≥ 152 on devnet).
+- `stacksdapp add --clarity-version <4|5|6>` for explicit language version when adding contracts (default `6`).
 - Devnet deploy success points to the running local app (`http://localhost:3000` or `:3001`) instead of restarting dev.
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for helping improve `stacksdapp`. This guide covers local development, ch
 |---|---|
 | Rust 1.75+ | via [rustup](https://rustup.rs) |
 | Node.js 20+ | frontend + Vitest contract tests |
-| Clarinet 3.21+ | contract toolchain (`brew install clarinet` or CI-style install) |
+| Clarinet 3.23+ | contract toolchain (`brew install clarinet` or CI-style install) |
 | Docker Desktop | only for local `stacksdapp dev` (devnet) |
 
 Run `stacksdapp doctor` after building to verify your machine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,28 @@ Thanks for helping improve `stacksdapp`. This guide covers local development, ch
 
 Run `stacksdapp doctor` after building to verify your machine.
 
+## Git hooks (mnemonic guard)
+
+`stacksdapp new` and `stacksdapp init` install `.githooks/pre-commit`, which blocks commits that look like real BIP39 seed phrases in `contracts/settings/Testnet.toml` or `Mainnet.toml`. Enable it in a project:
+
+```bash
+git config core.hooksPath .githooks
+# or
+npm run setup-hooks
+```
+
+`stacksdapp doctor --strict` warns when you run doctor inside a scaffold project and `core.hooksPath` is not `.githooks` (or the hook file is missing).
+
+### Emergency bypass (not for routine use)
+
+The hook can be disabled for a **single commit** with:
+
+```bash
+SCAFFOLD_ALLOW_COMMITTED_MNEMONIC=1 git commit ...
+```
+
+This prints **BYPASS ACTIVE** to stderr and skips the guard. Use only when debugging a false positive or in a private repo with intentional test keys — never for mainnet mnemonics. Prefer env-based or gitignored local settings files instead of committing seeds.
+
 ## Setup
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,27 @@ bash scripts/ci-smoke.sh
 
 - `cli/` — `stacksdapp` binary (clap, exit codes, command dispatch)
 - `crates/shell/` — verbosity / quiet / color / JSON + root discovery
-- `crates/scaffold/` — `new` / `init` / `add` / `upgrade` + frontend template
+- `crates/scaffold/` — `new` / `init` / `add` / `upgrade` + frontend template + agent skill template
 - `crates/codegen/`, `parser/`, `deployer/`, `watcher/`, `process_supervisor/` — domain crates
+
+## Agent skill template
+
+Source: `crates/scaffold/agent-skill-template/`. Installed automatically into every scaffolded project:
+
+- `AGENTS.md` (project root)
+- `.cursor/skills/scaffold-stacks/` (`SKILL.md`, `frontend.md`, `clarity-language.md`, `sip-standards.md`, + reference files)
+
+`stacksdapp new`, `stacksdapp init`, and `stacksdapp upgrade` copy or refresh these files. Edit the template in this repo only.
+
+When editing the template, also sync the CLI repo’s Cursor copy:
+
+```bash
+cp crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/*.md .cursor/skills/scaffold-stacks/
+```
+
+After template changes, run `bash scripts/ci-smoke.sh` (asserts skill files exist after `stacksdapp new`).
+
+Docs index for agents: https://scaffoldstacks.mintlify.app/llms.txt
 
 Prefer small, focused PRs. Match existing naming and error style; use `CliError` (or messages classified in `cli/src/error.rs`) when adding failure paths scripts need to distinguish.
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ crates/
   shell/                          # verbosity / quiet / color / JSON + project root discovery
   scaffold/                       # stacksdapp new + init + add + upgrade
     frontend-template/            # copied into every new project's frontend/
+    agent-skill-template/         # AI agent skill → .cursor/skills/scaffold-stacks/
   parser/                         # Clarity ABI → Rust structs
   codegen/                        # Rust structs → TypeScript via Tera
     templates/
@@ -286,6 +287,23 @@ crates/
   deployer/                       # clarinet deployments generate + apply
   process_supervisor/             # orchestrates dev per network
 ```
+
+---
+
+## AI agents (Cursor, Claude Code, Codex)
+
+Every project from `stacksdapp new` or `stacksdapp init` includes a bundled agent skill — **no extra setup**.
+
+| Path | Purpose |
+|---|---|
+| `.cursor/skills/scaffold-stacks/SKILL.md` | Cursor auto-discovery; read this first in other agents |
+| `AGENTS.md` | Short pointer at project root for non-Cursor tools |
+
+The skill covers CLI commands, Clarity version rules, testnet-first workflows, devnet caveats, and troubleshooting. `stacksdapp upgrade` refreshes it to match your CLI version.
+
+**Docs for agents:** https://scaffoldstacks.mintlify.app/llms.txt
+
+To change the skill, edit `crates/scaffold/agent-skill-template/` in this repo (source of truth).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Rust-powered CLI (`stacksdapp`) and Next.js template for building full-stack S
 |---|---|---|
 | **Rust** 1.75+ | [rustup.rs](https://rustup.rs) | Building the CLI |
 | **Node.js** 20+ | [nodejs.org](https://nodejs.org) | Frontend + contract tests |
-| **Clarinet** 3.21+ | `brew install clarinet` | Contract toolchain |
+| **Clarinet** 3.23+ | `brew install clarinet` | Contract toolchain (C6 devnet requires 3.23+) |
 | **Leather or Xverse** | [leather.io](https://leather.io) | Wallet for testnet/mainnet |
 | **Docker Desktop** | [docker.com](https://docker.com) | Local devnet only |
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ stacksdapp check
 
 ### Iterate and redeploy
 
-Because Stacks contracts are immutable, redeploying after changes auto-versions the contract name (`counter` → `counter-v2` → `counter-v3`). The CLI handles this automatically — no manual renaming needed.
+Because Stacks contracts are immutable, redeploying after changes auto-versions the contract name (`counter` → `counter-v2` → `counter-v3`). The CLI handles this automatically — no manual renaming needed. Use `--no-auto-version` to fail instead of renaming.
+
+**Testnet/mainnet deploy semantics:** By default, `deploy` exits once transactions are **broadcast** to the mempool (fast; no frozen terminal). Verify txids on the [Hiro explorer](https://explorer.hiro.so). Use `--wait-confirm` when you need the CLI to block until contracts are on chain (CI gates). Devnet always waits for local core confirmation.
 
 ---
 
@@ -227,6 +229,8 @@ my-app/
 | `stacksdapp deploy --network testnet --contract <name>` | Deploy only one contract by name |
 | `stacksdapp deploy --network testnet --dry-run` | Generate plan + estimated fee without broadcasting |
 | `stacksdapp deploy --network testnet -y` | Non-interactive deploy (skip confirmation / Clarinet fee prompts) |
+| `stacksdapp deploy --network testnet --wait-confirm` | Poll until contracts appear on chain (default: exit after mempool broadcast) |
+| `stacksdapp deploy --network testnet --no-auto-version` | Fail on name conflict instead of auto-renaming (`counter` → `counter-v2`) |
 | `stacksdapp deploy --network mainnet` | Deploy to mainnet |
 | `stacksdapp deploy --network devnet` | Deploy to local devnet |
 | `stacksdapp generate [--watch]` | Parse ABIs → regenerate TS bindings + debug UI |
@@ -244,7 +248,7 @@ my-app/
 | `-v` / `-vv`… | Increase diagnostic verbosity |
 | `-q` / `--quiet` | Suppress non-error human logs |
 | `--color auto\|always\|never` | Color control (default `auto`) |
-| `--json` | Machine-readable stdout (single JSON object) |
+| `--json` | Machine-readable stdout (single JSON object per command; `dev` emits once when the frontend is **ready**, errors always emit JSON) |
 | `--root <PATH>` | Project root (or set `STACKSDAPP_ROOT`); otherwise walks up for `stacksdapp.toml` / `contracts/Clarinet.toml` |
 
 ### Exit codes

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use colored::Colorize;
 use serde_json::json;
-use stacksdapp_shell::{self as shell, find_scaffold_root, inspect_settings_file, status, MnemonicCheck};
+use stacksdapp_shell::{
+    self as shell, find_scaffold_root, inspect_settings_file, status, MnemonicCheck,
+};
 use std::path::Path;
 use std::process::Stdio;
 use tokio::process::Command;
@@ -569,9 +571,10 @@ fn hooks_path_is_githooks(configured: &str, root: &Path) -> bool {
     }
 
     let expected = root.join(".githooks");
-    if let (Ok(expected_canon), Ok(configured_canon)) =
-        (expected.canonicalize(), Path::new(configured).canonicalize())
-    {
+    if let (Ok(expected_canon), Ok(configured_canon)) = (
+        expected.canonicalize(),
+        Path::new(configured).canonicalize(),
+    ) {
         return expected_canon == configured_canon;
     }
 

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -51,6 +51,7 @@ pub async fn run(strict: bool) -> Result<()> {
         check_git().await,
         check_git_hooks().await,
         check_deploy_mnemonics().await,
+        check_devnet_epochs().await,
         check_stacksdapp().await,
     ];
 
@@ -275,17 +276,25 @@ async fn check_clarinet() -> Check {
                          Run: brew upgrade clarinet  OR  cargo install clarinet --locked"
                     )),
                 }
-            } else if meets_semver(&version, 3, 21) {
+            } else if meets_semver(&version, 3, 23) {
                 Check {
                     name: "Clarinet",
                     result: CheckResult::Ok(version),
+                }
+            } else if meets_semver(&version, 3, 21) {
+                Check {
+                    name: "Clarinet",
+                    result: CheckResult::Warn(format!(
+                        "{version} — Clarinet 3.23+ recommended (Clarity 6 devnet / epoch 4.0 at burn 163). \
+                         Run: brew upgrade clarinet"
+                    )),
                 }
             } else {
                 Check {
                     name: "Clarinet",
                     result: CheckResult::Warn(format!(
-                        "{version} — Clarinet 3.21+ recommended (templates target 3.21). \
-                         Run: brew upgrade clarinet"
+                        "{version} — Clarinet 3.21+ required. \
+                         Run: brew upgrade clarinet  OR  cargo install clarinet --locked"
                     )),
                 }
             }
@@ -377,6 +386,47 @@ async fn check_git() -> Check {
                 "not found — optional but recommended. Install from https://git-scm.com".into(),
             ),
         },
+    }
+}
+
+async fn check_devnet_epochs() -> Check {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => {
+            return Check {
+                name: "Devnet epochs",
+                result: CheckResult::Ok("could not read working directory".into()),
+            };
+        }
+    };
+
+    let Some(root) = find_scaffold_root(&cwd) else {
+        return Check {
+            name: "Devnet epochs",
+            result: CheckResult::Ok("not in a scaffold project".into()),
+        };
+    };
+
+    let path = root.join("contracts/settings/Devnet.toml");
+    let Ok(raw) = tokio::fs::read_to_string(&path).await else {
+        return Check {
+            name: "Devnet epochs",
+            result: CheckResult::Ok("no Devnet.toml".into()),
+        };
+    };
+
+    if raw.contains("[epochs]") {
+        return Check {
+            name: "Devnet epochs",
+            result: CheckResult::Warn(
+                "Devnet.toml contains [epochs] — this overrides Clarinet 3.23+ defaults and can block epoch 4.0 / Clarity 6. Remove [epochs] or add epoch_4_0, then run stacksdapp clean.".into(),
+            ),
+        };
+    }
+
+    Check {
+        name: "Devnet epochs",
+        result: CheckResult::Ok("using Clarinet default epoch schedule".into()),
     }
 }
 

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use colored::Colorize;
 use serde_json::json;
-use stacksdapp_shell::{self as shell, status};
+use stacksdapp_shell::{self as shell, find_scaffold_root, inspect_settings_file, status, MnemonicCheck};
+use std::path::Path;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -48,6 +49,8 @@ pub async fn run(strict: bool) -> Result<()> {
         check_clarinet().await,
         check_docker().await,
         check_git().await,
+        check_git_hooks().await,
+        check_deploy_mnemonics().await,
         check_stacksdapp().await,
     ];
 
@@ -386,7 +389,167 @@ async fn check_stacksdapp() -> Check {
     }
 }
 
+async fn check_deploy_mnemonics() -> Check {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => {
+            return Check {
+                name: "Deploy mnemonics",
+                result: CheckResult::Ok("could not read working directory".into()),
+            };
+        }
+    };
+
+    let Some(root) = find_scaffold_root(&cwd) else {
+        return Check {
+            name: "Deploy mnemonics",
+            result: CheckResult::Ok("not in a scaffold project".into()),
+        };
+    };
+
+    let mut warnings = Vec::new();
+    let mut strict_failures = Vec::new();
+
+    for network in ["testnet", "mainnet"] {
+        let Some((path, check)) = inspect_settings_file(network, &root, true) else {
+            continue;
+        };
+        let network_label = stacksdapp_shell::settings_relative_path(network);
+        match check {
+            MnemonicCheck::NotConfigured => {}
+            MnemonicCheck::Ok => {}
+            MnemonicCheck::PublicDevnet => {
+                warnings.push(format!(
+                    "{path}: public devnet mnemonic — use a fresh wallet ({network_label})"
+                ));
+            }
+            MnemonicCheck::InvalidFormat(detail) => {
+                strict_failures.push(format!("{path}: {detail}"));
+            }
+        }
+    }
+
+    if !strict_failures.is_empty() {
+        return Check {
+            name: "Deploy mnemonics",
+            result: CheckResult::Warn(strict_failures.join("; ")),
+        };
+    }
+
+    if !warnings.is_empty() {
+        return Check {
+            name: "Deploy mnemonics",
+            result: CheckResult::Warn(warnings.join("; ")),
+        };
+    }
+
+    Check {
+        name: "Deploy mnemonics",
+        result: CheckResult::Ok("testnet/mainnet settings look safe".into()),
+    }
+}
+
+async fn check_git_hooks() -> Check {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => {
+            return Check {
+                name: "Git hooks",
+                result: CheckResult::Ok("could not read working directory".into()),
+            };
+        }
+    };
+
+    let Some(root) = find_scaffold_root(&cwd) else {
+        return Check {
+            name: "Git hooks",
+            result: CheckResult::Ok("not in a scaffold project".into()),
+        };
+    };
+
+    let hook_file = root.join(".githooks/pre-commit");
+    if !hook_file.is_file() {
+        return Check {
+            name: "Git hooks",
+            result: CheckResult::Warn(
+                "mnemonic guard hook missing (.githooks/pre-commit). \
+                 Run stacksdapp upgrade or recreate hooks from CONTRIBUTING.md"
+                    .into(),
+            ),
+        };
+    }
+
+    if !root.join(".git").exists() {
+        return Check {
+            name: "Git hooks",
+            result: CheckResult::Ok("scaffold project is not a git repository".into()),
+        };
+    }
+
+    match git_config_hooks_path(&root).await {
+        None => Check {
+            name: "Git hooks",
+            result: CheckResult::Warn(
+                "core.hooksPath not set — mnemonic guard inactive. \
+                 Run: npm run setup-hooks  OR  git config core.hooksPath .githooks"
+                    .into(),
+            ),
+        },
+        Some(path) if hooks_path_is_githooks(&path, &root) => Check {
+            name: "Git hooks",
+            result: CheckResult::Ok(".githooks".into()),
+        },
+        Some(path) => Check {
+            name: "Git hooks",
+            result: CheckResult::Warn(format!(
+                "core.hooksPath is \"{path}\" (expected .githooks) — mnemonic guard may be inactive. \
+                 Run: git config core.hooksPath .githooks"
+            )),
+        },
+    }
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// True when `git config core.hooksPath` points at this project's `.githooks` directory.
+fn hooks_path_is_githooks(configured: &str, root: &Path) -> bool {
+    let configured = configured.trim();
+    if configured == ".githooks" {
+        return true;
+    }
+
+    let expected = root.join(".githooks");
+    if let (Ok(expected_canon), Ok(configured_canon)) =
+        (expected.canonicalize(), Path::new(configured).canonicalize())
+    {
+        return expected_canon == configured_canon;
+    }
+
+    // When canonicalize fails (path does not exist yet), compare normalized absolute-style paths.
+    if let Ok(root_canon) = root.canonicalize() {
+        let expected = root_canon.join(".githooks");
+        let expected_display = expected.display().to_string().replace('\\', "/");
+        let configured_norm = configured.replace('\\', "/");
+        return configured_norm == expected_display;
+    }
+
+    false
+}
+
+async fn git_config_hooks_path(root: &Path) -> Option<String> {
+    Command::new("git")
+        .args(["config", "--get", "core.hooksPath"])
+        .current_dir(root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
 
 /// Run a command and return its trimmed stdout, or None if it failed / not found.
 async fn version_output(cmd: &str, args: &[&str]) -> Option<String> {
@@ -409,4 +572,23 @@ fn meets_semver(version: &str, req_major: u32, req_minor: u32) -> bool {
     let major: u32 = parts.next().unwrap_or("0").parse().unwrap_or(0);
     let minor: u32 = parts.next().unwrap_or("0").parse().unwrap_or(0);
     (major, minor) >= (req_major, req_minor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn hooks_path_accepts_relative_githooks() {
+        let root = PathBuf::from("/tmp/my-app");
+        assert!(hooks_path_is_githooks(".githooks", &root));
+    }
+
+    #[test]
+    fn hooks_path_rejects_unrelated_path() {
+        let root = PathBuf::from("/tmp/my-app");
+        assert!(!hooks_path_is_githooks(".husky", &root));
+        assert!(!hooks_path_is_githooks("../other/.githooks", &root));
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -96,6 +96,9 @@ enum Commands {
         /// Template to use
         #[arg(long, default_value = "blank", value_parser = ["blank", "sip010", "sip009"])]
         template: String,
+        /// Clarity language version for the new contract (default 6; use 5 for legacy contracts)
+        #[arg(long, default_value_t = 6, value_parser = clap::value_parser!(u8).range(4..=6))]
+        clarity_version: u8,
     },
     /// Deploy contracts to a network (defaults.network from stacksdapp.toml when omitted)
     Deploy {
@@ -224,11 +227,18 @@ async fn dispatch(cli: Cli) -> Result<()> {
             emit_command_ok("init", json!({}));
             Ok(())
         }
-        Commands::Add { name, template } => {
-            stacksdapp_scaffold::add_contract(&name, &template)
+        Commands::Add {
+            name,
+            template,
+            clarity_version,
+        } => {
+            stacksdapp_scaffold::add_contract(&name, &template, clarity_version)
                 .await
                 .map_err(map_scaffold_err)?;
-            emit_command_ok("add", json!({ "name": name, "template": template }));
+            emit_command_ok(
+                "add",
+                json!({ "name": name, "template": template, "clarity_version": clarity_version }),
+            );
             Ok(())
         }
         Commands::Deploy {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -111,6 +111,13 @@ enum Commands {
         /// (required for non-interactive testnet/mainnet deploys)
         #[arg(short = 'y', long)]
         yes: bool,
+        /// After broadcast, poll the node until contracts appear on chain (testnet/mainnet only).
+        /// Default: exit once transactions are in the mempool (faster; verify txids on explorer).
+        #[arg(long)]
+        wait_confirm: bool,
+        /// Fail instead of auto-versioning contract names on redeploy (e.g. counter → counter-v2)
+        #[arg(long)]
+        no_auto_version: bool,
     },
     /// Run contract and frontend tests (vitest)
     Test,
@@ -157,15 +164,15 @@ async fn main() -> ExitCode {
             let code = exit_code_for(&e);
             let kind = code_name_for(&e);
             if shell::is_json() {
-                if !shell::json_already_emitted() {
-                    shell::emit_json(&json!({
-                        "ok": false,
-                        "command": "stacksdapp",
-                        "error": e.to_string(),
-                        "code": kind,
-                        "exit_code": code,
-                    }));
-                }
+                // Always emit failure JSON so automation sees errors even if a prior
+                // success payload was written (e.g. dev crashed after ready).
+                shell::emit_json(&json!({
+                    "ok": false,
+                    "command": "stacksdapp",
+                    "error": e.to_string(),
+                    "code": kind,
+                    "exit_code": code,
+                }));
             } else {
                 eprintln!("Error: {e:#}");
                 shell::debug(1, format!("exit_code={code} ({kind})"));
@@ -207,15 +214,6 @@ async fn dispatch(cli: Cli) -> Result<()> {
             keep_state,
         } => {
             let network = resolve_default_network(network.as_deref())?;
-            emit_command_ok(
-                "dev",
-                json!({
-                    "network": network,
-                    "auto_deploy": auto_deploy,
-                    "keep_state": keep_state,
-                    "status": "starting",
-                }),
-            );
             stacksdapp_process_supervisor::dev(&network, auto_deploy, keep_state).await
         }
         Commands::Generate { watch } => run_generate(watch).await,
@@ -238,22 +236,31 @@ async fn dispatch(cli: Cli) -> Result<()> {
             contract,
             dry_run,
             yes,
+            wait_confirm,
+            no_auto_version,
         } => {
             let network = resolve_default_network(network.as_deref())?;
-            stacksdapp_deployer::deploy(&network, contract.as_deref(), dry_run, yes)
-                .await
-                .map_err(|e| {
-                    let msg = format!("{e:#}");
-                    let lower = msg.to_ascii_lowercase();
-                    if lower.contains("refusing to deploy")
-                        || lower.contains("aborted")
-                        || lower.contains("confirmation cancelled")
-                    {
-                        anyhow::Error::new(CliError::Aborted(msg))
-                    } else {
-                        anyhow::Error::new(CliError::Deploy(msg))
-                    }
-                })?;
+            let outcome = stacksdapp_deployer::deploy(
+                &network,
+                contract.as_deref(),
+                dry_run,
+                yes,
+                wait_confirm,
+                no_auto_version,
+            )
+            .await
+            .map_err(|e| {
+                let msg = format!("{e:#}");
+                let lower = msg.to_ascii_lowercase();
+                if lower.contains("refusing to deploy")
+                    || lower.contains("aborted")
+                    || lower.contains("confirmation cancelled")
+                {
+                    anyhow::Error::new(CliError::Aborted(msg))
+                } else {
+                    anyhow::Error::new(CliError::Deploy(msg))
+                }
+            })?;
             emit_command_ok(
                 "deploy",
                 json!({
@@ -261,6 +268,10 @@ async fn dispatch(cli: Cli) -> Result<()> {
                     "contract": contract,
                     "dry_run": dry_run,
                     "yes": yes,
+                    "wait_confirm": wait_confirm,
+                    "no_auto_version": no_auto_version,
+                    "status": outcome.status,
+                    "block_height": outcome.block_height,
                 }),
             );
             Ok(())

--- a/crates/deployer/src/devnet_recovery.rs
+++ b/crates/deployer/src/devnet_recovery.rs
@@ -290,10 +290,7 @@ pub async fn recover_devnet_if_stalled_during_wait(
     if !is_devnet_chain_stalled(previous, &current) {
         return false;
     }
-    let Some(name) = project
-        .map(str::to_string)
-        .or_else(devnet_project_name)
-    else {
+    let Some(name) = project.map(str::to_string).or_else(devnet_project_name) else {
         return false;
     };
     stacksdapp_shell::println_human_safe(format!(

--- a/crates/deployer/src/devnet_recovery.rs
+++ b/crates/deployer/src/devnet_recovery.rs
@@ -226,10 +226,10 @@ pub async fn ensure_devnet_chain_mining(context: &str) -> Result<()> {
         if second.stacks_tip_height > first.stacks_tip_height {
             return Ok(());
         }
-        if !is_devnet_chain_stalled(&first, &second) {
-            if wait_for_stacks_tip_above(first.stacks_tip_height, Duration::from_secs(45)).await {
-                return Ok(());
-            }
+        if !is_devnet_chain_stalled(&first, &second)
+            && wait_for_stacks_tip_above(first.stacks_tip_height, Duration::from_secs(45)).await
+        {
+            return Ok(());
         }
         // Stalled sample — fall through to recovery using latest observation.
         return recover_devnet_chain_mining(&project, context, &second).await;

--- a/crates/deployer/src/devnet_recovery.rs
+++ b/crates/deployer/src/devnet_recovery.rs
@@ -1,0 +1,348 @@
+//! Local Clarinet devnet recovery when Bitcoin burn advances but Stacks tip stalls
+//! (PoX / Nakamoto tenure desync around reward-cycle boundaries).
+
+use anyhow::{anyhow, Result};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalCoreInfo {
+    pub stacks_tip_height: u64,
+    pub burn_block_height: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryLevel {
+    /// Restart stacks-signer + stacks-node only.
+    StacksOnly,
+    /// Restart bitcoin-node, then stacks-signer + stacks-node.
+    WithBitcoin,
+    /// Restart all devnet containers (bitcoin, postgres, stacks-node, signer).
+    Full,
+}
+
+impl RecoveryLevel {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StacksOnly => "stacks-node + signer",
+            Self::WithBitcoin => "bitcoin-node + stacks-node + signer",
+            Self::Full => "full devnet stack",
+        }
+    }
+}
+
+/// True when Stacks tip is unchanged while burn height increased (classic devnet stall).
+pub fn is_devnet_chain_stalled(previous: &LocalCoreInfo, current: &LocalCoreInfo) -> bool {
+    current.stacks_tip_height == previous.stacks_tip_height
+        && current.burn_block_height > previous.burn_block_height
+}
+
+pub fn devnet_project_name() -> Option<String> {
+    let raw = std::fs::read_to_string("contracts/Clarinet.toml").ok()?;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("name = ") {
+            return trimmed
+                .trim_start_matches("name = ")
+                .trim()
+                .trim_matches('"')
+                .to_string()
+                .into();
+        }
+    }
+    None
+}
+
+pub async fn fetch_local_core_info_optional() -> Option<LocalCoreInfo> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .ok()?;
+    let response = client
+        .get("http://localhost:20443/v2/info")
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let json: serde_json::Value = response.json().await.ok()?;
+    Some(LocalCoreInfo {
+        stacks_tip_height: json.get("stacks_tip_height")?.as_u64()?,
+        burn_block_height: json.get("burn_block_height")?.as_u64()?,
+    })
+}
+
+fn docker_restart_container(name: &str) -> bool {
+    let id = docker_container_id(name);
+    let Some(id) = id else {
+        return false;
+    };
+    std::process::Command::new("docker")
+        .args(["restart", &id])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn docker_container_id(name: &str) -> Option<String> {
+    std::process::Command::new("docker")
+        .args(["ps", "-q", "--filter", &format!("name={name}")])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().lines().next().unwrap_or("").to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn docker_stop_container(name: &str) -> bool {
+    let Some(id) = docker_container_id(name) else {
+        return false;
+    };
+    std::process::Command::new("docker")
+        .args(["stop", &id])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn docker_start_container(name: &str) -> bool {
+    let id = std::process::Command::new("docker")
+        .args(["ps", "-aq", "--filter", &format!("name={name}")])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().lines().next().unwrap_or("").to_string())
+        .filter(|s| !s.is_empty());
+    let Some(id) = id else {
+        return false;
+    };
+    std::process::Command::new("docker")
+        .args(["start", &id])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Stop all devnet containers for a project (used before Clarinet respawn).
+pub fn stop_devnet_containers(project: &str) -> bool {
+    let names = [
+        format!("stacks-signer-0.{project}.devnet"),
+        format!("stacks-node.{project}.devnet"),
+        format!("postgres.{project}.devnet"),
+        format!("bitcoin-node.{project}.devnet"),
+    ];
+    let mut any = false;
+    for name in &names {
+        if docker_stop_container(name) {
+            any = true;
+        }
+    }
+    any
+}
+/// Restart devnet Docker containers for `project`. Returns true if anything restarted.
+pub fn try_recover_devnet_chain(project: &str, level: RecoveryLevel) -> bool {
+    let stacks = [
+        format!("stacks-signer-0.{project}.devnet"),
+        format!("stacks-node.{project}.devnet"),
+    ];
+    let bitcoin = format!("bitcoin-node.{project}.devnet");
+    let postgres = format!("postgres.{project}.devnet");
+
+    let mut any = false;
+    match level {
+        RecoveryLevel::StacksOnly => {
+            for name in &stacks {
+                if docker_restart_container(name) {
+                    any = true;
+                }
+            }
+        }
+        RecoveryLevel::WithBitcoin => {
+            if docker_restart_container(&bitcoin) {
+                any = true;
+            }
+            std::thread::sleep(Duration::from_secs(5));
+            for name in &stacks {
+                if docker_restart_container(name) {
+                    any = true;
+                }
+            }
+        }
+        RecoveryLevel::Full => {
+            // Stop/start (not restart) resets container processes while Clarinet's
+            // bitcoin controller reconnects — more reliable than restart alone.
+            for name in [&stacks[0], &stacks[1], &postgres, &bitcoin] {
+                docker_stop_container(name);
+            }
+            std::thread::sleep(Duration::from_secs(3));
+            for name in [&bitcoin, &postgres, &stacks[1], &stacks[0]] {
+                if docker_start_container(name) {
+                    any = true;
+                }
+            }
+        }
+    }
+    any
+}
+
+async fn wait_for_stacks_tip_above(min_exclusive: u64, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if let Some(info) = fetch_local_core_info_optional().await {
+            if info.stacks_tip_height > min_exclusive {
+                return true;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+    false
+}
+
+/// Block until Stacks tip advances, attempting escalating Docker recovery on stall.
+/// Devnet-only — callers must gate on `network == "devnet"`.
+pub async fn ensure_devnet_chain_mining(context: &str) -> Result<()> {
+    let project = devnet_project_name().ok_or_else(|| {
+        anyhow!(
+            "Cannot recover devnet: missing contracts/Clarinet.toml project name.\n\
+             Run deploy from a scaffold project root with `stacksdapp dev` running."
+        )
+    })?;
+
+    let first = fetch_local_core_info_optional()
+        .await
+        .ok_or_else(|| anyhow!("Local stacks-node at http://localhost:20443 is not responding."))?;
+
+    // Fast path: tip advancing normally (typical deploy within ~2 min of dev ready).
+    tokio::time::sleep(Duration::from_secs(8)).await;
+    if let Some(second) = fetch_local_core_info_optional().await {
+        if second.stacks_tip_height > first.stacks_tip_height {
+            return Ok(());
+        }
+        if !is_devnet_chain_stalled(&first, &second) {
+            if wait_for_stacks_tip_above(first.stacks_tip_height, Duration::from_secs(45)).await {
+                return Ok(());
+            }
+        }
+        // Stalled sample — fall through to recovery using latest observation.
+        return recover_devnet_chain_mining(&project, context, &second).await;
+    }
+
+    recover_devnet_chain_mining(&project, context, &first).await
+}
+
+async fn recover_devnet_chain_mining(
+    project: &str,
+    context: &str,
+    stalled_at: &LocalCoreInfo,
+) -> Result<()> {
+    stacksdapp_shell::println_human_safe(format!(
+        "[deploy] Devnet chain stalled (Stacks #{}, burn {}) before {context}.",
+        stalled_at.stacks_tip_height, stalled_at.burn_block_height
+    ));
+
+    let levels = [
+        RecoveryLevel::StacksOnly,
+        RecoveryLevel::WithBitcoin,
+        RecoveryLevel::Full,
+    ];
+    for (idx, level) in levels.iter().enumerate() {
+        stacksdapp_shell::println_human_safe(format!(
+            "[deploy] Recovering stalled chain (attempt {}/3): {} for {project}...",
+            idx + 1,
+            level.label()
+        ));
+        try_recover_devnet_chain(project, *level);
+        tokio::time::sleep(Duration::from_secs(12)).await;
+        if wait_for_stacks_tip_above(stalled_at.stacks_tip_height, Duration::from_secs(120)).await {
+            stacksdapp_shell::println_human_safe(
+                "[deploy] Devnet chain recovered — Stacks tip is advancing again.",
+            );
+            return Ok(());
+        }
+    }
+
+    Err(anyhow!(
+        "Devnet chain stalled at Stacks #{} (burn {}) and recovery did not restore block production.\n\
+         If `stacksdapp dev` is running, wait for \"[devnet] Clarinet devnet restarted\" then retry.\n\
+         Otherwise run `stacksdapp clean --force`, restart with `stacksdapp dev --auto-deploy`, and deploy while the tip advances.\n\
+         If this repeats, try `bitcoin_controller_block_time = 60_000` in contracts/settings/Devnet.toml.",
+        stalled_at.stacks_tip_height,
+        stalled_at.burn_block_height
+    ))
+}
+
+/// Poll during contract confirmation; trigger recovery if burn advances without new Stacks blocks.
+pub async fn recover_devnet_if_stalled_during_wait(
+    previous: &LocalCoreInfo,
+    project: Option<&str>,
+) -> bool {
+    let Some(current) = fetch_local_core_info_optional().await else {
+        return false;
+    };
+    if !is_devnet_chain_stalled(previous, &current) {
+        return false;
+    }
+    let Some(name) = project
+        .map(str::to_string)
+        .or_else(devnet_project_name)
+    else {
+        return false;
+    };
+    stacksdapp_shell::println_human_safe(format!(
+        "[deploy] Chain stalled while waiting (Stacks #{}, burn {}) — restarting devnet containers...",
+        current.stacks_tip_height, current.burn_block_height
+    ));
+    try_recover_devnet_chain(&name, RecoveryLevel::WithBitcoin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_stall_when_burn_advances_one_block() {
+        let prev = LocalCoreInfo {
+            stacks_tip_height: 71,
+            burn_block_height: 176,
+        };
+        let curr = LocalCoreInfo {
+            stacks_tip_height: 71,
+            burn_block_height: 177,
+        };
+        assert!(is_devnet_chain_stalled(&prev, &curr));
+    }
+
+    #[test]
+    fn not_stalled_when_stacks_advances() {
+        let prev = LocalCoreInfo {
+            stacks_tip_height: 71,
+            burn_block_height: 176,
+        };
+        let curr = LocalCoreInfo {
+            stacks_tip_height: 72,
+            burn_block_height: 177,
+        };
+        assert!(!is_devnet_chain_stalled(&prev, &curr));
+    }
+
+    #[test]
+    fn not_stalled_when_both_unchanged() {
+        let prev = LocalCoreInfo {
+            stacks_tip_height: 71,
+            burn_block_height: 176,
+        };
+        let curr = LocalCoreInfo {
+            stacks_tip_height: 71,
+            burn_block_height: 176,
+        };
+        assert!(!is_devnet_chain_stalled(&prev, &curr));
+    }
+}

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -18,8 +18,8 @@ use tokio::process::Command;
 pub mod devnet_recovery;
 mod ui;
 use devnet_recovery::{
-    ensure_devnet_chain_mining, fetch_local_core_info_optional, recover_devnet_if_stalled_during_wait,
-    LocalCoreInfo,
+    ensure_devnet_chain_mining, fetch_local_core_info_optional,
+    recover_devnet_if_stalled_during_wait, LocalCoreInfo,
 };
 use ui::DeployUi;
 
@@ -335,7 +335,8 @@ async fn restore_rename_snapshot(contracts_dir: &Path, snapshot: &RenameSnapshot
         let mut entries = fs::read_dir(&contracts_src).await?;
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "clar") && !snapshot.files.contains_key(&path)
+            if path.extension().is_some_and(|ext| ext == "clar")
+                && !snapshot.files.contains_key(&path)
             {
                 let _ = fs::remove_file(&path).await;
             }
@@ -530,7 +531,12 @@ async fn run_deploy_pipeline_inner(
         if no_auto_version && !renames.is_empty() {
             let conflicts: Vec<String> = renames
                 .iter()
-                .map(|r| format!("{} (network has {}; would rename to {})", r.from, r.from, r.to))
+                .map(|r| {
+                    format!(
+                        "{} (network has {}; would rename to {})",
+                        r.from, r.from, r.to
+                    )
+                })
                 .collect();
             return Err(anyhow!(
                 "Contract name conflict on {network}: {}.\n\
@@ -948,15 +954,7 @@ async fn run_apply_devnet(
     // Clarinet apply coordinates devnet mining with the bitcoin controller; prefer it on 3.23+.
     if clarinet_version_at_least(3, 23, 0) {
         ui.step_ok("Preparing Clarinet devnet broadcast");
-        match run_clarinet_deployments_apply(
-            ui,
-            network,
-            contracts,
-            single_contract,
-            None,
-        )
-        .await
-        {
+        match run_clarinet_deployments_apply(ui, network, contracts, single_contract, None).await {
             Ok(stdout) => return Ok(stdout),
             Err(clarinet_err) => {
                 stacksdapp_shell::println_human_safe(format!(
@@ -1096,7 +1094,9 @@ async fn run_clarinet_deployments_apply(
             }
         } else if let Some(name) = parse_clarinet_publish_line(&line) {
             // Intent only — success is counted when Broadcasted/txid appears above.
-            last_txid_by_name.entry(name).or_insert_with(|| "pending".to_string());
+            last_txid_by_name
+                .entry(name)
+                .or_insert_with(|| "pending".to_string());
         }
 
         if line.contains("Confirmed Publish") || line.contains("Published") {
@@ -1168,7 +1168,9 @@ async fn write_contracts_only_plan_file(network: &str) -> Result<PathBuf> {
     let mut file = NamedTempFile::new()?;
     use std::io::Write;
     file.write_all(rendered.as_bytes())?;
-    let (_, path) = file.keep().map_err(|e| anyhow!("Failed to persist filtered plan: {e:?}"))?;
+    let (_, path) = file
+        .keep()
+        .map_err(|e| anyhow!("Failed to persist filtered plan: {e:?}"))?;
     Ok(path)
 }
 
@@ -1967,7 +1969,8 @@ fn strip_version_suffix(name: &str) -> String {
 
 fn validate_settings_mnemonic(network: &str) -> Result<()> {
     let path = stacksdapp_shell::settings_relative_path(network);
-    let raw = std::fs::read_to_string(&path).map_err(|_| anyhow!("Settings file not found: {path}"))?;
+    let raw =
+        std::fs::read_to_string(&path).map_err(|_| anyhow!("Settings file not found: {path}"))?;
     let parsed = stacksdapp_shell::parse_deployer_mnemonic(&raw).ok_or_else(|| {
         anyhow!(
             "No [accounts.deployer].mnemonic in {path}.\n\
@@ -2527,7 +2530,9 @@ fn ui_log_wait_start() {
 
 fn ui_log_devnet_wait_start() {
     if !stacksdapp_shell::is_quiet() {
-        println!("Broadcast complete — waiting for local devnet confirmation (typically 15–90s)...");
+        println!(
+            "Broadcast complete — waiting for local devnet confirmation (typically 15–90s)..."
+        );
     }
 }
 
@@ -2563,9 +2568,9 @@ async fn probe_stacks_api_health() -> Result<bool> {
 }
 
 async fn fetch_local_core_info() -> Result<LocalCoreInfo> {
-    fetch_local_core_info_optional().await.ok_or_else(|| {
-        anyhow!("Local stacks-node at http://localhost:20443 is not responding.")
-    })
+    fetch_local_core_info_optional()
+        .await
+        .ok_or_else(|| anyhow!("Local stacks-node at http://localhost:20443 is not responding."))
 }
 
 fn parse_deployer_address_from_settings(toml_raw: &str) -> Option<String> {
@@ -2796,7 +2801,10 @@ mod tests {
 Broadcasted ContractPublish(StandardPrincipalData(ST1PQ), ContractName("counter"), "abc123def4567890abc123def4567890abc123def4567890abc123def4567890")
 "#;
         let map = super::collect_txids_from_clarinet_output(output);
-        assert_eq!(map.get("counter").map(String::as_str), Some("abc123def4567890abc123def4567890abc123def4567890abc123def4567890"));
+        assert_eq!(
+            map.get("counter").map(String::as_str),
+            Some("abc123def4567890abc123def4567890abc123def4567890abc123def4567890")
+        );
     }
 
     #[test]
@@ -3049,12 +3057,20 @@ path = "contracts/c.clar"
             "[contracts.counter]\npath = \"contracts/counter.clar\"\n",
         )
         .unwrap();
-        fs::write(src_dir.join("counter.clar"), "(define-read-only (get) (ok u0))").unwrap();
+        fs::write(
+            src_dir.join("counter.clar"),
+            "(define-read-only (get) (ok u0))",
+        )
+        .unwrap();
 
         let snapshot = super::snapshot_contract_state(&contracts_dir)
             .await
             .unwrap();
-        fs::rename(src_dir.join("counter.clar"), src_dir.join("counter-v2.clar")).unwrap();
+        fs::rename(
+            src_dir.join("counter.clar"),
+            src_dir.join("counter-v2.clar"),
+        )
+        .unwrap();
         fs::write(
             contracts_dir.join("Clarinet.toml"),
             "[contracts.counter-v2]\npath = \"contracts/counter-v2.clar\"\n",

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -362,6 +362,7 @@ async fn ensure_rename_snapshot(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn deploy_via_clarinet(
     ui: &DeployUi,
     network: &str,
@@ -424,6 +425,7 @@ async fn deploy_via_clarinet(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_deploy_pipeline(
     ui: &DeployUi,
     network: &str,
@@ -470,6 +472,7 @@ async fn run_deploy_pipeline(
     result
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_deploy_pipeline_inner(
     ui: &DeployUi,
     network: &str,
@@ -1113,13 +1116,11 @@ async fn run_clarinet_deployments_apply(
         .await
         .map_err(|_| anyhow!("Timed out waiting for clarinet deployments apply to finish"))??;
 
-    if broadcast_count == 0 {
-        if captured_stdout.contains("Publish ST1") {
-            return Err(anyhow!(
-                "clarinet deployments apply did not confirm any broadcasts.\nOutput:\n{}",
-                captured_stdout.trim()
-            ));
-        }
+    if broadcast_count == 0 && captured_stdout.contains("Publish ST1") {
+        return Err(anyhow!(
+            "clarinet deployments apply did not confirm any broadcasts.\nOutput:\n{}",
+            captured_stdout.trim()
+        ));
     }
     if !status.success() && broadcast_count == 0 {
         return Err(anyhow!(
@@ -1136,9 +1137,7 @@ async fn run_clarinet_deployments_apply(
         ));
     }
 
-    if broadcast_count > 0 && broadcast_count < expected_count {
-        ui.render_bar(expected_count, expected_count);
-    } else if broadcast_count < expected_count {
+    if broadcast_count < expected_count {
         ui.render_bar(expected_count, expected_count);
     }
 
@@ -2237,7 +2236,7 @@ async fn write_deployments_json_from_output(
             None if was_broadcast => {
                 stacksdapp_shell::debug(
                     1,
-                    &format!(
+                    format!(
                         "deploy: broadcast for '{name}' succeeded but txid was not in clarinet output"
                     ),
                 );

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -18,6 +18,14 @@ use tokio::process::Command;
 mod ui;
 use ui::DeployUi;
 
+/// Result metadata for deploy (used by `--json` and scripting).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeployOutcome {
+    /// `dry-run`, `broadcast`, or `confirmed`
+    pub status: &'static str,
+    pub block_height: Option<u64>,
+}
+
 pub struct NetworkConfig {
     pub stacks_node: String,
 }
@@ -160,7 +168,14 @@ async fn fetch_core_tip_height(client: &reqwest::Client) -> Result<Option<u64>> 
     Ok(json.get("stacks_tip_height").and_then(|v| v.as_u64()))
 }
 
-pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: bool) -> Result<()> {
+pub async fn deploy(
+    network: &str,
+    contract: Option<&str>,
+    dry_run: bool,
+    yes: bool,
+    wait_confirm: bool,
+    no_auto_version: bool,
+) -> Result<DeployOutcome> {
     if !Path::new("contracts/Clarinet.toml").exists() {
         return Err(anyhow!(
             "No scaffold-stacks project found. Run from the directory created by stacksdapp new"
@@ -178,7 +193,17 @@ pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: b
         wait_for_devnet_node().await?;
     }
 
-    deploy_via_clarinet(&ui, network, contract, dry_run, yes).await
+    deploy_via_clarinet(
+        &ui,
+        network,
+        contract,
+        dry_run,
+        yes,
+        wait_confirm,
+        no_auto_version,
+        &config.stacks_node,
+    )
+    .await
 }
 
 // ── Core deploy ───────────────────────────────────────────────────────────────
@@ -186,6 +211,11 @@ pub async fn deploy(network: &str, contract: Option<&str>, dry_run: bool, yes: b
 struct DeployWriteSnapshot {
     clarinet_toml: Option<Vec<u8>>,
     deployment_files: HashMap<std::path::PathBuf, Vec<u8>>,
+}
+
+/// Full contract tree snapshot before auto-version renames (Clarinet.toml + all .clar sources).
+struct RenameSnapshot {
+    files: HashMap<std::path::PathBuf, Vec<u8>>,
 }
 
 async fn snapshot_deploy_writes(contracts_dir: &Path) -> Result<DeployWriteSnapshot> {
@@ -246,13 +276,65 @@ async fn restore_deploy_writes(contracts_dir: &Path, snapshot: &DeployWriteSnaps
     Ok(())
 }
 
+async fn snapshot_contract_state(contracts_dir: &Path) -> Result<RenameSnapshot> {
+    let clarinet_path = contracts_dir.join("Clarinet.toml");
+    let clarinet_raw = fs::read_to_string(&clarinet_path).await?;
+    let clarinet_struct: ClarinetToml = toml::from_str(&clarinet_raw)?;
+    let mut files = HashMap::new();
+    files.insert(clarinet_path, clarinet_raw.into_bytes());
+    if let Some(contracts) = clarinet_struct.contracts {
+        for entry in contracts.values() {
+            let path = contracts_dir.join(&entry.path);
+            if path.is_file() {
+                files.insert(path.clone(), fs::read(&path).await?);
+            }
+        }
+    }
+    Ok(RenameSnapshot { files })
+}
+
+async fn restore_rename_snapshot(contracts_dir: &Path, snapshot: &RenameSnapshot) -> Result<()> {
+    let contracts_src = contracts_dir.join("contracts");
+    if contracts_src.is_dir() {
+        let mut entries = fs::read_dir(&contracts_src).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "clar") && !snapshot.files.contains_key(&path)
+            {
+                let _ = fs::remove_file(&path).await;
+            }
+        }
+    }
+
+    for (path, content) in &snapshot.files {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::write(path, content).await?;
+    }
+    Ok(())
+}
+
+async fn ensure_rename_snapshot(
+    contracts_dir: &Path,
+    slot: &mut Option<RenameSnapshot>,
+) -> Result<()> {
+    if slot.is_none() {
+        *slot = Some(snapshot_contract_state(contracts_dir).await?);
+    }
+    Ok(())
+}
+
 async fn deploy_via_clarinet(
     ui: &DeployUi,
     network: &str,
     contract: Option<&str>,
     dry_run: bool,
     yes: bool,
-) -> Result<()> {
+    wait_confirm: bool,
+    no_auto_version: bool,
+    stacks_node: &str,
+) -> Result<DeployOutcome> {
     let contracts_dir = std::path::Path::new("contracts");
 
     let step = ui.begin_step("Analyzing project");
@@ -273,13 +355,36 @@ async fn deploy_via_clarinet(
 
     if dry_run {
         let snapshot = snapshot_deploy_writes(contracts_dir).await?;
-        let result =
-            run_deploy_pipeline(ui, network, contract, dry_run, yes, contracts_dir, &ordered).await;
+        let result = run_deploy_pipeline(
+            ui,
+            network,
+            contract,
+            dry_run,
+            yes,
+            wait_confirm,
+            no_auto_version,
+            stacks_node,
+            contracts_dir,
+            &ordered,
+        )
+        .await;
         restore_deploy_writes(contracts_dir, &snapshot).await?;
         return result;
     }
 
-    run_deploy_pipeline(ui, network, contract, dry_run, yes, contracts_dir, &ordered).await
+    run_deploy_pipeline(
+        ui,
+        network,
+        contract,
+        dry_run,
+        yes,
+        wait_confirm,
+        no_auto_version,
+        stacks_node,
+        contracts_dir,
+        &ordered,
+    )
+    .await
 }
 
 async fn run_deploy_pipeline(
@@ -288,21 +393,39 @@ async fn run_deploy_pipeline(
     contract: Option<&str>,
     dry_run: bool,
     yes: bool,
+    wait_confirm: bool,
+    no_auto_version: bool,
+    stacks_node: &str,
     contracts_dir: &Path,
     ordered: &[String],
-) -> Result<()> {
+) -> Result<DeployOutcome> {
     let clarinet_path = contracts_dir.join("Clarinet.toml");
     let clarinet_backup = if !dry_run {
         Some(fs::read(&clarinet_path).await?)
     } else {
         None
     };
+    let mut rename_snapshot: Option<RenameSnapshot> = None;
 
-    let result =
-        run_deploy_pipeline_inner(ui, network, contract, dry_run, yes, contracts_dir, ordered)
-            .await;
+    let result = run_deploy_pipeline_inner(
+        ui,
+        network,
+        contract,
+        dry_run,
+        yes,
+        wait_confirm,
+        no_auto_version,
+        stacks_node,
+        contracts_dir,
+        ordered,
+        &mut rename_snapshot,
+    )
+    .await;
 
     if result.is_err() {
+        if let Some(snapshot) = rename_snapshot {
+            let _ = restore_rename_snapshot(contracts_dir, &snapshot).await;
+        }
         if let Some(bytes) = clarinet_backup {
             let _ = fs::write(&clarinet_path, bytes).await;
         }
@@ -316,9 +439,13 @@ async fn run_deploy_pipeline_inner(
     contract: Option<&str>,
     dry_run: bool,
     yes: bool,
+    wait_confirm: bool,
+    no_auto_version: bool,
+    stacks_node: &str,
     contracts_dir: &Path,
     ordered: &[String],
-) -> Result<()> {
+    rename_snapshot: &mut Option<RenameSnapshot>,
+) -> Result<DeployOutcome> {
     let fee_flag = "--low-cost";
 
     let step = ui.begin_step("Resolving contract dependencies");
@@ -358,7 +485,24 @@ async fn run_deploy_pipeline_inner(
                     "dry run note: conflicting contract names would be versioned on apply",
                 );
             }
-            return Ok(());
+            return Ok(DeployOutcome {
+                status: "dry-run",
+                block_height: None,
+            });
+        }
+
+        if no_auto_version && !renames.is_empty() {
+            let conflicts: Vec<String> = renames
+                .iter()
+                .map(|r| format!("{} (network has {}; would rename to {})", r.from, r.from, r.to))
+                .collect();
+            return Err(anyhow!(
+                "Contract name conflict on {network}: {}.\n\
+                 Omit --no-auto-version to allow auto-versioning (e.g. counter → counter-v2), \
+                 or pick a new contract name.\n\
+                 Tip: commit your project before deploying to testnet/mainnet.",
+                conflicts.join(", ")
+            ));
         }
 
         let deployer = get_deployer_from_plan(network).await?;
@@ -371,6 +515,7 @@ async fn run_deploy_pipeline_inner(
         }
 
         if !renames.is_empty() {
+            ensure_rename_snapshot(contracts_dir, rename_snapshot).await?;
             let step = ui.begin_step("Applying versioned contract names");
             if let Err(e) = apply_contract_renames(&renames).await {
                 step.fail();
@@ -398,6 +543,13 @@ async fn run_deploy_pipeline_inner(
             let retry_renames =
                 plan_conflicting_contract_renames(network, effective_contract.as_deref()).await?;
             if !retry_renames.is_empty() {
+                if no_auto_version {
+                    return Err(anyhow!(
+                        "Contract still exists on {network} after versioning. \
+                         Remove --no-auto-version or choose a new contract name."
+                    ));
+                }
+                ensure_rename_snapshot(contracts_dir, rename_snapshot).await?;
                 apply_contract_renames(&retry_renames).await?;
                 effective_contract = effective_contract
                     .as_deref()
@@ -418,6 +570,8 @@ async fn run_deploy_pipeline_inner(
                 network,
                 &clarinet_output2,
                 effective_contract.as_deref(),
+                wait_confirm,
+                stacks_node,
             )
             .await;
         }
@@ -427,6 +581,8 @@ async fn run_deploy_pipeline_inner(
             network,
             &clarinet_output,
             effective_contract.as_deref(),
+            wait_confirm,
+            stacks_node,
         )
         .await;
     }
@@ -435,10 +591,21 @@ async fn run_deploy_pipeline_inner(
         run_generate_and_apply(ui, network, fee_flag, contract, dry_run, yes, false).await?;
 
     if dry_run {
-        return Ok(());
+        return Ok(DeployOutcome {
+            status: "dry-run",
+            block_height: None,
+        });
     }
 
-    write_deployments_json_from_output(ui, network, &clarinet_output, contract).await
+    write_deployments_json_from_output(
+        ui,
+        network,
+        &clarinet_output,
+        contract,
+        wait_confirm,
+        stacks_node,
+    )
+    .await
 }
 
 async fn reorder_clarinet_toml(
@@ -977,7 +1144,17 @@ async fn write_partial_deployments_from_output(
     captured_stdout: &str,
     contract: Option<&str>,
 ) -> Result<()> {
-    write_deployments_json_from_output(ui, network, captured_stdout, contract).await
+    let stacks_node = network_config(network)?.stacks_node;
+    let _ = write_deployments_json_from_output(
+        ui,
+        network,
+        captured_stdout,
+        contract,
+        false,
+        &stacks_node,
+    )
+    .await?;
+    Ok(())
 }
 
 async fn read_deployment_plan(network: &str) -> Result<DeploymentPlanFile> {
@@ -1465,11 +1642,19 @@ fn strip_version_suffix(name: &str) -> String {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn validate_settings_mnemonic(network: &str) -> Result<()> {
-    let path = format!("contracts/settings/{}.toml", capitalize(network));
-    let raw =
-        std::fs::read_to_string(&path).map_err(|_| anyhow!("Settings file not found: {path}"))?;
-    let mnemonic = parse_mnemonic(&raw).unwrap_or_default();
-    if mnemonic.is_empty() || mnemonic.contains('<') || mnemonic.contains('>') {
+    let path = stacksdapp_shell::settings_relative_path(network);
+    let raw = std::fs::read_to_string(&path).map_err(|_| anyhow!("Settings file not found: {path}"))?;
+    let parsed = stacksdapp_shell::parse_deployer_mnemonic(&raw).ok_or_else(|| {
+        anyhow!(
+            "No [accounts.deployer].mnemonic in {path}.\n\
+             Add your deployer seed phrase:\n\n\
+             [accounts.deployer]\n\
+             mnemonic = \"your 24 words here\"\n\n\
+             Get testnet STX: https://explorer.hiro.so/sandbox/faucet?chain=testnet"
+        )
+    })?;
+
+    if stacksdapp_shell::is_mnemonic_placeholder(&parsed.mnemonic) {
         return Err(anyhow!(
             "No valid mnemonic in {path}.\n\
              Add your deployer seed phrase:\n\n\
@@ -1478,6 +1663,24 @@ fn validate_settings_mnemonic(network: &str) -> Result<()> {
              Get testnet STX: https://explorer.hiro.so/sandbox/faucet?chain=testnet"
         ));
     }
+
+    if stacksdapp_shell::is_public_devnet_mnemonic(&parsed.mnemonic) {
+        return Err(anyhow!(
+            "This is a public devnet mnemonic in {path} (line {}).\n\
+             Devnet seeds are publicly known — use a fresh wallet for {network}.\n\
+             Generate a new seed and fund it via the testnet faucet.",
+            parsed.line_number,
+            network = network
+        ));
+    }
+
+    if let Err(detail) = stacksdapp_shell::validate_mnemonic_word_format(&parsed.mnemonic) {
+        return Err(anyhow!(
+            "Invalid deployer mnemonic in {path} (line {}): {detail}",
+            parsed.line_number
+        ));
+    }
+
     Ok(())
 }
 
@@ -1581,7 +1784,9 @@ async fn write_deployments_json_from_output(
     network: &str,
     output: &str,
     contract: Option<&str>,
-) -> Result<()> {
+    wait_confirm: bool,
+    stacks_node: &str,
+) -> Result<DeployOutcome> {
     let mut txid_map: HashMap<String, String> = HashMap::new();
     let mut actual_deployer = None;
     for line in output.lines() {
@@ -1622,6 +1827,22 @@ async fn write_deployments_json_from_output(
         wait_for_devnet_contracts(&deployer_address, &contract_names).await?;
     }
 
+    let mut deploy_status = if network == "devnet" {
+        "confirmed"
+    } else {
+        "broadcast"
+    };
+    let mut block_height: Option<u64> = None;
+
+    if (network == "testnet" || network == "mainnet") && wait_confirm {
+        ui.waiting_confirmation();
+        block_height =
+            wait_for_remote_contracts(stacks_node, &deployer_address, &contract_names).await?;
+        deploy_status = "confirmed";
+    }
+
+    let confirmed_height = block_height.unwrap_or(0);
+
     let mut contracts_map = if contract.is_some() {
         load_existing_deployments_for_network(network).await?
     } else {
@@ -1659,7 +1880,7 @@ async fn write_deployments_json_from_output(
             DeploymentInfo {
                 contract_id,
                 tx_id: txid,
-                block_height: 0,
+                block_height: confirmed_height,
             },
         );
     }
@@ -1679,8 +1900,11 @@ async fn write_deployments_json_from_output(
     // Ensure bindings are fresh after rename (quiet).
     run_generate_quiet().await?;
 
-    ui.success(&success_entries);
-    Ok(())
+    ui.success(&success_entries, deploy_status);
+    Ok(DeployOutcome {
+        status: deploy_status,
+        block_height,
+    })
 }
 
 async fn load_existing_deployments_for_network(
@@ -1865,6 +2089,79 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
     ))
 }
 
+async fn wait_for_remote_contracts(
+    stacks_node: &str,
+    deployer: &str,
+    contract_names: &[String],
+) -> Result<Option<u64>> {
+    if contract_names.is_empty() {
+        return Ok(None);
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(8))
+        .build()?;
+    let node = stacks_node.trim_end_matches('/');
+
+    ui_log_wait_start();
+
+    for attempt in 1..=120 {
+        let mut pending = Vec::new();
+        for contract_name in contract_names {
+            let url = format!("{node}/v2/contracts/source/{deployer}/{contract_name}?proof=0");
+            let deployed = client
+                .get(&url)
+                .send()
+                .await
+                .map(|response| response.status().is_success())
+                .unwrap_or(false);
+            if !deployed {
+                pending.push(contract_name.clone());
+            }
+        }
+
+        if pending.is_empty() {
+            let mut tip = None;
+            if let Ok(response) = client.get(format!("{node}/v2/info")).send().await {
+                if let Ok(info) = response.json::<CoreInfoResponse>().await {
+                    tip = Some(info.stacks_tip_height);
+                }
+            }
+            return Ok(tip);
+        }
+
+        let _ = attempt;
+        if attempt == 1 || attempt % 5 == 0 {
+            ui_log_wait_tick(attempt, &pending);
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+
+    Err(anyhow!(
+        "Timed out waiting for on-chain confirmation after broadcast.\n\
+         Contracts still pending: {}.\n\
+         Transactions were submitted — verify txids on the explorer.\n\
+         Re-run without --wait-confirm for the default fast broadcast-only flow.",
+        contract_names.join(", ")
+    ))
+}
+
+fn ui_log_wait_start() {
+    if !stacksdapp_shell::is_quiet() {
+        println!("Broadcast complete — waiting for chain confirmation (--wait-confirm)...");
+    }
+}
+
+fn ui_log_wait_tick(attempt: u32, pending: &[String]) {
+    if !stacksdapp_shell::is_quiet() {
+        let secs = attempt as u64 * 2;
+        eprintln!(
+            "  still waiting ({secs}s) — pending: {}",
+            pending.join(", ")
+        );
+    }
+}
+
 async fn probe_stacks_api_health() -> Result<bool> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
@@ -2018,6 +2315,9 @@ mod tests {
     use reqwest::StatusCode;
     use std::collections::{HashMap, HashSet};
     use std::fs;
+    use std::sync::Mutex;
+
+    static CWD_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_strip_version_suffix() {
@@ -2291,5 +2591,77 @@ path = "contracts/c.clar"
             1, 2
         );
         assert!(err.contains("recorded in deployments.json"));
+    }
+
+    #[test]
+    fn validate_settings_rejects_public_devnet_mnemonic_on_testnet() {
+        let _lock = CWD_TEST_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let settings_dir = tmp.path().join("contracts/settings");
+        fs::create_dir_all(&settings_dir).unwrap();
+        fs::write(
+            settings_dir.join("Testnet.toml"),
+            format!(
+                "[accounts.deployer]\nmnemonic = \"{}\"\n",
+                stacksdapp_shell::PUBLIC_DEVNET_MNEMONICS[0]
+            ),
+        )
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        let err = super::validate_settings_mnemonic("testnet").unwrap_err();
+        std::env::set_current_dir(prev).unwrap();
+        assert!(err.to_string().contains("public devnet mnemonic"));
+    }
+
+    #[test]
+    fn validate_settings_rejects_invalid_word_count() {
+        let _lock = CWD_TEST_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let settings_dir = tmp.path().join("contracts/settings");
+        fs::create_dir_all(&settings_dir).unwrap();
+        fs::write(
+            settings_dir.join("Testnet.toml"),
+            "[accounts.deployer]\nmnemonic = \"one two three\"\n",
+        )
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        let err = super::validate_settings_mnemonic("testnet").unwrap_err();
+        std::env::set_current_dir(prev).unwrap();
+        assert!(err.to_string().contains("mnemonic has 3 words"));
+    }
+
+    #[tokio::test]
+    async fn rename_snapshot_restores_clar_and_clarinet_after_simulated_rename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let contracts_dir = tmp.path().join("contracts");
+        let src_dir = contracts_dir.join("contracts");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(
+            contracts_dir.join("Clarinet.toml"),
+            "[contracts.counter]\npath = \"contracts/counter.clar\"\n",
+        )
+        .unwrap();
+        fs::write(src_dir.join("counter.clar"), "(define-read-only (get) (ok u0))").unwrap();
+
+        let snapshot = super::snapshot_contract_state(&contracts_dir)
+            .await
+            .unwrap();
+        fs::rename(src_dir.join("counter.clar"), src_dir.join("counter-v2.clar")).unwrap();
+        fs::write(
+            contracts_dir.join("Clarinet.toml"),
+            "[contracts.counter-v2]\npath = \"contracts/counter-v2.clar\"\n",
+        )
+        .unwrap();
+
+        super::restore_rename_snapshot(&contracts_dir, &snapshot)
+            .await
+            .unwrap();
+
+        assert!(src_dir.join("counter.clar").exists());
+        assert!(!src_dir.join("counter-v2.clar").exists());
+        let clarinet = fs::read_to_string(contracts_dir.join("Clarinet.toml")).unwrap();
+        assert!(clarinet.contains("[contracts.counter]"));
     }
 }

--- a/crates/deployer/src/lib.rs
+++ b/crates/deployer/src/lib.rs
@@ -6,7 +6,7 @@ use bitcoin::Network as BitcoinNetwork;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str::FromStr;
 use tempfile::NamedTempFile;
@@ -15,8 +15,49 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
+pub mod devnet_recovery;
 mod ui;
+use devnet_recovery::{
+    ensure_devnet_chain_mining, fetch_local_core_info_optional, recover_devnet_if_stalled_during_wait,
+    LocalCoreInfo,
+};
 use ui::DeployUi;
+
+static CLARINET_VERSION: std::sync::OnceLock<Option<(u32, u32, u32)>> = std::sync::OnceLock::new();
+
+fn installed_clarinet_version() -> Option<(u32, u32, u32)> {
+    *CLARINET_VERSION.get_or_init(|| {
+        let output = std::process::Command::new("clarinet")
+            .arg("--version")
+            .output()
+            .ok()?;
+        let text = String::from_utf8_lossy(&output.stdout);
+        parse_semver_triple(text.trim().trim_start_matches("clarinet "))
+    })
+}
+
+fn parse_semver_triple(raw: &str) -> Option<(u32, u32, u32)> {
+    let version = raw.split_whitespace().next()?.trim_start_matches('v');
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts
+        .next()
+        .unwrap_or("0")
+        .split('-')
+        .next()
+        .unwrap_or("0")
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
+}
+
+pub fn clarinet_version_at_least(major: u32, minor: u32, patch: u32) -> bool {
+    match installed_clarinet_version() {
+        Some((m, mi, p)) => (m, mi, p) >= (major, minor, patch),
+        None => false,
+    }
+}
 
 /// Result metadata for deploy (used by `--json` and scripting).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,7 +74,8 @@ pub struct NetworkConfig {
 pub fn network_config(network: &str) -> Result<NetworkConfig> {
     match network {
         "devnet" => Ok(NetworkConfig {
-            stacks_node: "http://localhost:3999".into(),
+            // Core RPC — stacks-api is off by default (snapshot fast-boot).
+            stacks_node: "http://localhost:20443".into(),
         }),
         "testnet" => Ok(NetworkConfig {
             stacks_node: "https://api.testnet.hiro.so".into(),
@@ -99,12 +141,6 @@ struct PlannedPublish {
 #[derive(Debug, Deserialize)]
 struct AccountResponse {
     nonce: u64,
-}
-
-#[derive(Debug, Deserialize)]
-struct CoreInfoResponse {
-    burn_block_height: u64,
-    stacks_tip_height: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -842,7 +878,7 @@ async fn run_generate_and_apply(
     }
 
     if network == "devnet" {
-        return run_apply_devnet_direct(ui, network).await;
+        return run_apply_devnet(ui, network, &contracts, contract.is_some()).await;
     }
 
     let deployer = get_deployer_from_plan(network).await?;
@@ -857,40 +893,147 @@ async fn run_generate_and_apply(
         }
     }
 
+    let plan = read_deployment_plan(network).await?;
+    if plan_uses_direct_broadcast(&plan) {
+        return run_apply_direct(ui, network).await;
+    }
+
+    run_clarinet_deployments_apply(ui, network, &contracts, contract.is_some(), None).await
+}
+
+async fn run_apply_devnet(
+    ui: &DeployUi,
+    network: &str,
+    contracts: &[String],
+    single_contract: bool,
+) -> Result<String> {
+    let plan = read_deployment_plan(network).await?;
+    let transactions = flatten_contract_publishes(&plan);
+    if transactions.is_empty() {
+        return Err(anyhow!(
+            "No contract publish transactions found in the devnet deployment plan."
+        ));
+    }
+
+    let required_burn = transactions
+        .iter()
+        .map(|item| min_burn_height_for_publish(item.epoch.as_deref(), item.tx.clarity_version))
+        .max()
+        .unwrap_or(0);
+    if required_burn > 0 {
+        wait_for_burn_height(required_burn).await?;
+    }
+
+    ensure_devnet_chain_mining("broadcast").await?;
+
+    // Pre-Clarinet 3.23: stacks-node 3.4 rejects @stacks/transactions v7 C6 wire encoding.
+    let needs_clarinet_apply_for_c6 = transactions
+        .iter()
+        .any(|item| item.tx.clarity_version.unwrap_or(0) >= 6)
+        && !clarinet_version_at_least(3, 23, 0);
+
+    if needs_clarinet_apply_for_c6 {
+        ui.step_ok("Preparing Clarinet devnet broadcast (Clarity 6)");
+        let plan_path = write_contracts_only_plan_file(network).await?;
+        return run_clarinet_deployments_apply(
+            ui,
+            network,
+            contracts,
+            single_contract,
+            Some(plan_path.as_path()),
+        )
+        .await;
+    }
+
+    // Clarinet apply coordinates devnet mining with the bitcoin controller; prefer it on 3.23+.
+    if clarinet_version_at_least(3, 23, 0) {
+        ui.step_ok("Preparing Clarinet devnet broadcast");
+        match run_clarinet_deployments_apply(
+            ui,
+            network,
+            contracts,
+            single_contract,
+            None,
+        )
+        .await
+        {
+            Ok(stdout) => return Ok(stdout),
+            Err(clarinet_err) => {
+                stacksdapp_shell::println_human_safe(format!(
+                    "[deploy] Clarinet devnet apply failed ({clarinet_err:#}); trying direct broadcast..."
+                ));
+            }
+        }
+    }
+
+    run_apply_direct(ui, network).await
+}
+
+async fn run_clarinet_deployments_apply(
+    ui: &DeployUi,
+    network: &str,
+    contracts: &[String],
+    single_contract: bool,
+    plan_path: Option<&Path>,
+) -> Result<String> {
     ui.broadcasting_start();
 
+    let mut args = vec![
+        "deployments".to_string(),
+        "apply".to_string(),
+        "--no-dashboard".to_string(),
+    ];
+    if let Some(path) = plan_path {
+        args.push("-p".to_string());
+        args.push(path.display().to_string());
+    } else {
+        args.push(format!("--{network}"));
+    }
+
     let mut child = Command::new("clarinet")
-        .args([
-            "deployments",
-            "apply",
-            "--no-dashboard",
-            &format!("--{network}"),
-        ])
+        .args(&args)
         .current_dir("contracts")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()?;
 
     let mut stdin = child
         .stdin
         .take()
         .ok_or_else(|| anyhow!("Failed to open stdin"))?;
+    // Pre-answer cost/continue prompts (Clarinet may not echo them on stdout).
+    let _ = stdin.write_all(b"y\n").await;
+    let _ = stdin.flush().await;
     let stdout = child
         .stdout
         .take()
         .ok_or_else(|| anyhow!("Failed to open stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("Failed to open stderr"))?;
 
     let expected_count = contracts.len().max(1);
     let mut confirmed_count = 0usize;
     let mut broadcast_count = 0usize;
-    let mut reader = tokio::io::BufReader::new(stdout).lines();
     let mut captured_stdout = String::new();
     let mut last_txid_by_name: HashMap<String, String> = HashMap::new();
+    let mut stdout_reader = tokio::io::BufReader::new(stdout).lines();
+    let mut stderr_reader = tokio::io::BufReader::new(stderr).lines();
 
     ui.render_bar(0, expected_count);
 
-    while let Ok(Some(line)) = reader.next_line().await {
+    loop {
+        let line = tokio::select! {
+            line = stdout_reader.next_line() => line,
+            line = stderr_reader.next_line() => line,
+        };
+
+        let Some(line) = line? else {
+            break;
+        };
+
         captured_stdout.push_str(&line);
         captured_stdout.push('\n');
 
@@ -901,9 +1044,31 @@ async fn run_generate_and_apply(
             ));
         }
 
+        if line.contains("ContractAlreadyExists") {
+            let _ = child.kill().await;
+            return Err(anyhow!(
+                "Contract already exists on devnet.\n\
+                 Run `stacksdapp clean` and restart `stacksdapp dev`, or redeploy with a new contract name.\n\
+                 Output:\n{}",
+                captured_stdout.trim()
+            ));
+        }
+
+        if line.contains("Error publishing transactions")
+            || line.contains("unable to post transaction")
+            || line.starts_with("x Error")
+            || (line.contains("➡ Error(") && line.contains("Publish ST1"))
+        {
+            let _ = child.kill().await;
+            return Err(anyhow!(
+                "clarinet deployments apply failed.\nOutput:\n{}",
+                captured_stdout.trim()
+            ));
+        }
+
         // Auto-answer Clarinet prompts silently (consent already obtained).
         if line.contains("Overwrite?") {
-            let answer = if contract.is_some() { b"n\n" } else { b"y\n" };
+            let answer = if single_contract { b"n\n" } else { b"y\n" };
             let _ = stdin.write_all(answer).await;
             let _ = stdin.flush().await;
         } else if line.contains("Confirm?")
@@ -920,21 +1085,42 @@ async fn run_generate_and_apply(
                 last_txid_by_name.insert(name, txid);
             }
             ui.render_bar(broadcast_count, expected_count);
+        } else if line.contains("\"txid\"") && !line.contains("\"error\"") {
+            if let Some(txid) = line
+                .split('"')
+                .find(|part| part.len() == 64 && part.chars().all(|c| c.is_ascii_hexdigit()))
+            {
+                if let Some(name) = contracts.get(broadcast_count) {
+                    last_txid_by_name.insert(name.clone(), txid.to_string());
+                }
+            }
+        } else if let Some(name) = parse_clarinet_publish_line(&line) {
+            // Intent only — success is counted when Broadcasted/txid appears above.
+            last_txid_by_name.entry(name).or_insert_with(|| "pending".to_string());
         }
 
         if line.contains("Confirmed Publish") || line.contains("Published") {
             confirmed_count += 1;
         }
 
-        // Clarinet keeps polling Hiro for on-chain confirmation after broadcast; do not
-        // wait for that — finalize as soon as all txs are in the mempool (or confirmed).
         if confirmed_count >= expected_count || broadcast_count >= expected_count {
-            let _ = child.kill().await;
             break;
         }
     }
 
-    let status = child.wait().await?;
+    // Do not kill Clarinet after seeing a publish intent — let it finish posting.
+    let status = tokio::time::timeout(std::time::Duration::from_secs(120), child.wait())
+        .await
+        .map_err(|_| anyhow!("Timed out waiting for clarinet deployments apply to finish"))??;
+
+    if broadcast_count == 0 {
+        if captured_stdout.contains("Publish ST1") {
+            return Err(anyhow!(
+                "clarinet deployments apply did not confirm any broadcasts.\nOutput:\n{}",
+                captured_stdout.trim()
+            ));
+        }
+    }
     if !status.success() && broadcast_count == 0 {
         return Err(anyhow!(
             "clarinet deployments apply failed with status {status}.\nOutput:\n{}",
@@ -942,7 +1128,7 @@ async fn run_generate_and_apply(
         ));
     }
     if !status.success() && broadcast_count > 0 && broadcast_count < expected_count {
-        write_partial_deployments_from_output(ui, network, &captured_stdout, contract).await?;
+        write_partial_deployments_from_output(ui, network, &captured_stdout, None).await?;
         return Err(anyhow!(
             "Partial {network} deployment: {broadcast_count}/{expected_count} contracts broadcast and recorded in deployments.json.\n\
              clarinet deployments apply failed with status {status}.\nOutput:\n{}",
@@ -950,65 +1136,117 @@ async fn run_generate_and_apply(
         ));
     }
 
-    // Finalize bar once if we somehow exited without hitting 100%.
     if broadcast_count > 0 && broadcast_count < expected_count {
         ui.render_bar(expected_count, expected_count);
-    } else if broadcast_count >= expected_count {
-        // Already finalized inside render_bar when done == total.
-    } else {
+    } else if broadcast_count < expected_count {
         ui.render_bar(expected_count, expected_count);
     }
 
-    // Stable order matching the deployment plan.
-    for name in &contracts {
+    for name in contracts {
         if let Some(txid) = last_txid_by_name.get(name) {
             ui.contract_broadcast_ok(name, txid);
+            if txid != "pending" && txid != "already-deployed" {
+                captured_stdout.push_str(&format!(
+                    "Broadcasted ContractPublish(StandardPrincipalData(ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM), ContractName(\"{name}\"), \"{txid}\")\n"
+                ));
+            }
         }
     }
 
     Ok(captured_stdout)
 }
 
-async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String> {
-    ui.step_ok("Preparing direct devnet broadcast");
+async fn write_contracts_only_plan_file(network: &str) -> Result<PathBuf> {
+    let plan_path = format!("contracts/deployments/default.{network}-plan.yaml");
+    let raw = fs::read_to_string(&plan_path)
+        .await
+        .map_err(|e| anyhow!("Failed to read deployment plan at {plan_path}: {e}"))?;
+    let mut yaml: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .map_err(|e| anyhow!("Failed to parse deployment plan YAML at {plan_path}: {e}"))?;
+    filter_plan_contract_publishes_only(&mut yaml);
+    let rendered = serde_yaml::to_string(&yaml)?;
+    let mut file = NamedTempFile::new()?;
+    use std::io::Write;
+    file.write_all(rendered.as_bytes())?;
+    let (_, path) = file.keep().map_err(|e| anyhow!("Failed to persist filtered plan: {e:?}"))?;
+    Ok(path)
+}
+
+fn filter_plan_contract_publishes_only(yaml: &mut serde_yaml::Value) {
+    let Some(batches) = yaml
+        .get_mut("plan")
+        .and_then(|plan| plan.get_mut("batches"))
+        .and_then(|batches| batches.as_sequence_mut())
+    else {
+        return;
+    };
+
+    for batch in batches.iter_mut() {
+        let Some(transactions) = batch
+            .get_mut("transactions")
+            .and_then(|t| t.as_sequence_mut())
+        else {
+            continue;
+        };
+        transactions.retain(|tx| {
+            tx.get("transaction-type").and_then(|v| v.as_str()) == Some("contract-publish")
+        });
+    }
+
+    batches.retain(|batch| {
+        batch
+            .get("transactions")
+            .and_then(|t| t.as_sequence())
+            .map(|txs| !txs.is_empty())
+            .unwrap_or(false)
+    });
+}
+
+fn plan_uses_direct_broadcast(plan: &DeploymentPlanFile) -> bool {
+    flatten_contract_publishes(plan)
+        .iter()
+        .any(|item| item.tx.clarity_version.unwrap_or(0) >= 5)
+}
+
+async fn run_apply_direct(ui: &DeployUi, network: &str) -> Result<String> {
+    ui.step_ok(if network == "devnet" {
+        "Preparing direct devnet broadcast"
+    } else {
+        "Preparing direct broadcast (@stacks/transactions)"
+    });
     let plan = read_deployment_plan(network).await?;
     let transactions = flatten_contract_publishes(&plan);
     if transactions.is_empty() {
         return Err(anyhow!(
-            "No contract publish transactions found in the devnet deployment plan."
+            "No contract publish transactions found in the {network} deployment plan."
         ));
     }
 
-    let settings_raw = fs::read_to_string("contracts/settings/Devnet.toml").await?;
-    let mnemonic = parse_mnemonic(&settings_raw)
-        .ok_or_else(|| anyhow!("No deployer mnemonic found in contracts/settings/Devnet.toml"))?;
+    let settings_path = stacksdapp_shell::settings_relative_path(network);
+    let settings_raw = fs::read_to_string(&settings_path).await?;
+    let mnemonic = parse_mnemonic(&settings_raw).ok_or_else(|| {
+        anyhow!("No deployer mnemonic found in contracts/settings/{network}.toml")
+    })?;
     let derivation = parse_deployer_derivation(&settings_raw)
         .unwrap_or_else(|| "m/44'/5757'/0'/0/0".to_string());
     let sender_key = derive_private_key_from_mnemonic(&mnemonic, &derivation)?;
 
+    let node = network_config(network)?.stacks_node;
     let expected_sender = transactions
         .first()
         .and_then(|item| item.tx.expected_sender.clone())
-        .ok_or_else(|| anyhow!("No expected sender found in the devnet deployment plan."))?;
-    let script_path = write_devnet_broadcast_script()?;
+        .ok_or_else(|| anyhow!("No expected sender found in the {network} deployment plan."))?;
+    let script_path = write_broadcast_script()?;
     let mut captured_stdout = String::new();
 
-    // Clarity 5 / epoch 3.4 publishes must wait until burn height unlocks that epoch.
-    // Broadcasting earlier returns a txid, then the tx sits unmined forever (nonce stays put).
-    let required_burn = transactions
-        .iter()
-        .map(|item| min_burn_height_for_publish(item.epoch.as_deref(), item.tx.clarity_version))
-        .max()
-        .unwrap_or(0);
-    if required_burn > 0 {
-        wait_for_burn_height(required_burn).await?;
-    }
+    // Devnet burn/epoch gating is handled in run_apply_devnet before this path is reached.
 
     ui.broadcasting_start();
     let expected = transactions.len().max(1);
     ui.render_bar(0, expected);
 
     let mut broadcast_count = 0usize;
+    let mut next_nonce = fetch_core_nonce(&node, &expected_sender).await?;
     for item in transactions.into_iter() {
         let tx = item.tx;
         let contract_name = tx
@@ -1016,10 +1254,14 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
             .clone()
             .ok_or_else(|| anyhow!("Missing contract name in deployment plan."))?;
 
-        if contract_source_exists(&expected_sender, &contract_name).await? {
+        if contract_source_exists(&node, &expected_sender, &contract_name).await? {
             stacksdapp_shell::println_human_safe(format!(
                 "[deploy] {contract_name} already on core — skipping broadcast."
             ));
+            // Resync in case a prior run advanced the chain nonce.
+            next_nonce = fetch_core_nonce(&node, &expected_sender)
+                .await?
+                .max(next_nonce);
             // Still record a synthetic success marker so deployments.json is written.
             captured_stdout.push_str(&format!(
                 "Broadcasted ContractPublish(StandardPrincipalData({}), ContractName(\"{contract_name}\"), \"already-deployed\")\n",
@@ -1035,8 +1277,7 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
             anyhow!("Missing contract path for {contract_name} in deployment plan.")
         })?;
         let fee = tx.cost.unwrap_or(10_000).max(1);
-        // Always read nonce from core so skips / prior confirms stay consistent.
-        let nonce = fetch_local_core_nonce(&expected_sender).await?;
+        let nonce = next_nonce;
         let args = serde_json::json!({
             "contractName": contract_name,
             "codePath": contract_path,
@@ -1044,6 +1285,8 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
             "fee": fee.to_string(),
             "nonce": nonce.to_string(),
             "clarityVersion": tx.clarity_version,
+            "network": network,
+            "baseUrl": node,
         });
 
         let mut child = Command::new("node")
@@ -1133,9 +1376,72 @@ async fn run_apply_devnet_direct(ui: &DeployUi, network: &str) -> Result<String>
         broadcast_count += 1;
         ui.render_bar(broadcast_count, expected);
         ui.contract_broadcast_ok(tx.contract_name.as_deref().unwrap_or(""), txid);
+        next_nonce = nonce.saturating_add(1);
+
+        // Devnet: confirm on core before the next broadcast (15s blocks need this).
+        if network == "devnet" {
+            wait_for_single_devnet_contract(&expected_sender, &contract_name, 120).await?;
+            next_nonce = fetch_core_nonce(&node, &expected_sender)
+                .await?
+                .max(next_nonce);
+        }
     }
 
     Ok(captured_stdout)
+}
+
+async fn wait_for_single_devnet_contract(
+    deployer: &str,
+    contract_name: &str,
+    timeout_secs: u64,
+) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()?;
+    let node = "http://localhost:20443";
+    let project = devnet_recovery::devnet_project_name();
+    let mut last_core = fetch_local_core_info_optional().await;
+    let mut last_recovery = std::time::Instant::now() - std::time::Duration::from_secs(300);
+
+    for attempt in 1..=timeout_secs {
+        let url = format!("{node}/v2/contracts/source/{deployer}/{contract_name}?proof=0");
+        let deployed = client
+            .get(&url)
+            .send()
+            .await
+            .map(|response| response.status().is_success())
+            .unwrap_or(false);
+        if deployed {
+            return Ok(());
+        }
+
+        if attempt % 15 == 0 {
+            if let Some(prev) = last_core.as_ref() {
+                if last_recovery.elapsed() >= std::time::Duration::from_secs(45)
+                    && recover_devnet_if_stalled_during_wait(prev, project.as_deref()).await
+                {
+                    last_recovery = std::time::Instant::now();
+                }
+            }
+            last_core = fetch_local_core_info_optional().await;
+        }
+
+        if attempt == 1 || attempt % 10 == 0 {
+            stacksdapp_shell::println_human_safe(format!(
+                "[deploy] Waiting for {contract_name} on local core ({attempt}s)..."
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    ensure_devnet_chain_mining(&format!("confirm {contract_name}")).await?;
+    if contract_source_exists(node, deployer, contract_name).await? {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "Timed out waiting for {contract_name} to confirm on local devnet after {timeout_secs}s."
+    ))
 }
 
 async fn write_partial_deployments_from_output(
@@ -1197,8 +1503,18 @@ fn clarinet_default_epoch_start(epoch: &str) -> Option<u64> {
         "3.2" => Some(146),
         "3.3" => Some(148),
         "3.4" => Some(150),
-        "4.0" => Some(152),
+        // Clarinet 3.23+ devnet snapshot activates epoch 4.0 at burn 163 (was 152 on 3.21).
+        "4.0" => Some(epoch_40_burn_height()),
         _ => None,
+    }
+}
+
+/// Burn height for epoch 4.0 on Clarinet devnet (163 since Clarinet 3.23.0, 152 on older).
+fn epoch_40_burn_height() -> u64 {
+    if clarinet_version_at_least(3, 23, 0) {
+        163
+    } else {
+        152
     }
 }
 
@@ -1209,7 +1525,8 @@ fn min_burn_height_for_publish(epoch: Option<&str>, clarity_version: Option<u8>)
         }
     }
     match clarity_version {
-        // Clarity 5 activates with epoch 3.4 on Clarinet's default Devnet schedule.
+        Some(v) if v >= 6 => epoch_40_burn_height(),
+        // Clarity 5 activates with epoch 3.4.
         Some(v) if v >= 5 => 150,
         Some(v) if v >= 4 => 142,
         _ => 0,
@@ -1218,7 +1535,8 @@ fn min_burn_height_for_publish(epoch: Option<&str>, clarity_version: Option<u8>)
 
 async fn wait_for_burn_height(min_burn: u64) -> Result<()> {
     let mut last_log = std::time::Instant::now() - std::time::Duration::from_secs(30);
-    for _ in 0..120 {
+    let mut core_failures = 0u32;
+    for _ in 0..180 {
         match fetch_local_core_info().await {
             Ok(info) if info.burn_block_height >= min_burn => {
                 stacksdapp_shell::println_human_safe(format!(
@@ -1228,6 +1546,7 @@ async fn wait_for_burn_height(min_burn: u64) -> Result<()> {
                 return Ok(());
             }
             Ok(info) => {
+                core_failures = 0;
                 if last_log.elapsed() >= std::time::Duration::from_secs(8) {
                     stacksdapp_shell::println_human_safe(format!(
                         "[deploy] Waiting for epoch burn height {min_burn} (currently {})...",
@@ -1237,6 +1556,14 @@ async fn wait_for_burn_height(min_burn: u64) -> Result<()> {
                 }
             }
             Err(_) => {
+                core_failures += 1;
+                if core_failures >= 5 {
+                    return Err(anyhow!(
+                        "Local stacks-node stopped responding while waiting for burn height ≥ {min_burn}.\n\
+                         Devnet often stalls or restarts near epoch 4.0 activation (~burn 161→163).\n\
+                         Run `stacksdapp clean --force`, restart `stacksdapp dev` (Clarinet 3.23+ uses the epoch 4.0 snapshot), wait until burn ≥ {min_burn}, then deploy again."
+                    ));
+                }
                 if last_log.elapsed() >= std::time::Duration::from_secs(8) {
                     stacksdapp_shell::println_human_safe(
                         "[deploy] Waiting for local stacks-node before epoch check...",
@@ -1249,17 +1576,18 @@ async fn wait_for_burn_height(min_burn: u64) -> Result<()> {
     }
     Err(anyhow!(
         "Timed out waiting for burn height ≥ {min_burn}.\n\
-         Clarity 5 / epoch 3.4 contracts cannot mine before that height on Clarinet Devnet.\n\
-         Keep `stacksdapp dev` running and retry deploy once burn height catches up."
+         Clarity 5 (epoch 3.4 / burn ≥ 150) and Clarity 6 (epoch 4.0 / burn ≥ {}) contracts cannot mine before that height on Clarinet Devnet.\n\
+         Keep `stacksdapp dev` running and retry deploy once burn height catches up.\n\
+         If burn height stalls, run `stacksdapp clean --force` and restart devnet (Clarinet 3.23+ pulls a new epoch 4.0 snapshot).",
+        epoch_40_burn_height()
     ))
 }
 
-async fn contract_source_exists(deployer: &str, contract_name: &str) -> Result<bool> {
+async fn contract_source_exists(node: &str, deployer: &str, contract_name: &str) -> Result<bool> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
-    let url =
-        format!("http://localhost:20443/v2/contracts/source/{deployer}/{contract_name}?proof=0");
+    let url = format!("{node}/v2/contracts/source/{deployer}/{contract_name}?proof=0");
     Ok(client
         .get(&url)
         .send()
@@ -1268,20 +1596,17 @@ async fn contract_source_exists(deployer: &str, contract_name: &str) -> Result<b
         .unwrap_or(false))
 }
 
-fn write_devnet_broadcast_script() -> Result<std::path::PathBuf> {
+fn write_broadcast_script() -> Result<std::path::PathBuf> {
     let mut file = NamedTempFile::new()?;
     use std::io::Write;
-    file.write_all(DEVNET_BROADCAST_SCRIPT.as_bytes())?;
+    file.write_all(BROADCAST_SCRIPT.as_bytes())?;
     let (_, path) = file.keep()?;
     Ok(path)
 }
 
-/// Node bridge for direct devnet publishes. Payload (including senderKey) is read
-/// from stdin — never from argv — so keys do not appear in `ps`.
-///
-/// Uses `broadcastTransaction` (@stacks/transactions v6+/v7) — `broadcastRawTransaction`
-/// was removed and must not be used. Testnet/mainnet still go through Clarinet apply.
-const DEVNET_BROADCAST_SCRIPT: &str = r#"
+/// Node bridge for direct publishes (devnet + testnet/mainnet Clarity 5/6).
+/// Payload (including senderKey) is read from stdin — never from argv — so keys do not appear in `ps`.
+const BROADCAST_SCRIPT: &str = r#"
 import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
@@ -1323,16 +1648,15 @@ const transaction = await makeContractDeploy({
   senderKey: input.senderKey,
   fee: BigInt(input.fee),
   nonce: BigInt(input.nonce),
-  network: 'devnet',
+  network: input.network,
   anchorMode: AnchorMode.OnChainOnly,
   postConditionMode: PostConditionMode.Deny,
   ...(typeof input.clarityVersion === 'number' ? { clarityVersion: input.clarityVersion } : {}),
 });
 
-// Prefer core RPC (:20443) so deploy works even if stacks-api is lagging on new_block.
 const response = await broadcastTransaction({
   transaction,
-  client: { baseUrl: 'http://localhost:20443' },
+  client: { baseUrl: input.baseUrl },
 });
 
 // @stacks/transactions returns error JSON (no throw) on non-2xx — treat as failure.
@@ -1343,11 +1667,11 @@ if (response?.error || response?.reason || !response?.txid) {
 console.log(JSON.stringify(response));
 "#;
 
-async fn fetch_local_core_nonce(address: &str) -> Result<u64> {
+async fn fetch_core_nonce(node: &str, address: &str) -> Result<u64> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
-    let url = format!("http://localhost:20443/v2/accounts/{address}?proof=0");
+    let url = format!("{node}/v2/accounts/{address}?proof=0");
     let response = client
         .get(&url)
         .send()
@@ -1758,6 +2082,49 @@ fn replace_contract_reference(source: &str, old_name: &str, new_name: &str) -> S
     out
 }
 
+fn collect_txids_from_clarinet_output(output: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let mut last_publish: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(name) = parse_clarinet_publish_line(line) {
+            last_publish = Some(name);
+        }
+
+        if line.contains("Broadcasted") {
+            if let Some((name, txid)) = parse_broadcast_line(line) {
+                map.insert(name, txid);
+            }
+        }
+
+        if line.contains("\"txid\"") && !line.contains("\"error\"") {
+            if let Some(txid) = line
+                .split('"')
+                .find(|part| part.len() == 64 && part.chars().all(|c| c.is_ascii_hexdigit()))
+            {
+                if let Some(name) = last_publish.clone() {
+                    map.entry(name).or_insert_with(|| txid.to_string());
+                }
+            }
+        }
+    }
+
+    map
+}
+
+fn parse_clarinet_publish_line(line: &str) -> Option<String> {
+    let marker = "Publish ST1";
+    let pos = line.find(marker)?;
+    let rest = &line[pos + marker.len()..];
+    let dot = rest.find('.')?;
+    let name = rest[dot + 1..].trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
 fn parse_broadcast_line(line: &str) -> Option<(String, String)> {
     let cn_marker = "ContractName(\"";
     let name = {
@@ -1787,7 +2154,7 @@ async fn write_deployments_json_from_output(
     wait_confirm: bool,
     stacks_node: &str,
 ) -> Result<DeployOutcome> {
-    let mut txid_map: HashMap<String, String> = HashMap::new();
+    let txid_map = collect_txids_from_clarinet_output(output);
     let mut actual_deployer = None;
     for line in output.lines() {
         if line.contains("Broadcasted") {
@@ -1796,10 +2163,6 @@ async fn write_deployments_json_from_output(
                 if let Some(end) = rest.find(')') {
                     actual_deployer = Some(rest[..end].to_string());
                 }
-            }
-
-            if let Some((contract_name, txid)) = parse_broadcast_line(line) {
-                txid_map.insert(contract_name, txid);
             }
         }
     }
@@ -1823,7 +2186,6 @@ async fn write_deployments_json_from_output(
     }
 
     if network == "devnet" {
-        ui.waiting_confirmation();
         wait_for_devnet_contracts(&deployer_address, &contract_names).await?;
     }
 
@@ -1855,11 +2217,13 @@ async fn write_deployments_json_from_output(
     for name in &contract_names {
         let contract_id = format!("{deployer_address}.{name}");
         let broadcast_marker = format!("ContractName(\"{name}\")");
-        let was_broadcast = output
-            .lines()
-            .any(|line| line.contains("Broadcasted") && line.contains(&broadcast_marker));
+        let publish_marker = format!(".{name}");
+        let was_broadcast = output.lines().any(|line| {
+            (line.contains("Broadcasted") && line.contains(&broadcast_marker))
+                || (line.contains("Publish ST1") && line.contains(&publish_marker))
+        });
         let txid = match txid_map.get(name) {
-            Some(t) if t == "already-deployed" => String::new(),
+            Some(t) if t == "already-deployed" || t == "pending" => String::new(),
             Some(t) => {
                 if t.starts_with("0x") {
                     t.clone()
@@ -1868,9 +2232,13 @@ async fn write_deployments_json_from_output(
                 }
             }
             None if was_broadcast => {
-                return Err(anyhow!(
-                    "Deployment broadcast for '{name}' succeeded but txid could not be parsed from clarinet output."
-                ));
+                stacksdapp_shell::debug(
+                    1,
+                    &format!(
+                        "deploy: broadcast for '{name}' succeeded but txid was not in clarinet output"
+                    ),
+                );
+                String::new()
             }
             None => String::new(),
         };
@@ -2027,6 +2395,8 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
     let node = "http://localhost:20443";
     let initial_info = fetch_local_core_info().await.ok();
 
+    ui_log_devnet_wait_start();
+
     // Quietly wait for local core to expose published contracts.
     // 15s block times need more than 30s; epoch-gated publishes may confirm a bit later.
     for attempt in 1..=90 {
@@ -2050,11 +2420,15 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
             return Ok(());
         }
 
-        let _ = attempt;
+        if attempt == 1 || attempt % 5 == 0 {
+            ui_log_devnet_wait_tick(attempt, &pending);
+        }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 
-    let nonce = fetch_local_core_nonce(deployer).await.unwrap_or_default();
+    let nonce = fetch_core_nonce("http://localhost:20443", deployer)
+        .await
+        .unwrap_or_default();
     let stacks_api_healthy = probe_stacks_api_health().await.unwrap_or(false);
     let final_info = fetch_local_core_info().await.ok();
     let stall_hint = match (initial_info, final_info) {
@@ -2067,9 +2441,11 @@ async fn wait_for_devnet_contracts(deployer: &str, contract_names: &[String]) ->
                 end.burn_block_height, end.stacks_tip_height
             )
         }
-        _ => "Local devnet tip did move during the wait, so the publish appears to be stuck independently of tip progression.\n\
-              Common cause: Clarity 5 contracts were broadcast before burn height 150 (epoch 3.4) — they sit unmined. Re-run deploy after the latest stacksdapp fix (it waits for that epoch)."
-            .to_string(),
+        _ => format!(
+            "Local devnet tip did move during the wait, so the publish appears to be stuck independently of tip progression.\n\
+              Common cause: Clarity 5/6 contracts were broadcast before their epoch burn height (150 for C5, {} for C6) — they sit unmined. Re-run deploy after stacksdapp waits for the required epoch.",
+            epoch_40_burn_height()
+        ),
     };
 
     Err(anyhow!(
@@ -2121,12 +2497,9 @@ async fn wait_for_remote_contracts(
         }
 
         if pending.is_empty() {
-            let mut tip = None;
-            if let Ok(response) = client.get(format!("{node}/v2/info")).send().await {
-                if let Ok(info) = response.json::<CoreInfoResponse>().await {
-                    tip = Some(info.stacks_tip_height);
-                }
-            }
+            let tip = fetch_local_core_info_optional()
+                .await
+                .map(|info| info.stacks_tip_height);
             return Ok(tip);
         }
 
@@ -2152,6 +2525,21 @@ fn ui_log_wait_start() {
     }
 }
 
+fn ui_log_devnet_wait_start() {
+    if !stacksdapp_shell::is_quiet() {
+        println!("Broadcast complete — waiting for local devnet confirmation (typically 15–90s)...");
+    }
+}
+
+fn ui_log_devnet_wait_tick(attempt: u32, pending: &[String]) {
+    if !stacksdapp_shell::is_quiet() {
+        eprintln!(
+            "  confirming on local core ({attempt}s) — waiting for: {}",
+            pending.join(", ")
+        );
+    }
+}
+
 fn ui_log_wait_tick(attempt: u32, pending: &[String]) {
     if !stacksdapp_shell::is_quiet() {
         let secs = attempt as u64 * 2;
@@ -2174,13 +2562,10 @@ async fn probe_stacks_api_health() -> Result<bool> {
         .unwrap_or(false))
 }
 
-async fn fetch_local_core_info() -> Result<CoreInfoResponse> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
-        .build()?;
-    let response = client.get("http://localhost:20443/v2/info").send().await?;
-    let response = response.error_for_status()?;
-    Ok(response.json().await?)
+async fn fetch_local_core_info() -> Result<LocalCoreInfo> {
+    fetch_local_core_info_optional().await.ok_or_else(|| {
+        anyhow!("Local stacks-node at http://localhost:20443 is not responding.")
+    })
 }
 
 fn parse_deployer_address_from_settings(toml_raw: &str) -> Option<String> {
@@ -2362,19 +2747,19 @@ mod tests {
     #[test]
     fn devnet_broadcast_script_reads_payload_from_stdin_not_argv() {
         assert!(
-            !super::DEVNET_BROADCAST_SCRIPT.contains("process.argv"),
+            !super::BROADCAST_SCRIPT.contains("process.argv"),
             "sender key must not be passed via argv"
         );
         assert!(
-            super::DEVNET_BROADCAST_SCRIPT.contains("process.stdin"),
+            super::BROADCAST_SCRIPT.contains("process.stdin"),
             "deploy payload must be read from stdin"
         );
         assert!(
-            super::DEVNET_BROADCAST_SCRIPT.contains("broadcastTransaction"),
+            super::BROADCAST_SCRIPT.contains("broadcastTransaction"),
             "must use @stacks/transactions broadcastTransaction (v7+)"
         );
         assert!(
-            !super::DEVNET_BROADCAST_SCRIPT.contains("broadcastRawTransaction"),
+            !super::BROADCAST_SCRIPT.contains("broadcastRawTransaction"),
             "broadcastRawTransaction was removed from @stacks/transactions v7"
         );
     }
@@ -2391,6 +2776,27 @@ mod tests {
             142
         );
         assert_eq!(super::min_burn_height_for_publish(None, Some(2)), 0);
+    }
+
+    #[test]
+    fn min_burn_height_gates_clarity6_and_epoch_40() {
+        let c6_height = super::epoch_40_burn_height();
+        assert_eq!(
+            super::min_burn_height_for_publish(Some("4.0"), Some(6)),
+            c6_height
+        );
+        assert_eq!(super::min_burn_height_for_publish(None, Some(6)), c6_height);
+        // C5 must not inherit C6's burn height when epoch is unspecified.
+        assert_eq!(super::min_burn_height_for_publish(None, Some(5)), 150);
+    }
+
+    #[test]
+    fn collect_txids_from_clarinet_output_finds_broadcast_lines() {
+        let output = r#"Publish ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.counter
+Broadcasted ContractPublish(StandardPrincipalData(ST1PQ), ContractName("counter"), "abc123def4567890abc123def4567890abc123def4567890abc123def4567890")
+"#;
+        let map = super::collect_txids_from_clarinet_output(output);
+        assert_eq!(map.get("counter").map(String::as_str), Some("abc123def4567890abc123def4567890abc123def4567890abc123def4567890"));
     }
 
     #[test]

--- a/crates/deployer/src/ui.rs
+++ b/crates/deployer/src/ui.rs
@@ -296,6 +296,7 @@ impl DeployUi {
     pub fn success(
         &self,
         entries: &[(String, String, String)], // name, full_contract_id, full_txid
+        deploy_status: &str,
     ) {
         if !human_output_enabled() {
             return;
@@ -393,11 +394,24 @@ impl DeployUi {
                     println!("{}", url.truecolor(167, 139, 250));
                 }
                 println!();
-                println!(
-                    "{}",
-                    "Note: the explorer link may take 10–15 seconds to show the transaction while it indexes."
-                        .truecolor(156, 163, 175)
-                );
+                if deploy_status == "broadcast" {
+                    println!(
+                        "{}",
+                        "Note: transactions were broadcast to the mempool. Verify txids on the explorer."
+                            .truecolor(156, 163, 175)
+                    );
+                    println!(
+                        "{}",
+                        "Use --wait-confirm to block until contracts appear on chain."
+                            .truecolor(156, 163, 175)
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        "Note: the explorer link may take 10–15 seconds to show the transaction while it indexes."
+                            .truecolor(156, 163, 175)
+                    );
+                }
                 println!();
             }
         }
@@ -483,7 +497,10 @@ mod tests {
         ui.step_detail("hidden");
         ui.print_summary("ST1PQ", &["counter".into()], 1000);
         ui.dry_run_done(&["counter".into()], 1000);
-        ui.success(&[("counter".into(), "ST1PQ.counter".into(), "0xabc".into())]);
+        ui.success(
+            &[("counter".into(), "ST1PQ.counter".into(), "0xabc".into())],
+            "confirmed",
+        );
         ui.begin_step("quiet step").finish();
     }
 }

--- a/crates/deployer/src/ui.rs
+++ b/crates/deployer/src/ui.rs
@@ -324,12 +324,50 @@ impl DeployUi {
         println!();
         for (_, _, txid) in entries {
             if txid.is_empty() {
-                println!("{}", "(pending)".truecolor(156, 163, 175));
+                if deploy_status == "broadcast" {
+                    println!(
+                        "{}",
+                        "(submitted to mempool — txid not captured; re-run with -vv or check explorer)"
+                            .truecolor(156, 163, 175)
+                    );
+                } else {
+                    println!("{}", "(pending)".truecolor(156, 163, 175));
+                }
             } else {
                 println!("{}", txid.white());
             }
         }
         println!();
+
+        if deploy_status == "broadcast" && self.network != "devnet" {
+            println!("{}", "Status".bold().white());
+            println!();
+            let timing = if self.network == "mainnet" {
+                "Mainnet blocks typically confirm within 10–30 minutes."
+            } else {
+                "Testnet blocks typically confirm within 1–10 minutes."
+            };
+            println!(
+                "{}",
+                format!("Broadcast to mempool — {timing}")
+                    .truecolor(156, 163, 175)
+            );
+            println!(
+                "{}",
+                "Use --wait-confirm to block until contracts appear on chain."
+                    .truecolor(156, 163, 175)
+            );
+            println!();
+        } else if deploy_status == "confirmed" && self.network == "devnet" {
+            println!("{}", "Status".bold().white());
+            println!();
+            println!(
+                "{}",
+                "Confirmed on local devnet — contract source is live on stacks-core."
+                    .truecolor(156, 163, 175)
+            );
+            println!();
+        }
 
         println!("{}", "Generated".bold().white());
         println!();
@@ -397,12 +435,7 @@ impl DeployUi {
                 if deploy_status == "broadcast" {
                     println!(
                         "{}",
-                        "Note: transactions were broadcast to the mempool. Verify txids on the explorer."
-                            .truecolor(156, 163, 175)
-                    );
-                    println!(
-                        "{}",
-                        "Use --wait-confirm to block until contracts appear on chain."
+                        "Explorer pages may take 10–30 seconds to appear after broadcast."
                             .truecolor(156, 163, 175)
                     );
                 } else {

--- a/crates/deployer/src/ui.rs
+++ b/crates/deployer/src/ui.rs
@@ -349,8 +349,7 @@ impl DeployUi {
             };
             println!(
                 "{}",
-                format!("Broadcast to mempool — {timing}")
-                    .truecolor(156, 163, 175)
+                format!("Broadcast to mempool — {timing}").truecolor(156, 163, 175)
             );
             println!(
                 "{}",

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -133,6 +133,46 @@ fn print_ready_panel(network: &str, local_url: &str, tip_height: Option<u64>) {
     stacksdapp_shell::rule();
 }
 
+/// JSON payload emitted once when `stacksdapp dev --json` reaches a ready frontend (not at start).
+pub fn dev_ready_json_payload(
+    network: &str,
+    local_url: &str,
+    tip_height: Option<u64>,
+    auto_deploy: bool,
+    keep_state: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "ok": true,
+        "command": "dev",
+        "status": "ready",
+        "network": network,
+        "url": local_url,
+        "tip_height": tip_height,
+        "auto_deploy": auto_deploy,
+        "keep_state": keep_state,
+    })
+}
+
+fn notify_dev_ready(
+    network: &str,
+    local_url: &str,
+    tip_height: Option<u64>,
+    auto_deploy: bool,
+    keep_state: bool,
+) {
+    if stacksdapp_shell::is_json() {
+        stacksdapp_shell::emit_json(&dev_ready_json_payload(
+            network,
+            local_url,
+            tip_height,
+            auto_deploy,
+            keep_state,
+        ));
+        return;
+    }
+    print_ready_panel(network, local_url, tip_height);
+}
+
 async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
     stacksdapp_shell::print_banner("Development Mode 🌱");
 
@@ -235,7 +275,7 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
     match tokio::time::timeout(Duration::from_secs(120), ready_rx).await {
         Ok(Ok(url)) => {
             step.finish();
-            print_ready_panel("devnet", &url, tip_height);
+            notify_dev_ready("devnet", &url, tip_height, auto_deploy, keep_state);
         }
         Ok(Err(_)) => {
             step.fail();
@@ -337,7 +377,7 @@ async fn dev_remote(network: &str) -> Result<()> {
     match tokio::time::timeout(Duration::from_secs(120), ready_rx).await {
         Ok(Ok(url)) => {
             step.finish();
-            print_ready_panel(network, &url, None);
+            notify_dev_ready(network, &url, None, false, false);
         }
         Ok(Err(_)) => {
             step.fail();
@@ -389,7 +429,7 @@ async fn dev_remote(network: &str) -> Result<()> {
 async fn run_auto_deploy() {
     match stacksdapp_deployer::wait_for_devnet_node().await {
         Ok(()) => {
-            if let Err(e) = stacksdapp_deployer::deploy("devnet", None, false, false).await {
+            if let Err(e) = stacksdapp_deployer::deploy("devnet", None, false, false, false, false).await {
                 stacksdapp_shell::println_human_safe(format!("[dev] Auto-deploy failed: {e:#}"));
                 stacksdapp_shell::println_human_safe(
                     "[dev] You can deploy manually in another terminal: stacksdapp deploy --network devnet",
@@ -1561,5 +1601,25 @@ bitcoin_controller_block_time = 1_000
         assert!(changed);
         assert!(updated.contains("bitcoin_controller_block_time = 15_000"));
         assert!(!updated.contains("bitcoin_controller_block_time = 1_000"));
+    }
+
+    #[test]
+    fn dev_ready_json_payload_uses_ready_status_not_starting() {
+        let payload = super::dev_ready_json_payload(
+            "devnet",
+            "http://localhost:3000",
+            Some(42),
+            true,
+            false,
+        );
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["command"], "dev");
+        assert_eq!(payload["status"], "ready");
+        assert_ne!(payload["status"], "starting");
+        assert_eq!(payload["network"], "devnet");
+        assert_eq!(payload["url"], "http://localhost:3000");
+        assert_eq!(payload["tip_height"], 42);
+        assert_eq!(payload["auto_deploy"], true);
+        assert_eq!(payload["keep_state"], false);
     }
 }

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -1,3 +1,8 @@
+use stacksdapp_deployer::devnet_recovery::{
+    devnet_project_name, fetch_local_core_info_optional, is_devnet_chain_stalled,
+    stop_devnet_containers, try_recover_devnet_chain, RecoveryLevel,
+};
+
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use std::path::Path;
@@ -113,10 +118,10 @@ fn print_ready_panel(network: &str, local_url: &str, tip_height: Option<u64>) {
     }
     println!();
     if network == "devnet" {
-        stacksdapp_shell::kv("Deploy", "stacksdapp deploy --network devnet");
+        stacksdapp_shell::kv("Deploy", "stacksdapp deploy --network devnet  (or stacksdapp dev --auto-deploy)");
         println!(
             "{}",
-            "  Tip must keep advancing before deploy; stalled tips need: stacksdapp clean && stacksdapp dev"
+            "  Deploy within ~2 min of ready, or use --auto-deploy — tip stalls ~#71 after PoX cycle 4."
                 .truecolor(156, 163, 175)
         );
     } else {
@@ -254,7 +259,12 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
         }
     };
 
-    let health_monitor = tokio::spawn(monitor_devnet_chain_health());
+    let health_monitor = {
+        let (respawn_tx, respawn_rx) = tokio::sync::mpsc::channel(1);
+        let monitor = tokio::spawn(monitor_devnet_chain_health(respawn_tx));
+        (monitor, respawn_rx)
+    };
+    let (health_monitor, mut devnet_respawn_rx) = health_monitor;
 
     let deploy_task = if auto_deploy {
         Some(tokio::spawn(run_auto_deploy()))
@@ -293,13 +303,25 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
         "contracts/contracts",
     )));
 
-    let result = tokio::select! {
+    let result = loop {
+        break tokio::select! {
         _ = tokio::signal::ctrl_c() => {
             if !stacksdapp_shell::is_quiet() {
                 println!();
                 println!("{}", "Shutting down...".truecolor(156, 163, 175));
             }
             Ok(())
+        }
+        _ = devnet_respawn_rx.recv() => {
+            if let Err(e) = restart_clarinet_devnet(
+                &mut clarinet,
+                std::sync::Arc::clone(&fatal),
+            ).await {
+                stacksdapp_shell::println_human_safe(format!(
+                    "[devnet] Clarinet restart after stall failed: {e:#}"
+                ));
+            }
+            continue;
         }
         status = clarinet.wait() => {
             match status {
@@ -322,6 +344,7 @@ async fn dev_devnet(auto_deploy: bool, keep_state: bool) -> Result<()> {
                 Err(e) => Err(anyhow!("Contract watcher task join failed: {e}")),
             }
         }
+        };
     };
 
     health_monitor.abort();
@@ -451,9 +474,6 @@ async fn wait_for_devnet_chain_ready(
     clarinet: &mut Child,
     fatal: std::sync::Arc<std::sync::Mutex<Option<String>>>,
 ) -> Result<u64> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(3))
-        .build()?;
     let started = Instant::now();
     let mut first_tip: Option<u64> = None;
     let mut second_tip: Option<u64> = None;
@@ -520,7 +540,7 @@ async fn wait_for_devnet_chain_ready(
             ));
         }
 
-        match fetch_local_stacks_tip(&client).await {
+        match fetch_local_stacks_tip().await {
             Some(height) => match (first_tip, second_tip) {
                 (None, _) => {
                     first_tip = Some(height);
@@ -770,62 +790,125 @@ async fn detect_stacks_node_crash() -> Option<String> {
     )
 }
 
-/// Poll local devnet tip height and warn if the chain appears stalled.
-async fn monitor_devnet_chain_health() {
+/// Poll local devnet and attempt recovery when Bitcoin burn advances but Stacks tip stalls
+/// (common at PoX reward-cycle boundaries on Clarinet 3.23+ Nakamoto devnet).
+async fn monitor_devnet_chain_health(respawn_tx: tokio::sync::mpsc::Sender<()>) {
     tokio::time::sleep(Duration::from_secs(20)).await;
 
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(3))
-        .build()
-    {
-        Ok(c) => c,
-        Err(_) => return,
-    };
-
-    let mut last_height: Option<u64> = None;
+    let project = devnet_project_name();
+    let mut last_core: Option<stacksdapp_deployer::devnet_recovery::LocalCoreInfo> = None;
     let mut unchanged_since = Instant::now();
     let mut last_warning = Instant::now() - Duration::from_secs(120);
+    let mut last_recovery = Instant::now() - Duration::from_secs(300);
+    let mut recovery_attempts = 0u32;
+    let mut last_respawn = Instant::now() - Duration::from_secs(600);
+
+    let recovery_levels = [
+        RecoveryLevel::StacksOnly,
+        RecoveryLevel::WithBitcoin,
+        RecoveryLevel::Full,
+    ];
 
     loop {
-        let current = fetch_local_stacks_tip(&client).await;
+        if let Some(info) = fetch_local_core_info_optional().await {
+            let stacks_stuck = last_core
+                .as_ref()
+                .map(|prev| prev.stacks_tip_height == info.stacks_tip_height)
+                .unwrap_or(false);
+            let burn_advanced = last_core
+                .as_ref()
+                .map(|prev| is_devnet_chain_stalled(prev, &info))
+                .unwrap_or(false);
 
-        if let Some(height) = current {
-            if Some(height) == last_height {
+            if stacks_stuck {
                 if unchanged_since.elapsed() >= Duration::from_secs(45)
                     && last_warning.elapsed() >= Duration::from_secs(60)
                 {
                     stacksdapp_shell::println_human_safe(format!(
-                        "[devnet] Warning: local chain tip stalled at height {height} for 45s+."
+                        "[devnet] Warning: Stacks tip stalled at #{}, burn at {}.",
+                        info.stacks_tip_height, info.burn_block_height
                     ));
+                    if burn_advanced {
+                        stacksdapp_shell::println_human_safe(
+                            "  Bitcoin is still mining — PoX/Nakamoto tenure desync (Missing canonical anchor block).",
+                        );
+                    }
                     stacksdapp_shell::println_human_safe(
-                        "  Deployments may hang until blocks advance. This is often a Clarinet/Docker issue.",
-                    );
-                    stacksdapp_shell::println_human_safe(
-                        "  Try: stacksdapp clean --force && stacksdapp dev",
+                        "  Deployments wait for blocks; the CLI will try restarting devnet containers.",
                     );
                     last_warning = Instant::now();
                 }
+
+                if burn_advanced
+                    && unchanged_since.elapsed() >= Duration::from_secs(60)
+                    && last_recovery.elapsed() >= Duration::from_secs(90)
+                {
+                    if let Some(ref name) = project {
+                        if recovery_attempts < 3 {
+                            let level = recovery_levels[recovery_attempts as usize];
+                            recovery_attempts += 1;
+                            last_recovery = Instant::now();
+                            stacksdapp_shell::println_human_safe(format!(
+                                "[devnet] Recovering stalled chain (attempt {recovery_attempts}/3): {} for {name}...",
+                                level.label()
+                            ));
+                            if try_recover_devnet_chain(name, level) {
+                                unchanged_since = Instant::now();
+                                last_warning = Instant::now();
+                            }
+                        } else if last_respawn.elapsed() >= Duration::from_secs(300)
+                            && respawn_tx.try_send(()).is_ok()
+                        {
+                            last_respawn = Instant::now();
+                            last_recovery = Instant::now();
+                            recovery_attempts = 0;
+                            stacksdapp_shell::println_human_safe(
+                                "[devnet] Docker recovery insufficient — restarting Clarinet devnet process...",
+                            );
+                        }
+                    }
+                }
             } else {
-                last_height = Some(height);
+                recovery_attempts = 0;
                 unchanged_since = Instant::now();
             }
+
+            last_core = Some(info);
         }
 
         tokio::time::sleep(Duration::from_secs(10)).await;
     }
 }
 
-async fn fetch_local_stacks_tip(client: &reqwest::Client) -> Option<u64> {
-    let response = client
-        .get("http://localhost:20443/v2/info")
-        .send()
+async fn fetch_local_stacks_tip() -> Option<u64> {
+    fetch_local_core_info_optional()
         .await
-        .ok()?;
-    if !response.status().is_success() {
-        return None;
+        .map(|info| info.stacks_tip_height)
+}
+
+async fn restart_clarinet_devnet(
+    clarinet: &mut Child,
+    fatal: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+) -> Result<()> {
+    let project = devnet_project_name().ok_or_else(|| anyhow!("Missing Clarinet project name"))?;
+    shutdown_child("clarinet devnet", clarinet).await;
+    stop_devnet_containers(&project);
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    if let Ok(mut slot) = fatal.lock() {
+        *slot = None;
     }
-    let json: serde_json::Value = response.json().await.ok()?;
-    json.get("stacks_tip_height")?.as_u64()
+    *clarinet = spawn_clarinet_devnet()?;
+    attach_filtered_output(clarinet, OutputStyle::Clarinet, std::sync::Arc::clone(&fatal));
+    let _ = wait_for_devnet_chain_ready(
+        Duration::from_secs(300),
+        clarinet,
+        fatal,
+    )
+    .await?;
+    stacksdapp_shell::println_human_safe(
+        "[devnet] Clarinet devnet restarted — deploy now while the tip is advancing.",
+    );
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -1290,9 +1373,10 @@ pub fn stop_stale_devnet_docker() {
         .status();
 }
 
-/// Rewrite `contracts/settings/Devnet.toml` for Clarinet 3.2+ snapshot fast-boot.
-/// Preserves accounts and other custom keys; only strips PoX stacking orders and
-/// ensures explorers are off / API on / faster block time. Does not touch Testnet/Mainnet.
+/// Rewrite `contracts/settings/Devnet.toml` for Clarinet 3.23+ snapshot fast-boot.
+/// Preserves accounts and other custom keys; ensures default PoX stacking orders
+/// (required for the epoch-4.0 snapshot), explorers off, and faster block time.
+/// Does not touch Testnet/Mainnet.
 async fn ensure_devnet_fast_boot_settings() -> Result<()> {
     let path = Path::new("contracts/settings/Devnet.toml");
     if !path.is_file() {
@@ -1303,43 +1387,77 @@ async fn ensure_devnet_fast_boot_settings() -> Result<()> {
     if changed {
         fs::write(path, updated).await?;
         stacksdapp_shell::println_human_safe(
-            "[devnet] Applied fast-boot settings (snapshot-friendly; explorers off).",
+            "[devnet] Applied fast-boot settings (snapshot-compatible PoX stacking; explorers off).",
         );
     }
     Ok(())
 }
 
+/// Snapshot-compatible PoX stacking block (matches Clarinet 3.23 `DevnetConfig::default()`).
+const SNAPSHOT_POX_STACKING_ORDERS: &str = r#"
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_2"
+slots = 2
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_3"
+slots = 2
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
+"#;
+
+const SNAPSHOT_WALLET_ACCOUNTS: &str = r#"
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+"#;
+
 /// Pure rewrite helper (unit-tested). Returns `(new_contents, did_change)`.
 pub fn optimize_devnet_toml_for_fast_boot(raw: &str) -> (String, bool) {
     let mut out: Vec<String> = Vec::new();
-    let mut skipping_pox = false;
     let mut in_devnet = false;
     let mut saw_devnet = false;
     let mut has_btc_explorer = false;
     let mut has_stacks_explorer = false;
     let mut has_stacks_api = false;
     let mut has_block_time = false;
-    let mut removed_pox = false;
 
     for line in raw.lines() {
         let trimmed = line.trim();
 
         if trimmed.starts_with('[') {
-            skipping_pox = false;
             in_devnet = trimmed == "[devnet]";
             if in_devnet {
                 saw_devnet = true;
             }
-            if trimmed == "[[devnet.pox_stacking_orders]]" {
-                skipping_pox = true;
-                removed_pox = true;
-                continue;
-            }
-        }
-
-        if skipping_pox {
-            // Drop the whole array-of-tables block (keys until next [section]).
-            continue;
         }
 
         if in_devnet {
@@ -1355,15 +1473,13 @@ pub fn optimize_devnet_toml_for_fast_boot(raw: &str) -> (String, bool) {
             }
             if trimmed.starts_with("disable_stacks_api") {
                 has_stacks_api = true;
-                // Keep API enabled — frontend / deploy tooling may use :3999.
-                out.push("disable_stacks_api = false".to_string());
+                // Off by default: stacks-api + Clarinet snapshot often desync (blocks stall at ~38).
+                out.push("disable_stacks_api = true".to_string());
                 continue;
             }
             if trimmed.starts_with("bitcoin_controller_block_time") {
                 has_block_time = true;
-                // 15s: local UX stays usable; Nakamoto/signer can keep pace.
-                // 1s burns ahead of stacks-node and tips stall after the first tenure.
-                out.push("bitcoin_controller_block_time = 15_000".to_string());
+                out.push("bitcoin_controller_block_time = 45_000".to_string());
                 continue;
             }
         }
@@ -1387,11 +1503,11 @@ pub fn optimize_devnet_toml_for_fast_boot(raw: &str) -> (String, bool) {
                     injected = true;
                 }
                 if !has_stacks_api {
-                    final_out.push("disable_stacks_api = false".to_string());
+                    final_out.push("disable_stacks_api = true".to_string());
                     injected = true;
                 }
                 if !has_block_time {
-                    final_out.push("bitcoin_controller_block_time = 15_000".to_string());
+                    final_out.push("bitcoin_controller_block_time = 45_000".to_string());
                     injected = true;
                 }
             }
@@ -1402,8 +1518,8 @@ pub fn optimize_devnet_toml_for_fast_boot(raw: &str) -> (String, bool) {
         out.push("[devnet]".to_string());
         out.push("disable_bitcoin_explorer = true".to_string());
         out.push("disable_stacks_explorer = true".to_string());
-        out.push("disable_stacks_api = false".to_string());
-        out.push("bitcoin_controller_block_time = 15_000".to_string());
+        out.push("disable_stacks_api = true".to_string());
+        out.push("bitcoin_controller_block_time = 45_000".to_string());
         injected = true;
     }
 
@@ -1411,22 +1527,74 @@ pub fn optimize_devnet_toml_for_fast_boot(raw: &str) -> (String, bool) {
     if !updated.ends_with('\n') {
         updated.push('\n');
     }
+
+    let needs_wallets = !updated.contains("[accounts.wallet_1]");
+    if !snapshot_pox_orders_complete(&updated) {
+        updated = strip_pox_stacking_order_blocks(&updated);
+        updated.push_str(SNAPSHOT_POX_STACKING_ORDERS);
+        if !updated.ends_with('\n') {
+            updated.push('\n');
+        }
+        injected = true;
+    }
+    if needs_wallets {
+        if let Some(devnet_pos) = updated.find("\n[devnet]") {
+            updated.insert_str(devnet_pos, SNAPSHOT_WALLET_ACCOUNTS);
+        } else {
+            updated.push_str(SNAPSHOT_WALLET_ACCOUNTS);
+        }
+        injected = true;
+    }
+
     let normalized_raw = if raw.ends_with('\n') {
         raw.to_string()
     } else {
         format!("{raw}\n")
     };
-    let changed = removed_pox || injected || updated != normalized_raw;
+    let changed = injected || updated != normalized_raw;
     (updated, changed)
+}
+
+fn snapshot_pox_orders_complete(raw: &str) -> bool {
+    [
+        "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC",
+        "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG",
+        "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7",
+    ]
+    .iter()
+    .all(|addr| raw.contains(addr))
+}
+
+fn strip_pox_stacking_order_blocks(raw: &str) -> String {
+    let mut out: Vec<String> = Vec::new();
+    let mut skipping_pox = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            skipping_pox = trimmed == "[[devnet.pox_stacking_orders]]";
+        }
+        if skipping_pox {
+            continue;
+        }
+        out.push(line.to_string());
+    }
+    let mut updated = out.join("\n");
+    if !updated.is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated
 }
 
 fn spawn_clarinet_devnet() -> Result<Child> {
     // --no-dashboard is required: Clarinet's TUI corrupts our spinner/ready panel.
-    // --from-genesis avoids Clarinet's default snapshot path, which with Clarinet 3.21
-    // often boots a hybrid bitcoin/stacks snapshot that mines one Nakamoto tenure then stalls.
-    // stdin must be piped so we can answer the snapshot "continue? (y/N)" prompt if it still appears.
+    // Clarinet 3.23+ ships an epoch 4.0 / Clarity 6 snapshot (burn ≥ 163) — use it.
+    // Older Clarinet: --from-genesis avoids a hybrid snapshot that stalls after one tenure.
+    let mut args = vec!["devnet", "start", "--no-dashboard"];
+    if !stacksdapp_deployer::clarinet_version_at_least(3, 23, 0) {
+        args.push("--from-genesis");
+    }
     let child = Command::new("clarinet")
-        .args(["devnet", "start", "--no-dashboard", "--from-genesis"])
+        .args(&args)
         .current_dir("contracts")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -1538,7 +1706,7 @@ auth_token = "12345"
     }
 
     #[test]
-    fn optimize_devnet_toml_strips_pox_and_disables_explorers() {
+    fn optimize_devnet_toml_injects_snapshot_pox_and_disables_explorers() {
         let raw = r#"# WARNING: public mnemonics
 
 [network]
@@ -1554,35 +1722,99 @@ disable_stacks_api = false
 [[devnet.pox_stacking_orders]]
 start_at_cycle = 1
 wallet = "wallet_1"
-
-[[devnet.pox_stacking_orders]]
-start_at_cycle = 1
-wallet = "wallet_2"
 "#;
         let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
         assert!(changed);
-        assert!(!updated.contains("pox_stacking_orders"));
+        assert!(updated.contains("[[devnet.pox_stacking_orders]]"));
+        assert!(updated.contains("wallet = \"wallet_3\""));
+        assert!(updated.contains("[accounts.wallet_1]"));
         assert!(updated.contains("disable_bitcoin_explorer = true"));
         assert!(updated.contains("disable_stacks_explorer = true"));
-        assert!(updated.contains("disable_stacks_api = false"));
-        assert!(updated.contains("bitcoin_controller_block_time = 15_000"));
+        assert!(updated.contains("disable_stacks_api = true"));
+        assert!(updated.contains("bitcoin_controller_block_time = 45_000"));
         assert!(updated.contains("[accounts.deployer]"));
         assert!(updated.contains("mnemonic = \"twice kind fence tip\""));
     }
 
     #[test]
-    fn optimize_devnet_toml_is_idempotent_when_already_fast() {
+    fn optimize_devnet_toml_injects_missing_snapshot_block_for_minimal_devnet() {
         let raw = r#"[network]
 name = "devnet"
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip"
 
 [devnet]
 disable_bitcoin_explorer = true
 disable_stacks_explorer = true
-disable_stacks_api = false
-bitcoin_controller_block_time = 15_000
+disable_stacks_api = true
+bitcoin_controller_block_time = 45_000
 "#;
         let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
-        assert!(!changed, "already optimized file should not rewrite");
+        assert!(changed);
+        assert!(updated.contains("[accounts.wallet_1]"));
+        assert!(updated.contains("[[devnet.pox_stacking_orders]]"));
+        assert!(updated.contains("btc_address = \"mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7\""));
+    }
+
+    #[test]
+    fn optimize_devnet_toml_is_idempotent_when_snapshot_compatible() {
+        let raw = r#"[network]
+name = "devnet"
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip"
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+derivation = "m/44'/5757'/0'/0/0"
+
+[devnet]
+disable_bitcoin_explorer = true
+disable_stacks_explorer = true
+disable_stacks_api = true
+bitcoin_controller_block_time = 45_000
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_2"
+slots = 2
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_3"
+slots = 2
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
+"#;
+        let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
+        assert!(!changed, "already snapshot-compatible file should not rewrite");
         assert_eq!(updated, raw);
     }
 
@@ -1594,12 +1826,12 @@ name = "devnet"
 [devnet]
 disable_bitcoin_explorer = true
 disable_stacks_explorer = true
-disable_stacks_api = false
+disable_stacks_api = true
 bitcoin_controller_block_time = 1_000
 "#;
         let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
         assert!(changed);
-        assert!(updated.contains("bitcoin_controller_block_time = 15_000"));
+        assert!(updated.contains("bitcoin_controller_block_time = 45_000"));
         assert!(!updated.contains("bitcoin_controller_block_time = 1_000"));
     }
 

--- a/crates/process_supervisor/src/lib.rs
+++ b/crates/process_supervisor/src/lib.rs
@@ -118,7 +118,10 @@ fn print_ready_panel(network: &str, local_url: &str, tip_height: Option<u64>) {
     }
     println!();
     if network == "devnet" {
-        stacksdapp_shell::kv("Deploy", "stacksdapp deploy --network devnet  (or stacksdapp dev --auto-deploy)");
+        stacksdapp_shell::kv(
+            "Deploy",
+            "stacksdapp deploy --network devnet  (or stacksdapp dev --auto-deploy)",
+        );
         println!(
             "{}",
             "  Deploy within ~2 min of ready, or use --auto-deploy — tip stalls ~#71 after PoX cycle 4."
@@ -452,7 +455,9 @@ async fn dev_remote(network: &str) -> Result<()> {
 async fn run_auto_deploy() {
     match stacksdapp_deployer::wait_for_devnet_node().await {
         Ok(()) => {
-            if let Err(e) = stacksdapp_deployer::deploy("devnet", None, false, false, false, false).await {
+            if let Err(e) =
+                stacksdapp_deployer::deploy("devnet", None, false, false, false, false).await
+            {
                 stacksdapp_shell::println_human_safe(format!("[dev] Auto-deploy failed: {e:#}"));
                 stacksdapp_shell::println_human_safe(
                     "[dev] You can deploy manually in another terminal: stacksdapp deploy --network devnet",
@@ -898,13 +903,12 @@ async fn restart_clarinet_devnet(
         *slot = None;
     }
     *clarinet = spawn_clarinet_devnet()?;
-    attach_filtered_output(clarinet, OutputStyle::Clarinet, std::sync::Arc::clone(&fatal));
-    let _ = wait_for_devnet_chain_ready(
-        Duration::from_secs(300),
+    attach_filtered_output(
         clarinet,
-        fatal,
-    )
-    .await?;
+        OutputStyle::Clarinet,
+        std::sync::Arc::clone(&fatal),
+    );
+    let _ = wait_for_devnet_chain_ready(Duration::from_secs(300), clarinet, fatal).await?;
     stacksdapp_shell::println_human_safe(
         "[devnet] Clarinet devnet restarted — deploy now while the tip is advancing.",
     );
@@ -1814,7 +1818,10 @@ slots = 2
 btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
 "#;
         let (updated, changed) = optimize_devnet_toml_for_fast_boot(raw);
-        assert!(!changed, "already snapshot-compatible file should not rewrite");
+        assert!(
+            !changed,
+            "already snapshot-compatible file should not rewrite"
+        );
         assert_eq!(updated, raw);
     }
 
@@ -1837,13 +1844,8 @@ bitcoin_controller_block_time = 1_000
 
     #[test]
     fn dev_ready_json_payload_uses_ready_status_not_starting() {
-        let payload = super::dev_ready_json_payload(
-            "devnet",
-            "http://localhost:3000",
-            Some(42),
-            true,
-            false,
-        );
+        let payload =
+            super::dev_ready_json_payload("devnet", "http://localhost:3000", Some(42), true, false);
         assert_eq!(payload["ok"], true);
         assert_eq!(payload["command"], "dev");
         assert_eq!(payload["status"], "ready");

--- a/crates/scaffold/Cargo.toml
+++ b/crates/scaffold/Cargo.toml
@@ -24,6 +24,8 @@ include = [
     "frontend-template/public/**/*",
     "frontend-template/scripts/**/*",
     "frontend-template/src/**/*",
+    "agent-skill-template/AGENTS.md",
+    "agent-skill-template/.cursor/**/*",
 ]
 
 [dependencies]

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/SKILL.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: scaffold-stacks
+description: >-
+  Build, test, deploy, and debug full-stack Stacks (Bitcoin L2) dApps with the
+  stacksdapp CLI — Clarity contracts, auto-generated React hooks, TypeScript
+  bindings, Next.js custom frontend, testnet/mainnet/devnet deployment. Use when
+  the user mentions stacksdapp, Scaffold Stacks, Clarity, Stacks dApp, Clarinet,
+  generated hooks, custom frontend, SIP-010, SIP-009, devnet, testnet deploy, or
+  works in a project with stacksdapp.toml or contracts/Clarinet.toml.
+---
+
+# Scaffold Stacks
+
+Scaffold Stacks = **Rust CLI** (`stacksdapp`) + **monorepo** (Clarity + Next.js). Auto-generates TypeScript from contract ABIs, ships a debug UI, deploys to testnet/mainnet/devnet.
+
+**Docs:** https://scaffoldstacks.mintlify.app/ · **Index:** https://scaffoldstacks.mintlify.app/llms.txt
+
+## When to use this skill
+
+- User is in a `stacksdapp new` or `stacksdapp init` project
+- Tasks involve contracts, deploy, devnet, bindings, React hooks, or custom frontend UI
+- User asks about Clarity + frontend integration on Stacks
+- User asks about SIP-010, SIP-009, or Clarity language syntax
+
+**Deep language / spec detail:** [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md) · [Stacks docs](https://docs.stacks.co/llms.txt)
+
+## Project root
+
+Commands resolve the root by walking up for `stacksdapp.toml` or `contracts/Clarinet.toml`. From subdirs use `--root PATH` or `STACKSDAPP_ROOT`.
+
+```
+my-app/
+├── stacksdapp.toml              # project marker + defaults.network
+├── AGENTS.md                    # this project's agent pointer
+├── contracts/
+│   ├── Clarinet.toml            # registry, clarity_version, epoch per contract
+│   ├── contracts/*.clar         # EDIT HERE
+│   ├── settings/*.toml          # deployer mnemonics — never commit real seeds
+│   ├── tests/*.test.ts          # Vitest + initSimnet
+│   └── .cache/                  # ABI cache (gitignored)
+└── frontend/
+    ├── src/generated/           # AUTO-GENERATED — never hand-edit
+    └── .env.local               # NEXT_PUBLIC_NETWORK
+```
+
+Details: [project-layout.md](project-layout.md)
+
+## Command decision tree
+
+| User goal | Command |
+|-----------|---------|
+| New project | `stacksdapp new NAME` |
+| Adopt Clarinet repo | `stacksdapp init` |
+| Add contract | `stacksdapp add NAME [--template blank\|sip010\|sip009] [--clarity-version 4\|5\|6]` |
+| Type-check | `stacksdapp check` |
+| Regenerate TS | `stacksdapp generate [--watch]` |
+| Test | `stacksdapp test` |
+| Local full stack | `stacksdapp dev [--auto-deploy]` (Docker) |
+| Frontend only | `stacksdapp dev --network testnet\|mainnet` |
+| Deploy | `stacksdapp deploy --network devnet\|testnet\|mainnet [--contract X] [--yes] [--dry-run]` |
+| Reset generated/devnet | `stacksdapp clean [--force]` |
+| Health check | `stacksdapp doctor [--strict]` |
+| Refresh deps + skill | `stacksdapp upgrade` |
+
+Full flags and exit codes: [cli-reference.md](cli-reference.md)
+
+## Default workflow — testnet first
+
+Recommend testnet for deploy verification (no Docker, reliable):
+
+```bash
+stacksdapp doctor
+# Set mnemonic in contracts/settings/Testnet.toml (placeholder uses <YOUR...>)
+stacksdapp check && stacksdapp generate && stacksdapp test
+stacksdapp deploy --network testnet --yes
+stacksdapp dev --network testnet
+```
+
+For CI/automation always pass `--yes` on deploy. Use `--dry-run` to preview fees.
+
+After **any** `.clar` or `Clarinet.toml` change: `check` → `generate` → `test` → `deploy`.
+
+## Clarity versions
+
+| Version | Epoch | Notes |
+|---------|-------|-------|
+| **6** (default) | `4.0` | New projects; Clarinet **3.23+** for devnet |
+| **5** | `3.4` | Legacy; set **both** version and epoch |
+| **4** | `3.0` | Older contracts |
+
+`stacksdapp add --clarity-version 5` sets epoch automatically. Manual downgrades must update both fields in `Clarinet.toml`.
+
+Details: [clarity-versions.md](clarity-versions.md)
+
+## Agent rules
+
+### Do
+
+- Run from project root (or rely on walk-up / `--root`)
+- Run `stacksdapp doctor` when prerequisites are unclear
+- Edit only `contracts/contracts/*.clar` and app components under `frontend/src/`
+- Regenerate after contract changes: `stacksdapp generate`
+- Use `--yes` for non-interactive deploys
+- Prefer **testnet** for deploy CI and first-time verification
+- Warn before committing mnemonics; devnet seeds in template are **public burners**
+
+### Do not
+
+- Hand-edit `frontend/src/generated/*`
+- Commit real testnet/mainnet mnemonics
+- Run `clarinet devnet start` alongside `stacksdapp dev` (port conflicts)
+- Reuse devnet template mnemonics on testnet/mainnet
+- Assume devnet is production-like for long-running deploy tests
+- Hand-write SIP tokens with `(impl-trait 'sip-010-trait)` — use `stacksdapp add --template sip010|sip009` (full trait path required; see [sip-standards.md](sip-standards.md))
+- Call `BigInt(hook.data)` on read-only uint results — unwrap cvToJSON shapes first ([frontend.md](frontend.md))
+- Fire read-only hooks (`get-balance`, etc.) without checking deploy + network + wallet address — causes `Failed to fetch` ([frontend.md](frontend.md))
+- Run `stacksdapp dev` (devnet) when contracts were deployed to testnet — set `NEXT_PUBLIC_NETWORK=testnet` instead
+
+## Devnet (local Docker)
+
+```bash
+stacksdapp dev                  # devnet + frontend + watcher
+stacksdapp dev --auto-deploy    # deploy once chain is ready (recommended)
+```
+
+**Caveats:** Docker required. Long idle devnet sessions can stall around Stacks block ~71 (PoX). Prefer `--auto-deploy` or deploy soon after boot. For reliable deploy verification use testnet.
+
+If stuck booting: `stacksdapp clean --force`, stop leftover devnet containers, retry.
+
+Details: [workflows.md](workflows.md) · [troubleshooting.md](troubleshooting.md)
+
+## Deploy behavior
+
+- **Testnet/mainnet:** Direct broadcast via `@stacks/transactions`; auto-versioning on redeploy (`counter` → `counter-v2`) unless `--no-auto-version`
+- **Devnet:** Epoch burn gating for C5/C6; waits for core node `:20443`
+- **`--dry-run`:** Plan + fee estimate only
+- **`--wait-confirm`:** Poll until on-chain (testnet/mainnet; slower)
+
+## Code generation
+
+`stacksdapp generate` writes:
+
+- `frontend/src/generated/contracts.ts` — async contract call functions
+- `frontend/src/generated/hooks.ts` — React hooks
+- `frontend/src/generated/DebugContracts.tsx` — debug UI forms
+- `frontend/src/generated/deployments.json` — addresses after deploy
+
+ABI cache in `contracts/.cache/` speeds repeat generates.
+
+## Frontend (hooks & wallet)
+
+Generated bindings → React hooks → your components:
+
+- **`contracts.ts`** — async call functions (wallet on testnet/mainnet, burners on devnet)
+- **`hooks.ts`** — `useCounter_Increment()` etc. with `{ call, data, loading, txid, txStatus, … }`
+- **`deployments.json`** — contract addresses (requires deploy first)
+
+Wallet (`WalletConnect` + Jotai) is for **testnet/mainnet**. Devnet writes use public burner keys — no wallet popup.
+
+Full guide: [frontend.md](frontend.md)
+
+## Global CLI flags
+
+```
+-v, --verbosity    More diagnostic output (repeatable)
+-q, --quiet        Suppress non-errors
+--json             Machine-readable output (implies quiet logs)
+--color auto|always|never
+--root PATH        Project root (env: STACKSDAPP_ROOT)
+```
+
+## Exit codes (for scripts)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Project not found |
+| 3 | Prerequisite / doctor failure |
+| 4 | User aborted |
+| 5 | Validation error |
+| 6 | Clarity check failed |
+| 7 | Tests failed |
+| 8 | Deploy failed |
+| 10 | Generate failed |
+
+## Examples
+
+**Add token and deploy to testnet:**
+
+```bash
+stacksdapp add my-token --template sip010
+# edit contracts/contracts/my-token.clar
+stacksdapp check && stacksdapp generate && stacksdapp test
+stacksdapp deploy --network testnet --yes
+```
+
+**Adopt existing Clarinet project:**
+
+```bash
+cd existing-clarinet-repo
+stacksdapp init
+stacksdapp deploy --network testnet --yes
+```
+
+**Frontend against mainnet (no local chain):**
+
+```bash
+stacksdapp dev --network mainnet
+```
+
+## Additional resources
+
+- [frontend.md](frontend.md) — hooks, wallet, devnet signing, custom UI
+- [clarity-language.md](clarity-language.md) — Clarity cheat sheet + Stacks learning links
+- [sip-standards.md](sip-standards.md) — SIP-010/009 specs + scaffold templates
+- [cli-reference.md](cli-reference.md) — all commands, flags, config files
+- [workflows.md](workflows.md) — new, adopt, upgrade, CI patterns
+- [clarity-versions.md](clarity-versions.md) — C4/C5/C6 migration
+- [troubleshooting.md](troubleshooting.md) — doctor, Docker, deploy errors
+- [project-layout.md](project-layout.md) — directories and env vars

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/clarity-language.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/clarity-language.md
@@ -1,0 +1,167 @@
+# Clarity language — learning path & scaffold cheat sheet
+
+Scaffold Stacks handles deploy, bindings, and frontend — **you still write Clarity** in `contracts/contracts/*.clar`. For language depth, use official docs; this file routes agents there and lists syntax you'll use daily in scaffold projects.
+
+## When to use which resource
+
+| Need | Resource |
+|------|----------|
+| First-time Clarity | [Clarity Crash Course](https://docs.stacks.co/get-started/clarity-crash-course.md) |
+| Structured book | [Clarity Book](https://book.clarity-lang.org/) |
+| Interactive course | [Clarity Universe](https://clarity-lang.org/universe) |
+| Browser REPL | [Clarity Playground](https://play.stackslabs.com/) |
+| Function/type reference | [Clarity Reference](https://docs.stacks.co/reference/clarity/functions.md) |
+| Full docs index | [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) |
+| Language spec (SIP-002) | [SIP-002 Smart Contract Language](https://github.com/stacksgov/sips/blob/main/sips/sip-002/sip-002-smart-contract-language.md) |
+| Ask docs a question | `GET https://docs.stacks.co/<page>.md?ask=<question>&goal=<goal>` |
+
+**Agent rule:** For Clarity language questions beyond this cheat sheet, fetch Stacks docs — do not invent syntax.
+
+## Scaffold project workflow (Clarity side)
+
+```bash
+# edit contracts/contracts/my-contract.clar
+stacksdapp check          # Clarinet type-check + check_checker
+stacksdapp test           # Vitest + initSimnet in contracts/tests/
+stacksdapp generate       # refresh frontend hooks
+stacksdapp deploy --network testnet --yes
+```
+
+Contract tests live in `contracts/tests/*.test.ts` — no Docker. See [Testing with Clarinet SDK](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md).
+
+## Syntax essentials (scaffold projects)
+
+Clarity is LISP-like: expressions in parentheses.
+
+### Data variables
+
+```clarity
+(define-data-var counter uint u0)
+(var-get counter)
+(var-set counter (+ (var-get counter) u1))
+```
+
+### Functions
+
+| Form | Who can call | Mutates state |
+|------|--------------|---------------|
+| `define-read-only` | Anyone | No |
+| `define-public` | Anyone | Yes (via ok path) |
+| `define-private` | Same contract only | Yes |
+
+```clarity
+(define-read-only (get-count)
+  (ok (var-get counter)))
+
+(define-public (increment)
+  (begin
+    (var-set counter (+ (var-get counter) u1))
+    (ok (var-get counter))))
+```
+
+### Responses (critical)
+
+Public functions return `(response T uint)` — success `(ok value)` or error `(err uint)`:
+
+```clarity
+(define-constant ERR_UNAUTHORIZED (err u401))
+
+(define-public (admin-only)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (ok true)))
+```
+
+- `asserts!` — aborts with err if condition false
+- `try!` — unwrap ok or propagate err
+
+### Built-in principals & context
+
+| Name | Meaning |
+|------|---------|
+| `tx-sender` | Principal that signed the transaction |
+| `contract-caller` | Immediate caller (another contract if applicable) |
+| `as-contract` | Run as current contract |
+
+### Fungible tokens (SIP-010 building blocks)
+
+```clarity
+(define-fungible-token my-token)
+(ft-mint? my-token amount recipient)
+(ft-transfer? my-token amount sender recipient)
+(ft-get-balance my-token who)
+(ft-get-supply my-token)
+```
+
+### Non-fungible tokens (SIP-009 building blocks)
+
+```clarity
+(define-non-fungible-token my-nft uint)
+(nft-mint? my-nft token-id recipient)
+(nft-transfer? my-nft token-id sender recipient)
+(nft-get-owner? my-nft token-id)
+```
+
+### Traits (standards)
+
+```clarity
+;; Always use the FULL deployed trait path on mainnet — see sip-standards.md
+;; WRONG: (impl-trait 'sip-010-trait)  → VM Error: use of undeclared trait
+;; Testnet: omit impl-trait (no standard trait deployed on testnet chain)
+;; Mainnet:
+(impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+(use-trait token-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+
+(define-public (call-token (token <token-trait>))
+  (contract-call? token transfer u100 tx-sender recipient none))
+```
+
+Scaffold SIP templates ship with correct `impl-trait` and `[[project.requirements]]` — prefer `stacksdapp add --template sip010|sip009` over hand-written tokens. See [sip-standards.md](sip-standards.md).
+
+### Maps, lists, optional
+
+```clarity
+(define-map balances principal uint)
+(map-set balances who amount)
+(map-get? balances who)
+
+(define-public (example (maybe-id (optional uint)))
+  (match maybe-id id (ok id) ERR_NONE))
+```
+
+## Testing in scaffold (TypeScript + simnet)
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const deployer = simnet.getAccounts().get("deployer")!;
+
+it("increments", () => {
+  const { result } = simnet.callPublicFn("counter", "increment", [], deployer);
+  expect(result).toBeOk(Cl.uint(1));
+});
+```
+
+- `simnet.callPublicFn(contract, fn, args, sender)`
+- `simnet.callReadOnlyFn(contract, fn, args, sender)`
+- Use `Cl.uint`, `Cl.standardPrincipal`, etc. for args
+
+More: [Clarinet testing guide](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) · [Rendezvous fuzz testing](https://docs.stacks.co/rendezvous/overview.md)
+
+## Security reminders
+
+- Contracts are **immutable** after deploy — test thoroughly first
+- Use `asserts!` / `try!` — never ignore error paths
+- Prefer explicit access control (`tx-sender`, `contract-owner`)
+- Run [check_checker](https://docs.stacks.co/clarinet/check-checker.md) — enabled in scaffold `Clarinet.toml` by default
+
+## Clarity versions in scaffold
+
+New projects default to **Clarity 6** (`epoch = "4.0"`). See [clarity-versions.md](clarity-versions.md) for C5/C4 downgrades.
+
+## Related skill files
+
+- Token standards (SIP-010 / SIP-009): [sip-standards.md](sip-standards.md)
+- Frontend hooks after deploy: [frontend.md](frontend.md)
+- CLI commands: [cli-reference.md](cli-reference.md)

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/clarity-versions.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/clarity-versions.md
@@ -1,0 +1,91 @@
+# Clarity versions and epochs
+
+Scaffold Stacks supports Clarity 4, 5, and 6. **New projects default to Clarity 6.**
+
+## Version ↔ epoch mapping
+
+| clarity_version | epoch | Stacks epoch | Use case |
+|-----------------|-------|--------------|----------|
+| 6 | `"4.0"` | 4.0 (burn 163+) | Default for new contracts |
+| 5 | `"3.4"` | 3.4 | Legacy contracts, backward compat |
+| 4 | `"3.0"` | 3.0 | Older contracts |
+
+**Critical:** `clarity_version` and `epoch` must match. Clarinet 3.23+ treats ambiguous configs as epoch 4.0 — a C5 contract with `epoch = "4.0"` will misbehave on devnet deploy.
+
+## Adding contracts
+
+```bash
+# Default C6 + epoch 4.0
+stacksdapp add my-contract
+
+# Legacy C5 + epoch 3.4 (automatic)
+stacksdapp add legacy --clarity-version 5
+
+# C4 + epoch 3.0
+stacksdapp add old --clarity-version 4
+```
+
+The `add` command writes the correct epoch into `Clarinet.toml` for the new contract entry.
+
+## Downgrading an existing project
+
+If changing C6 → C5 manually:
+
+1. Set `clarity_version = 5` **and** `epoch = "3.4"` on each affected `[contracts.*]` entry
+2. Regenerate deployment plans:
+   ```bash
+   cd contracts
+   clarinet deployments generate --devnet
+   clarinet deployments generate --testnet
+   ```
+3. `stacksdapp check && stacksdapp test`
+4. Redeploy
+
+Never leave `clarity_version = 5` with `epoch = "4.0"`.
+
+## Deploy implications
+
+### Testnet / mainnet
+
+- Direct broadcast via `@stacks/transactions`
+- Works for C4, C5, C6 when node supports the epoch
+- No Docker required
+
+### Devnet
+
+- **Clarity 6** requires **Clarinet 3.23+** and epoch 4.0 devnet snapshot
+- C5/C6 deploys wait for epoch burn height before broadcasting
+- Devnet `settings/Devnet.toml` includes PoX stacking orders required for epoch 4.0 snapshot — do not remove them
+
+Run `stacksdapp doctor` to verify Clarinet version.
+
+## Templates
+
+| Template | Standard | Notes |
+|----------|----------|-------|
+| `blank` | — | Empty public/read-only stubs |
+| `sip010` | SIP-010 | Fungible token — full guide: [sip-standards.md](sip-standards.md) |
+| `sip009` | SIP-009 | NFT — full guide: [sip-standards.md](sip-standards.md) |
+
+Templates inherit `--clarity-version` (default 6). Adds trait **requirements** to `Clarinet.toml` automatically.
+
+## Testing
+
+Contract tests use `initSimnet()` via Vitest — no Docker. Simnet uses Clarinet's in-memory chain; epoch behavior differs from devnet but type-checking and logic tests are reliable.
+
+```bash
+stacksdapp test    # runs contracts/tests/*.test.ts
+```
+
+## When to use which version
+
+| Scenario | Recommendation |
+|----------|----------------|
+| New dApp | C6 (default) |
+| Porting existing C5 contract | `--clarity-version 5` or manual 3.4 epoch |
+| Audited C5 codebase | Keep C5; do not upgrade epoch without audit |
+| Mainnet production | Match deployed epoch; test on testnet first |
+
+## Codegen
+
+`stacksdapp generate` reads ABIs regardless of Clarity version. After version changes, always regenerate bindings.

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/cli-reference.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/cli-reference.md
@@ -1,0 +1,150 @@
+# CLI reference — stacksdapp
+
+Syntax and flags for Scaffold Stacks 0.2.x. Walkthroughs: https://scaffoldstacks.mintlify.app/
+
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `-v`, `--verbosity` | Repeat for more debug (walk-up root, deploy steps) |
+| `-q`, `--quiet` | Suppress non-error output |
+| `--json` | JSON success/failure payloads; implies quiet human logs |
+| `--color auto\|always\|never` | Terminal colors (default `auto`) |
+| `--root PATH` | Project root; env `STACKSDAPP_ROOT` |
+
+## Exit codes
+
+| Code | `code` field (JSON) | When |
+|------|---------------------|------|
+| 0 | — | Success |
+| 1 | `error` | Generic / unexpected |
+| 2 | `project` | No project found, invalid `--root` |
+| 3 | `prerequisite` | `doctor` fail, missing clarinet/node/rust |
+| 4 | `aborted` | User declined confirmation |
+| 5 | `validation` | Invalid project/contract name, bad flags |
+| 6 | `check` | Clarity type-check failed |
+| 7 | `test` | Vitest failed |
+| 8 | `deploy` | Broadcast/plan/mnemonic failure |
+| 10 | `generate` | Codegen / ABI export failed |
+
+## Commands
+
+### `stacksdapp new <name>`
+
+Scaffold monorepo: contracts, frontend, git hooks, agent skill, default counter contract.
+
+| Flag | Description |
+|------|-------------|
+| `--no-git` | Skip `git init` |
+
+### `stacksdapp init`
+
+Adopt existing Clarinet project. Adds frontend (if missing), support files, bindings, git hooks, agent skill.
+
+Expects `Clarinet.toml` at repo root **or** `contracts/Clarinet.toml`. Normalizes standard Clarinet layout into scaffold layout.
+
+### `stacksdapp upgrade`
+
+Refresh npm deps, regenerate bindings, refresh git hooks and agent skill. Non-destructive to user contracts.
+
+### `stacksdapp doctor`
+
+Checks Rust 1.75+, Node 20+, Clarinet 3.23+ (C6 devnet), Docker (for devnet), git hooks path.
+
+| Flag | Description |
+|------|-------------|
+| `--strict` | Warnings → non-zero exit |
+
+### `stacksdapp add <name>`
+
+Add contract to `contracts/contracts/<name>.clar`, update `Clarinet.toml`, regenerate bindings.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--template` | `blank` | `blank`, `sip010`, `sip009` |
+| `--clarity-version` | `6` | `4`, `5`, or `6` — sets matching epoch |
+
+### `stacksdapp check`
+
+Run Clarinet type-checker on all contracts.
+
+### `stacksdapp generate`
+
+Export ABIs → TypeScript bindings + debug UI. Uses `contracts/.cache/` when sources unchanged.
+
+| Flag | Description |
+|------|-------------|
+| `--watch` | Regenerate on `.clar` changes |
+
+### `stacksdapp test`
+
+Run Vitest in `contracts/` (initSimnet) and frontend tests.
+
+### `stacksdapp clean`
+
+Remove `contracts/.cache/`, devnet state, generated frontend bindings.
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Skip confirmation |
+
+### `stacksdapp dev`
+
+| Flag | Description |
+|------|-------------|
+| `--network devnet\|testnet\|mainnet` | Default: devnet (Docker). Remote networks = frontend only |
+| `--auto-deploy` | Devnet only: deploy once chain healthy |
+| `--keep-state` | Devnet: preserve cache between runs |
+
+### `stacksdapp deploy`
+
+| Flag | Description |
+|------|-------------|
+| `--network` | `devnet`, `testnet`, `mainnet` (default from `stacksdapp.toml`) |
+| `--contract NAME` | Single contract |
+| `--dry-run` | Plan + fee, no broadcast |
+| `-y`, `--yes` | Non-interactive (required for CI/agents) |
+| `--wait-confirm` | Poll until confirmed on-chain (testnet/mainnet) |
+| `--no-auto-version` | Fail instead of renaming on collision |
+
+### `stacksdapp completions <shell>`
+
+Generate shell completions: bash, zsh, fish, powershell, elvish.
+
+## Configuration files
+
+| Path | Role |
+|------|------|
+| `stacksdapp.toml` | Project marker; `defaults.network` |
+| `contracts/Clarinet.toml` | Contract registry, clarity_version, epoch |
+| `contracts/settings/Devnet.toml` | Local devnet accounts (public test mnemonics) |
+| `contracts/settings/Testnet.toml` | Testnet deployer mnemonic |
+| `contracts/settings/Mainnet.toml` | Mainnet deployer mnemonic |
+| `frontend/.env.local` | `NEXT_PUBLIC_NETWORK`, optional node URL |
+| `contracts/.cache/` | Cached ABIs |
+| `frontend/src/generated/*` | Generated — do not edit |
+| `.githooks/pre-commit` | Blocks likely seed phrases in Testnet/Mainnet settings |
+| `.cursor/skills/scaffold-stacks/` | Bundled agent skill |
+
+## Name validation
+
+- **Project name:** single segment, letters/digits/`-`/`_`, no `..` or absolute paths
+- **Contract name:** Clarity identifier, letter first, max 40 chars
+
+## JSON output
+
+With `--json`, success payloads include `"ok": true` and command-specific fields. Failures include `"ok": false`, `"error"`, `"code"`, `"exit_code"`.
+
+Example: `stacksdapp doctor --json`
+
+## Prerequisites
+
+| Tool | Minimum |
+|------|---------|
+| Rust | 1.75+ |
+| Node.js | 20+ |
+| Clarinet | 3.23+ (C6 devnet) |
+| Docker | Devnet only |
+| Wallet | Leather or Xverse for testnet/mainnet UI |
+
+Install CLI: `cargo install stacksdapp`

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/frontend.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/frontend.md
@@ -1,0 +1,593 @@
+# Frontend — hooks, wallet, and infra
+
+Next.js 15 + React 18 + Tailwind + Jotai + `@stacks/connect` v8 + `@stacks/transactions` v7.
+
+After `stacksdapp generate` and `stacksdapp deploy`, the frontend calls deployed contracts via **reusable generated hooks**.
+
+## Full-stack checklist (custom UI + hooks)
+
+Use this end-to-end when building a dApp with your own frontend (not only the debug panel):
+
+```
+1. stacksdapp new my-app && cd my-app
+2. Edit contracts/contracts/*.clar  (or stacksdapp add …)
+3. stacksdapp check && stacksdapp generate && stacksdapp test
+4. Set deployer mnemonic in contracts/settings/Testnet.toml
+5. stacksdapp deploy --network testnet --yes   → writes deployments.json
+6. Create frontend/src/components/YourFeature.tsx  ("use client", import hooks)
+7. Add <YourFeature /> to frontend/src/app/page.tsx (or a new app/*/page.tsx)
+8. stacksdapp dev --network testnet   # MUST match deploy network (not bare dev if deployed to testnet)
+9. Connect wallet (testnet/mainnet) → call public functions from your component
+```
+
+Keep `<DebugContracts />` on the home page while building — it validates hooks work; ship custom UI alongside or replace it later.
+
+## Architecture
+
+```
+contracts/*.clar
+    ↓ stacksdapp generate
+frontend/src/generated/
+    contracts.ts      ← low-level call functions
+    hooks.ts          ← React hooks wrapping contracts.ts
+    DebugContracts.tsx← debug UI (uses hooks)
+    deployments.json  ← on-chain addresses (written by deploy)
+         ↓
+frontend/src/components/   ← your custom UI (edit here)
+frontend/src/app/          ← Next.js pages
+frontend/src/lib/devnet.ts ← devnet burner signing (hand-edited)
+frontend/src/scaffold.config.ts ← network config (hand-edited)
+```
+
+**Rule:** Never edit `generated/*`. Build custom UI in `components/` and import from `@/generated/hooks` or `@/generated/contracts`.
+
+## Imports and paths
+
+`frontend/tsconfig.json` maps `@/*` → `./src/*`:
+
+```tsx
+import { useCounter_Increment } from '@/generated/hooks';
+import { counter_increment } from '@/generated/contracts';
+import { scaffoldConfig } from '@/scaffold.config';
+import { useAtomValue } from 'jotai';
+import { addressAtom } from '@/store/wallet';
+```
+
+## Discovering hooks after generate
+
+Each public/read-only function gets one hook in `frontend/src/generated/hooks.ts`:
+
+| Contract `counter` | Function `increment` | Hook `useCounter_Increment` |
+| Contract `my-token` | Function `transfer` | Hook `useMyToken_Transfer` |
+
+Naming: `use` + `{ContractPascalCase}` + `_` + `{FunctionPascalCase}`.
+
+After `stacksdapp add my-nft` → `stacksdapp generate` → new hooks appear automatically. Search `hooks.ts` or let TypeScript autocomplete imports.
+
+## deployments.json
+
+Contract calls resolve addresses from `frontend/src/generated/deployments.json`:
+
+```json
+{ "contracts": { "counter": { "contract_id": "ST....counter" } } }
+```
+
+- Written by `stacksdapp deploy`
+- If missing, `contracts.ts` logs a warning and calls return `undefined` / `null`
+- After redeploy with auto-versioning (`counter-v2`), regenerate is automatic via deploy; run `stacksdapp generate` if bindings drift
+
+## scaffold.config.ts
+
+Driven by `frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_NETWORK=devnet   # devnet | testnet | mainnet
+# NEXT_PUBLIC_STACKS_NODE_URL=...   # optional override
+# NEXT_PUBLIC_HIRO_API_KEY=...      # optional Hiro API key for read calls
+```
+
+Exports `scaffoldConfig`:
+
+| Field | Purpose |
+|-------|---------|
+| `network` | Active network |
+| `nodeUrl` | Hiro API (devnet: `http://localhost:3999`) |
+| `targetNetwork` | Wallet request network (`testnet` when UI is devnet) |
+| `isDevnet` / `isTestnet` / `isMainnet` | Branching helpers |
+| `getReadOnlyNetwork()` | Network object for read-only RPC calls |
+
+`stacksdapp dev --network testnet` updates `.env.local` automatically.
+
+## Signing model (critical)
+
+| Network | Public (write) calls | Read-only calls |
+|---------|----------------------|-----------------|
+| **devnet** | `lib/devnet.ts` — public burner keys, no wallet popup | `fetchCallReadOnlyFunction` via node |
+| **testnet/mainnet** | `@stacks/connect` `request('stx_callContract')` — **wallet popup** | `fetchCallReadOnlyFunction` via Hiro |
+
+**Do not** expect Leather/Xverse to sign devnet writes — devnet uses template burner mnemonics (same as `contracts/settings/Devnet.toml`). Wallet connect is for testnet/mainnet UX and display.
+
+## contracts.ts (generated)
+
+One async function per contract function:
+
+```ts
+// Naming: {contractCamel}_{functionCamel}
+counter_increment(functionArgs, postConditions?)
+counter_getCount(functionArgs, senderAddress?)
+```
+
+- **Public:** devnet → `callDevnetContract`; testnet/mainnet → wallet `request()`
+- **Read-only:** always RPC via `fetchCallReadOnlyFunction` + `cvToValue`
+- Import `Cl` from `@stacks/transactions` to build args (see table below)
+- Read-only `data` is JSON from `cvToValue` (numbers, booleans, objects, `(ok …)` / `(err …)` shapes)
+
+### Parsing hook `data` — avoid `BigInt([object Object])`
+
+Read-only hooks (e.g. `useMyToken_GetBalance`, `useMyToken_GetTotalSupply`) return **`cvToValue` output**, not plain JavaScript numbers.
+
+For Clarity `(response uint uint)` functions like SIP-010 `get-balance`, `data` is typically a **cvToJSON-shaped object**, not a `bigint`:
+
+```ts
+// hook.data after get-balance — NOT a bigint
+{ type: "uint", value: "1500000" }
+```
+
+**Wrong** (throws `Cannot convert [object Object] to a BigInt`):
+
+```tsx
+function formatTokenAmount(raw: unknown, decimals = 6): string {
+  const value = typeof raw === "bigint" ? raw : BigInt(String(raw)); // raw is { type, value }
+  // ...
+}
+```
+
+**Right** — unwrap cvToJSON shapes first, then format:
+
+```tsx
+/** Extract a Clarity uint/int from hook `data` (cvToValue / cvToJSON shapes). */
+function clarityUintToBigInt(raw: unknown): bigint | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "bigint") return raw;
+  if (typeof raw === "number" && Number.isFinite(raw)) return BigInt(Math.trunc(raw));
+  if (typeof raw === "string" && raw !== "") return BigInt(raw);
+
+  if (typeof raw === "object") {
+    const obj = raw as { type?: string; value?: unknown };
+    // (ok uint) / (ok int) from read-only calls
+    if (obj.type === "uint" || obj.type === "int") {
+      return BigInt(String(obj.value));
+    }
+    // (optional uint), nested some, etc.
+    if ("value" in obj && obj.value != null) {
+      return clarityUintToBigInt(obj.value);
+    }
+  }
+  return null;
+}
+
+function formatTokenAmount(raw: unknown, decimals = 6): string {
+  const value = clarityUintToBigInt(raw);
+  if (value === null) return "—";
+  const whole = value / BigInt(10 ** decimals);
+  const fraction = value % BigInt(10 ** decimals);
+  const fractionStr = fraction
+    .toString()
+    .padStart(decimals, "0")
+    .replace(/0+$/, "");
+  return fractionStr ? `${whole}.${fractionStr}` : String(whole);
+}
+```
+
+Usage with generated hooks:
+
+```tsx
+"use client";
+import { useEffect } from "react";
+import { useMyToken_GetBalance } from "@/generated/hooks";
+import { Cl } from "@stacks/transactions";
+import { useAtomValue } from "jotai";
+import { addressAtom } from "@/store/wallet";
+
+export function BalanceDisplay() {
+  const address = useAtomValue(addressAtom);
+  const { call, data, loading } = useMyToken_GetBalance();
+
+  useEffect(() => {
+    if (address) void call([Cl.principal(address)]);
+  }, [call, address]);
+
+  if (loading) return <p>Loading…</p>;
+  return <p>Balance: {formatTokenAmount(data)}</p>; // pass hook.data, not data.value blindly
+}
+```
+
+**Agent rules for display helpers:**
+
+| `data` shape | What to do |
+|--------------|------------|
+| `{ type: "uint", value: "123" }` | Use `BigInt(obj.value)` — SIP-010 amounts are **base units** (divide by `10**decimals` for display) |
+| `{ type: "(optional …)", value: … }` | Recurse into `.value` |
+| `{ type: "bool", value: true }` | Use `.value` directly — do not `BigInt()` |
+| `string` / `bigint` | `BigInt(raw)` after null check |
+| Unsure | `console.log(JSON.stringify(data))` once, then write extractor |
+
+**Never** `BigInt(hook.data)` or `BigInt(String(hook.data))` when `data` comes from a read-only hook — always unwrap first.
+
+### Read-only RPC — avoid `Failed to fetch`
+
+Generated read-only functions (e.g. `airdropTokenV2_getBalance` in `contracts.ts`) call Hiro / local node via `fetchCallReadOnlyFunction`. Browser `TypeError: Failed to fetch` means the **HTTP request never succeeded** — not a Clarity revert.
+
+Typical stack trace:
+
+```
+Failed to fetch
+src/generated/contracts.ts … fetchCallReadOnlyFunction({ … functionName: 'get-balance'
+```
+
+#### Root causes (check in order)
+
+| Cause | Symptom | Fix |
+|-------|---------|-----|
+| **Network env mismatch** | Deployed to testnet, app still on devnet (`localhost:3999`) | Set `NEXT_PUBLIC_NETWORK=testnet` in `frontend/.env.local`, or run `stacksdapp dev --network testnet` (updates env automatically). **Restart** Next.js after changing env. |
+| **Devnet node down** | Request to `http://localhost:3999/...` fails | Run `stacksdapp dev` (Docker). Do not use `npm run dev` alone on devnet without the stacks node. |
+| **Contract not deployed** | `deployments.json` missing entry; console warns `"airdrop-token-v2" not deployed` | `stacksdapp deploy --network testnet --contract airdrop-token-v2 --yes` |
+| **Wrong chain for address** | `deployments.json` has `ST…` contract but app points at mainnet (or vice versa) | Match `NEXT_PUBLIC_NETWORK` to deploy network; ST* = testnet, SP* = mainnet |
+| **Invalid / missing principal arg** | `get-balance` called with `undefined`, `""`, or before wallet connect | Guard: only call when address is a valid `ST…` / `SP…` principal |
+| **Hiro rate limit / blocker** | Intermittent failures to `api.testnet.hiro.so` | Add `NEXT_PUBLIC_HIRO_API_KEY=…` in `.env.local`; disable ad-blocker for Hiro domains |
+| **Calling from server** | Error during SSR / in non-client component | Read-only hooks only in `"use client"` components |
+
+**Agent rule:** After `stacksdapp deploy --network testnet`, always run `stacksdapp dev --network testnet` (not bare `stacksdapp dev` which defaults to devnet).
+
+#### Pre-flight before read-only hooks
+
+```bash
+# 1. Contract deployed on intended network
+cat frontend/src/generated/deployments.json   # must contain "airdrop-token-v2": { "contract_id": "ST…" }
+
+# 2. Frontend network matches deploy
+grep NEXT_PUBLIC_NETWORK frontend/.env.local  # testnet if contract_id starts with ST
+
+# 3. Node reachable (pick one)
+curl -s -o /dev/null -w "%{http_code}" https://api.testnet.hiro.so/v2/info   # expect 200
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3999/v2/info        # devnet only, expect 200 when stacksdapp dev is up
+```
+
+#### Safe read-only hook pattern (guards + error UI)
+
+Do **not** fire `get-balance` on mount unconditionally. Guard address, deployment, and network:
+
+```tsx
+"use client";
+import { useEffect } from "react";
+import { useAirdropTokenV2_GetBalance } from "@/generated/hooks";
+import { Cl } from "@stacks/transactions";
+import { useAtomValue } from "jotai";
+import { addressAtom } from "@/store/wallet";
+import { scaffoldConfig } from "@/scaffold.config";
+import deployments from "@/generated/deployments.json";
+
+const CONTRACT = "airdrop-token-v2";
+
+function isValidPrincipal(addr: string | null | undefined): addr is string {
+  return typeof addr === "string" && /^(ST|SP)[0-9A-HJ-NP-Z]{38,41}$/.test(addr);
+}
+
+export function TokenBalance() {
+  const walletAddress = useAtomValue(addressAtom);
+  const { call, data, loading, error } = useAirdropTokenV2_GetBalance();
+
+  const contractId = deployments?.contracts?.[CONTRACT]?.contract_id as string | undefined;
+  const isDeployed = Boolean(contractId);
+
+  useEffect(() => {
+    if (!isDeployed) return;
+    if (!isValidPrincipal(walletAddress)) return;
+    // Avoid unhandled rejection noise — hook sets `error`
+    void call([Cl.principal(walletAddress)]).catch(() => {});
+  }, [call, walletAddress, isDeployed]);
+
+  if (!isDeployed) {
+    return (
+      <p>
+        {CONTRACT} not deployed — run{" "}
+        <code>stacksdapp deploy --network testnet --contract {CONTRACT} --yes</code>
+      </p>
+    );
+  }
+
+  if (scaffoldConfig.isDevnet) {
+    return (
+      <p>
+        Devnet mode — ensure <code>stacksdapp dev</code> is running (node: {scaffoldConfig.nodeUrl})
+      </p>
+    );
+  }
+
+  if (!isValidPrincipal(walletAddress)) {
+    return <p>Connect wallet to view balance</p>;
+  }
+
+  if (loading) return <p>Loading balance…</p>;
+
+  if (error) {
+    return (
+      <p>
+        Could not load balance ({error.message}). Check{" "}
+        <code>NEXT_PUBLIC_NETWORK={scaffoldConfig.network}</code> matches deploy network and Hiro is
+        reachable.
+      </p>
+    );
+  }
+
+  return <p>Balance: {formatTokenAmount(data)}</p>;
+}
+```
+
+#### Debugging in browser DevTools
+
+1. **Network tab** — find the failed request URL:
+   - `localhost:3999` → devnet not running or wrong `NEXT_PUBLIC_NETWORK`
+   - `api.testnet.hiro.so` → Hiro outage, rate limit, or blocker
+2. **Console** — look for `[scaffold-stacks] "…" not deployed` before the fetch error
+3. **Compare** `deployments.json` `contract_id` prefix with `scaffoldConfig.network`
+
+#### Optional: Hiro API key (rate limits)
+
+In `frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_HIRO_API_KEY=your_hiro_platform_api_key
+```
+
+`scaffold.config.ts` passes this to `getReadOnlyNetwork()` for read-only calls.
+
+### Building `ClarityValue[]` arguments
+
+| Clarity type | TypeScript |
+|--------------|------------|
+| `uint` | `Cl.uint(n)` or `Cl.uint(BigInt(n))` |
+| `int` | `Cl.int(n)` |
+| `bool` | `Cl.bool(true)` |
+| `principal` | `Cl.principal('ST…')` |
+| `(string-ascii …)` | `Cl.stringAscii('hello')` |
+| `(string-utf8 …)` | `Cl.stringUtf8('hello')` |
+| `(buff …)` | `Cl.bufferFromHex('0x…')` |
+| `(tuple (field-a …) …)` | `Cl.tuple({ 'field-a': Cl.uint(1), … })` |
+| `(list …)` | `Cl.list([Cl.uint(1), Cl.uint(2)])` |
+| `(optional …)` | `Cl.none()` or `Cl.some(Cl.uint(1))` |
+
+Check the generated debug UI or contract ABI for exact field names. For complex args, reference `DebugContracts.tsx` form handling.
+
+### Post-conditions
+
+Generated **hooks** call public functions with default empty post-conditions (`[]`). Wallet requests use `postConditionMode: 'allow'`.
+
+For explicit post-conditions, call **`contracts.ts` directly**:
+
+```ts
+import { counter_increment } from '@/generated/contracts';
+import { Pc, PostConditionMode } from '@stacks/transactions';
+
+await counter_increment([Cl.uint(1)], [
+  Pc.principal('ST…').willSendLte(1000).ustx(),
+]);
+```
+
+Devnet path uses `PostConditionMode.Deny` in `lib/devnet.ts`.
+
+## hooks.ts (generated)
+
+One hook per public/read-only function:
+
+```ts
+// Naming: use{ContractPascal}_{FunctionPascal}
+import { useCounter_Increment } from '@/generated/hooks';
+
+function MyButton() {
+  const { call, data, loading, error, txid, txStatus, txStatusError, explorerUrl } =
+    useCounter_Increment();
+
+  return (
+    <button
+      disabled={loading}
+      onClick={() => call([])}  // ClarityValue[] — empty if no args
+    >
+      {loading ? '…' : 'Increment'}
+    </button>
+  );
+}
+```
+
+### Hook return values
+
+| Field | Meaning |
+|-------|---------|
+| `call(args)` | Invoke the contract function |
+| `data` | Last result |
+| `loading` | In-flight |
+| `error` | Thrown error |
+| `txid` | Public calls only — broadcast tx id |
+| `txStatus` | `pending` \| `success` \| `abort_by_response` \| `error` |
+| `txStatusError` | Revert message when aborted |
+| `explorerUrl` | Hiro explorer link for `txid` |
+
+Public hooks poll `${nodeUrl}/extended/v1/tx/{txid}` until success/abort (respects `NEXT_PUBLIC_HIRO_API_KEY`).
+
+Read-only hooks resolve on `call()` — no txid polling.
+
+### Composing multiple hooks
+
+Use several hooks in one client component — each manages its own loading/tx state:
+
+```tsx
+"use client";
+import { useCounter_GetCount, useCounter_Increment } from '@/generated/hooks';
+
+export function CounterPanel() {
+  const read = useCounter_GetCount();
+  const write = useCounter_Increment();
+  // call read.call([]) to refresh; write.call([]) to increment
+}
+```
+
+## Wallet infra (hand-edited)
+
+```
+app/layout.tsx
+  └── WalletProvider          # syncs @stacks/connect → Jotai
+        ├── Header            # WalletConnect + NetworkBadge
+        └── page content
+
+store/wallet.ts
+  addressAtom                 # persisted STX address (localStorage)
+  isMountedAtom               # SSR guard
+
+components/WalletConnect.tsx
+  connect() / disconnect()    # @stacks/connect v8
+```
+
+- `WalletConnect` shows connect button or truncated address
+- User must connect wallet on **testnet/mainnet** before public calls from custom UI
+- Debug UI on devnet works without wallet (burner keys)
+
+### Show connected address in custom UI
+
+```tsx
+"use client";
+import { useAtomValue } from 'jotai';
+import { addressAtom } from '@/store/wallet';
+
+export function MyPanel() {
+  const address = useAtomValue(addressAtom);
+  if (!address) return <p>Connect wallet to continue</p>;
+  return <p>Signed in as {address}</p>;
+}
+```
+
+## Debug UI
+
+```
+components/debug/DebugContracts.tsx   → re-exports @/generated/DebugContracts
+app/page.tsx                          → renders <DebugContracts />
+```
+
+Auto-generated debug panel: tabs per contract, forms per function, shows tx status. Use as reference for hook usage; customize by building your own components importing the same hooks.
+
+## Devnet burners (`lib/devnet.ts`)
+
+- Derives keys from public template mnemonics (`deployer`, `wallet_1`…)
+- `ensureDefaultBurner()` — default sender `wallet_1`
+- `getDevnetSenderAddress()` — used as read-only sender on devnet
+- `callDevnetContract()` — broadcasts with `PostConditionMode.Deny`
+
+**Never** reuse devnet burners on testnet/mainnet.
+
+## Custom UI workflow
+
+1. Edit / add contracts → `stacksdapp check && stacksdapp generate && stacksdapp test`
+2. Deploy → `stacksdapp deploy --network testnet --yes`
+3. Create component in `frontend/src/components/`:
+
+```tsx
+"use client";
+import { useCounter_GetCount } from '@/generated/hooks';
+import { useEffect } from 'react';
+
+export function CounterDisplay() {
+  const { call, data, loading } = useCounter_GetCount();
+
+  useEffect(() => { void call([]); }, [call]);
+
+  if (loading) return <p>Loading…</p>;
+  return <p>Count: {JSON.stringify(data)}</p>;
+}
+```
+
+4. Import into `app/page.tsx` or create `app/dashboard/page.tsx` (Next.js App Router)
+5. Run `stacksdapp dev --network testnet` (or devnet with Docker)
+
+### SIP-010 / SIP-009 in custom UI
+
+After `stacksdapp add my-token --template sip010` and deploy:
+
+```tsx
+"use client";
+import { useMyToken_GetBalance, useMyToken_Transfer } from '@/generated/hooks';
+import { Cl } from '@stacks/transactions';
+
+export function TokenPanel() {
+  const balance = useMyToken_GetBalance();
+  const transfer = useMyToken_Transfer();
+  // balance.call([Cl.principal('ST…')])
+  // transfer.call([Cl.uint(100), Cl.principal('ST…')])
+}
+```
+
+Same hook pattern for SIP-009 NFT contracts — see [sip-standards.md](sip-standards.md) for trait functions and hook arg examples.
+
+### Contract tests (backend)
+
+When adding functions, extend `contracts/tests/*.test.ts` using `simnet` + `Cl` from `@stacks/transactions`. Run `stacksdapp test` before deploy — no Docker required.
+
+## Live reload
+
+- **`stacksdapp dev`** (devnet): file watcher regenerates bindings when `.clar` files change
+- **`stacksdapp dev --network testnet`**: run `stacksdapp generate --watch` in a second terminal, or regenerate manually after edits
+- **`stacksdapp generate --watch`**: standalone ABI watcher from project root
+
+After regenerate, new hooks appear in `hooks.ts` — refresh imports in your components.
+
+## Direct contract calls (no hook)
+
+For non-React code or one-off scripts inside the app:
+
+```ts
+import { counter_increment } from '@/generated/contracts';
+import { Cl } from '@stacks/transactions';
+
+await counter_increment([]);
+```
+
+Prefer hooks in React components for loading/error/tx state.
+
+## Frontend scripts
+
+```bash
+cd frontend
+npm run dev          # or stacksdapp dev from project root
+npm run build
+npm run typecheck
+npm test             # vitest (optional frontend tests)
+```
+
+## Common agent mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Edit `generated/hooks.ts` | Run `stacksdapp generate` |
+| Expect wallet popup on devnet | Devnet uses burners in `lib/devnet.ts` |
+| Call contract before deploy | Deploy first; check `deployments.json` |
+| Wrong network in wallet vs app | Match wallet network to `NEXT_PUBLIC_NETWORK` |
+| Skip `"use client"` in hook components | Hooks require client components |
+| Build args as plain JS | Use `Cl.*` from `@stacks/transactions` |
+| `BigInt(hook.data)` on read-only uint | Unwrap cvToJSON shape first — see **Parsing hook data** above |
+| Pass `data` straight to `formatTokenAmount` without unwrapping | SIP-010 `get-balance` returns `{ type: "uint", value: "…" }`, not `bigint` |
+| Fire read-only hooks on mount without guards | Wait for valid wallet address + deployed contract; handle `hook.error` |
+| `stacksdapp dev` after testnet deploy | Use `stacksdapp dev --network testnet` so `.env.local` matches `deployments.json` |
+| `npm run dev` alone on devnet | Needs `stacksdapp dev` — local node at `localhost:3999` |
+| Remove DebugContracts too early | Keep it while validating new hooks |
+| Forget redeploy after new contract | `deploy` then verify `deployments.json` |
+
+## Skill coverage map
+
+| Full-stack need | Documented in |
+|-----------------|---------------|
+| CLI: new, add, check, generate, test, deploy | `SKILL.md`, `workflows.md`, `cli-reference.md` |
+| Clarity versions / epochs | `clarity-versions.md` |
+| Clarity language + learning links | `clarity-language.md` |
+| SIP-010 / SIP-009 specs + templates | `sip-standards.md` |
+| Generated hooks + custom components | `frontend.md` |
+| Wallet vs devnet signing | this file |
+| Project directories | `project-layout.md` |
+| Errors / devnet stall | `troubleshooting.md` |

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/project-layout.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/project-layout.md
@@ -1,0 +1,129 @@
+# Project layout
+
+Scaffold Stacks monorepo structure after `stacksdapp new` or `stacksdapp init`.
+
+## Root
+
+```
+.
+├── stacksdapp.toml          # [project] name, [defaults] network = "devnet"
+├── AGENTS.md                # Pointer for non-Cursor agents
+├── package.json             # npm scripts wrapping stacksdapp commands
+├── .gitignore
+├── .githooks/
+│   └── pre-commit           # Mnemonic guard for Testnet/Mainnet settings
+└── .cursor/
+    └── skills/
+        └── scaffold-stacks/ # Agent skill (auto-installed)
+```
+
+## contracts/
+
+```
+contracts/
+├── Clarinet.toml            # [contracts.*] path, clarity_version, epoch
+├── contracts/
+│   └── *.clar               # Clarity source — primary edit surface
+├── settings/
+│   ├── Devnet.toml          # Public burner mnemonics (devnet only)
+│   ├── Testnet.toml         # User's testnet deployer
+│   └── Mainnet.toml         # User's mainnet deployer
+├── tests/
+│   └── *.test.ts            # Vitest + clarinet-sdk initSimnet
+├── deployments/             # Clarinet deployment plans (generated/updated on deploy)
+├── package.json             # @stacks/clarinet-sdk, vitest
+├── vitest.config.ts
+├── tsconfig.json
+├── .cache/                  # ABI export cache (gitignored)
+└── .devnet/                 # Local devnet state (gitignored)
+```
+
+### Clarinet.toml
+
+Each contract entry includes:
+
+```toml
+[contracts.counter]
+path = "contracts/counter.clar"
+clarity_version = 6
+epoch = "4.0"
+```
+
+Project-level `clarity_version` in `[project]` may also appear; per-contract settings take precedence for deploy.
+
+## frontend/
+
+```
+frontend/
+├── src/
+│   ├── app/                 # Next.js app router pages
+│   ├── components/          # UI components (editable)
+│   │   └── debug/           # Debug panel wrapper
+│   ├── generated/           # AUTO-GENERATED — run stacksdapp generate
+│   │   ├── contracts.ts
+│   │   ├── hooks.ts
+│   │   ├── DebugContracts.tsx
+│   │   └── deployments.json # Written on deploy
+│   ├── lib/devnet.ts        # devnet burner signing
+│   ├── store/wallet.ts      # Jotai wallet state
+│   └── scaffold.config.ts   # network / node URL config
+├── scripts/
+│   ├── export-abi.mjs       # Used by codegen pipeline
+│   └── build-tx.mjs
+├── .env.local               # NEXT_PUBLIC_NETWORK=devnet|testnet|mainnet
+└── package.json
+```
+
+## Edit matrix
+
+| Path | Edit? | Action on change |
+|------|-------|------------------|
+| `contracts/contracts/*.clar` | Yes | `check` → `generate` → `test` |
+| `contracts/Clarinet.toml` | Yes | May need redeploy plan regen |
+| `contracts/tests/*.test.ts` | Yes | `stacksdapp test` |
+| `frontend/src/components/**` | Yes | Normal frontend dev |
+| `frontend/src/generated/**` | **No** | `stacksdapp generate` |
+| `contracts/settings/Testnet.toml` | Yes (local) | Never commit real mnemonics |
+| `contracts/.cache/**` | No | Deleted by `stacksdapp clean` |
+
+## Environment variables
+
+### frontend/.env.local
+
+```bash
+NEXT_PUBLIC_NETWORK=devnet          # devnet | testnet | mainnet
+# NEXT_PUBLIC_STACKS_NODE_URL=...    # optional override
+# NEXT_PUBLIC_HIRO_API_KEY=...       # optional Hiro API key
+```
+
+`stacksdapp dev` and deploy update network-related env as needed.
+
+Frontend hooks, wallet, and signing: [frontend.md](frontend.md)
+
+### Agent / CI
+
+```bash
+STACKSDAPP_ROOT=/path/to/project    # Same as --root
+SCAFFOLD_ALLOW_COMMITTED_MNEMONIC=1 # Emergency only — bypass pre-commit hook
+```
+
+## Root discovery
+
+CLI walks up from CWD looking for:
+
+1. `stacksdapp.toml`, or
+2. `contracts/Clarinet.toml`
+
+Standard Clarinet repos (root `Clarinet.toml`) are normalized on `init`/`upgrade` to nested layout.
+
+## Git hooks
+
+After clone, enable mnemonic guard:
+
+```bash
+git config core.hooksPath .githooks
+# or
+npm run setup-hooks
+```
+
+`stacksdapp doctor --strict` warns if hooks are not configured.

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/sip-standards.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/sip-standards.md
@@ -1,0 +1,195 @@
+# SIP-010 & SIP-009 — standards + scaffold templates
+
+Scaffold Stacks ships **starter contracts** for fungible tokens (SIP-010) and NFTs (SIP-009). This file maps the specs to `stacksdapp add` templates, Clarity functions, and generated frontend hooks.
+
+## Official specifications
+
+| Standard | Spec | Stacks docs |
+|----------|------|-------------|
+| **SIP-010** (fungible token) | [GitHub SIP-010](https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md) | [Create a fungible token](https://docs.stacks.co/get-started/create-a-token/fungible-tokens.md) |
+| **SIP-009** (NFT) | [GitHub SIP-009](https://github.com/stacksgov/sips/blob/main/sips/sip-009/sip-009-nft-standard.md) | [Create an NFT](https://docs.stacks.co/get-started/create-a-token/non-fungible-tokens.md) |
+| Clarity Book (FT) | [SIP010 chapter](https://book.clarity-lang.org/ch10-03-sip010-ft-standard.html) | — |
+| Clarity Book (NFT) | [SIP009 chapter](https://book.clarity-lang.org/ch10-01-sip009-nft-standard.html) | — |
+
+Metadata extensions: [SIP-016](https://github.com/stacksgov/sips/blob/main/sips/sip-016/sip-016-metadata-schema.md) · [SIP-019 metadata updates](https://github.com/stacksgov/sips/blob/main/sips/sip-019/sip-019-token-metadata-update-notifications.md)
+
+## Scaffold commands (prefer over hand-written tokens)
+
+```bash
+stacksdapp add my-token --template sip010
+stacksdapp add my-nft --template sip009
+stacksdapp add legacy-token --template sip010 --clarity-version 5   # if needed
+```
+
+**Do not** hand-write a token from blog snippets. Use the template — it includes SIP-compatible functions, tests, requirements, and hooks.
+
+Each command creates:
+
+- `contracts/contracts/<name>.clar` with all required SIP **functions** (see below)
+- `contracts/tests/<name>.test.ts` (if no test file exists)
+- `[contracts.<name>]` entry in `Clarinet.toml` with correct epoch
+- `[[project.requirements]]` for the mainnet trait (Clarinet simnet type-checking)
+- Regenerated hooks in `frontend/src/generated/hooks.ts`
+
+## `impl-trait` — testnet vs mainnet (critical)
+
+### Common mistake → explorer error
+
+```
+VM Error: use of undeclared trait <sip-010-trait>
+```
+
+**Cause:** `(impl-trait 'sip-010-trait)` or `(impl-trait '.sip-010-trait)` — a short name with no `(define-trait …)` in the same contract and no full `SP…` contract path.
+
+**Fix:**
+
+1. Prefer `stacksdapp add NAME --template sip010` (or `sip009`) instead of writing from scratch.
+2. Follow the network rules below — **never** paste a bare trait name.
+
+**Never:**
+
+```clarity
+(impl-trait 'sip-010-trait)           ;; WRONG — undeclared trait (most common AI mistake)
+(define-trait sip-010-trait ...)      ;; WRONG shortcut — use deployed mainnet trait for production
+(impl-trait 'SP3....sip-010-trait)    ;; WRONG on testnet — mainnet trait contract is not on testnet chain
+```
+
+### Network rules
+
+| Network | `impl-trait` in token contract | Notes |
+|---------|-------------------------------|-------|
+| **Testnet** | **Omit** `(impl-trait …)` | No standard SIP-010/SIP-009 trait contract is deployed on testnet today. Scaffold templates ship **without** `impl-trait` so testnet deploy succeeds. Functions (`get-name`, `transfer`, …) still match SIP-010. |
+| **Mainnet** | **Required** for wallet listing | Add before deploy: `(impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)` |
+| **Simnet / `stacksdapp test`** | Omit (template default) | Clarinet requirement pulls mainnet trait source for type-checking only |
+
+### Mainnet trait addresses
+
+| Standard | `impl-trait` (mainnet only) | `[[project.requirements]]` (scaffold default) |
+|----------|----------------------------|-----------------------------------------------|
+| SIP-010 | `'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait` | `SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard` |
+| SIP-009 | `'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait` | `SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait` |
+
+Scaffold templates include a **comment** with the exact mainnet `impl-trait` line to uncomment before mainnet deploy.
+
+## SIP-010 trait (required interface)
+
+Seven functions wallets and apps expect:
+
+| Function | Purpose |
+|----------|---------|
+| `transfer(amount, sender, recipient, memo)` | Move tokens |
+| `get-name` | Token name |
+| `get-symbol` | Ticker |
+| `get-decimals` | Display decimals |
+| `get-balance(who)` | Balance of principal |
+| `get-total-supply` | Circulating supply |
+| `get-token-uri` | Optional metadata URI |
+
+Trait definition: [SIP-010 trait section](https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md)
+
+### Scaffold SIP-010 template
+
+The template implements all SIP-010 functions plus:
+
+| Function | Access | Notes |
+|----------|--------|-------|
+| `mint(amount, recipient)` | public | Owner-only; initial supply |
+| `set-token-uri(value)` | public | Owner-only; emits SIP-019-style print |
+| `define-fungible-token` | — | Asset name = contract name |
+
+Default: **6 decimals**, owner = deployer at deploy time.
+
+### SIP-010 test (generated)
+
+```typescript
+simnet.callPublicFn("my-token", "mint", [Cl.uint(100), Cl.standardPrincipal(deployer)], deployer);
+```
+
+### SIP-010 frontend hooks (after generate + deploy)
+
+```tsx
+import { useMyToken_GetBalance, useMyToken_Transfer, useMyToken_Mint } from '@/generated/hooks';
+import { Cl } from '@stacks/transactions';
+
+// read:  useMyToken_GetBalance().call([Cl.principal('ST…')])
+// write: useMyToken_Transfer().call([Cl.uint(100), Cl.principal(sender), Cl.principal(recipient), Cl.none()])
+```
+
+Hook names follow `use{ContractPascal}_{FunctionPascal}` — see [frontend.md](frontend.md).
+
+---
+
+## SIP-009 trait (required interface)
+
+Four functions for NFT interoperability:
+
+| Function | Purpose |
+|----------|---------|
+| `get-last-token-id` | Highest minted id |
+| `get-token-uri(token-id)` | Metadata URI for id |
+| `get-owner(token-id)` | Current owner |
+| `transfer(token-id, sender, recipient)` | Change owner |
+
+Spec: [SIP-009 trait section](https://github.com/stacksgov/sips/blob/main/sips/sip-009/sip-009-nft-standard.md)
+
+### Scaffold SIP-009 template
+
+Implements all SIP-009 functions plus:
+
+| Function | Access | Notes |
+|----------|--------|-------|
+| `mint(recipient)` | public | Owner-only; auto-increments id |
+| `set-base-uri(value)` | public | Owner-only; metadata template with `{id}` |
+| `define-non-fungible-token` | — | Token ids are `uint` |
+| `COLLECTION_LIMIT` | constant | Default cap u1000 |
+
+### SIP-009 test (generated)
+
+```typescript
+simnet.callPublicFn("my-nft", "mint", [Cl.standardPrincipal(deployer)], deployer);
+// expect Cl.uint(1) — first token id
+```
+
+### SIP-009 frontend hooks
+
+```tsx
+import { useMyNft_GetOwner, useMyNft_Mint, useMyNft_Transfer } from '@/generated/hooks';
+
+// useMyNft_GetOwner().call([Cl.uint(1)])
+// useMyNft_Transfer().call([Cl.uint(1), Cl.principal(sender), Cl.principal(recipient)])
+```
+
+---
+
+## End-to-end: token/NFT dApp
+
+```bash
+stacksdapp add my-token --template sip010
+stacksdapp check && stacksdapp generate && stacksdapp test
+stacksdapp deploy --network testnet --contract my-token --yes   # no impl-trait needed
+# For mainnet: uncomment impl-trait line in .clar first, then deploy
+stacksdapp dev --network testnet
+```
+
+Same flow for `--template sip009`.
+
+## Customizing templates
+
+| Goal | Edit in `.clar` |
+|------|-----------------|
+| Change decimals / collection limit | constants at top |
+| Restrict mint | `asserts!` on `tx-sender` |
+| Royalties / marketplace | add functions; keep trait fns compatible |
+| Metadata | `set-token-uri` / `set-base-uri`; consider SIP-016 off-chain JSON |
+| Mainnet wallet listing | Uncomment/add mainnet `impl-trait` line before mainnet deploy |
+
+After edits: `check` → `generate` → `test` → `deploy`.
+
+## Agent rules
+
+- **Always** use `stacksdapp add --template sip010|sip009` for new tokens
+- **Never** add `(impl-trait 'sip-010-trait)` — use full mainnet path or omit for testnet
+- Read the **SIP spec** for interface contracts; read the **scaffold template** for what's already implemented
+- Do not break trait function signatures if wallet compatibility matters
+- Use generated hooks for frontend — do not reimplement transfer in raw `@stacks/transactions` unless necessary
+- Clarity language help: [clarity-language.md](clarity-language.md)

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/troubleshooting.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/troubleshooting.md
@@ -1,0 +1,180 @@
+# Troubleshooting
+
+Common issues and agent actions for Scaffold Stacks projects.
+
+## Prerequisites
+
+Always start with:
+
+```bash
+stacksdapp doctor
+stacksdapp doctor --strict   # CI: fail on warnings
+```
+
+| Check fails | Fix |
+|-------------|-----|
+| Rust missing/old | Install via rustup.rs |
+| Node missing | Install Node 20+ |
+| Clarinet missing/old | `brew install clarinet` — need **3.23+** for C6 devnet |
+| Docker missing | Install Docker Desktop for devnet only |
+| Git hooks | `git config core.hooksPath .githooks` or `npm run setup-hooks` |
+
+## Project not found (exit 2)
+
+```
+No scaffold-stacks project found...
+```
+
+- `cd` to directory containing `stacksdapp.toml` or `contracts/Clarinet.toml`
+- Or: `stacksdapp --root /path/to/project <command>`
+- For raw Clarinet repos: run `stacksdapp init` first
+
+## Deploy failures (exit 8)
+
+### Testnet / mainnet
+
+| Symptom | Action |
+|---------|--------|
+| Placeholder mnemonic | Replace `<YOUR PRIVATE...>` in Testnet.toml |
+| Insufficient STX | Fund via testnet faucet |
+| Interactive prompt hangs | Add `--yes` |
+| Tx in mempool, not confirmed | Normal without `--wait-confirm`; check explorer |
+| Wrong network | Match `--network` to settings and wallet |
+
+### Devnet
+
+| Symptom | Action |
+|---------|--------|
+| Deploy never confirms | Chain may be stalled; use `--auto-deploy` or testnet |
+| Port in use | Stop parallel `clarinet devnet start`; `stacksdapp clean --force` |
+| Epoch burn wait | Expected for C5/C6; wait or use testnet |
+
+## Devnet boot stuck
+
+```
+waiting for bitcoin-node / stacks-node...
+```
+
+1. Ensure Docker is running
+2. Stop conflicting containers: `docker ps --filter name=devnet -q | xargs docker stop`
+3. `stacksdapp clean --force`
+4. Retry `stacksdapp dev --auto-deploy`
+5. Do not run manual `clarinet devnet start` alongside `stacksdapp dev`
+
+## Devnet stall after ~block 71
+
+Known issue with long-running local devnet (PoX / signer timeout).
+
+**Workarounds:**
+- Deploy early: `stacksdapp dev --auto-deploy`
+- Use testnet for deploy verification
+- Full reset: `stacksdapp clean --force`, restart Docker, retry
+
+Testnet/mainnet deploy is unaffected.
+
+## Clarity version / epoch mismatch
+
+- C5 requires `epoch = "3.4"` (not `"4.0"`)
+- C6 requires `epoch = "4.0"`
+- Regenerate plans: `cd contracts && clarinet deployments generate --devnet`
+
+Or: `stacksdapp add name --clarity-version 5`
+
+## Bindings out of sync
+
+```bash
+stacksdapp generate
+```
+
+Never patch `frontend/src/generated/*` manually.
+
+## Check failed (exit 6)
+
+Run `stacksdapp check` and fix Clarinet checker errors in `.clar` files.
+
+### `use of undeclared trait <sip-010-trait>` (or `<nft-trait>`)
+
+Explorer / deploy abort with this VM error when `impl-trait` uses a **short trait name** instead of a full on-chain contract path.
+
+| Bad (causes error) | Good |
+|--------------------|------|
+| `(impl-trait 'sip-010-trait)` | **Testnet:** omit `impl-trait` — use `stacksdapp add --template sip010` |
+| `(impl-trait 'SP3....sip-010-trait)` on testnet | **Mainnet only:** full `SP3FBR2…sip-010-trait` path (see [sip-standards.md](sip-standards.md)) |
+
+**Agent actions:**
+
+1. Run `stacksdapp add NAME --template sip010` (or `sip009`) — do not rewrite token from blog snippets
+2. Open [sip-standards.md](sip-standards.md) for the network trait table
+3. Match `[[project.requirements]]` in `Clarinet.toml` to the same network
+4. `stacksdapp check` → `stacksdapp test` → redeploy
+
+## Frontend: `Cannot convert [object Object] to a BigInt`
+
+Common in custom UI when formatting SIP-010 balances or other uint read-only results.
+
+```
+formatTokenAmount(raw) → BigInt(String(raw))
+Cannot convert [object Object] to a BigInt
+```
+
+**Cause:** `raw` is hook `data` from a read-only call. Scaffold uses `cvToValue`, which represents `(ok uint)` as `{ type: "uint", value: "1500000" }` — not a native `bigint`.
+
+**Fix:**
+
+1. Do not `BigInt(hook.data)` directly.
+2. Unwrap with a helper — full example in [frontend.md](frontend.md) (`clarityUintToBigInt` + `formatTokenAmount`).
+3. Remember SIP-010 amounts are **base units**; divide by `10**decimals` for human display.
+
+**Debug:** `console.log(JSON.stringify(data))` on the hook result to see the shape before writing formatters.
+
+## Frontend: `Failed to fetch` on read-only calls
+
+```
+TypeError: Failed to fetch
+src/generated/contracts.ts … fetchCallReadOnlyFunction({ … functionName: 'get-balance'
+```
+
+**Cause:** Browser could not reach the Stacks node — not a contract revert. Most often **network env mismatch** or **devnet node down**.
+
+| Failed request host | Fix |
+|---------------------|-----|
+| `localhost:3999` | Run `stacksdapp dev` (Docker), **or** switch to testnet: `NEXT_PUBLIC_NETWORK=testnet` + restart Next.js |
+| `api.testnet.hiro.so` | Check connectivity; add `NEXT_PUBLIC_HIRO_API_KEY`; disable ad-blocker |
+| Contract deployed but still fails | Verify `deployments.json` has the contract (e.g. `airdrop-token-v2`) and `ST…` prefix matches testnet |
+
+**Agent checklist:**
+
+1. `cat frontend/src/generated/deployments.json` — contract entry exists
+2. `grep NEXT_PUBLIC_NETWORK frontend/.env.local` — matches deploy network (`testnet` for `ST…` contracts)
+3. After testnet deploy: `stacksdapp dev --network testnet` (not default devnet)
+4. In custom UI: guard read-only `call()` until wallet address is valid; show `hook.error` — full pattern in [frontend.md](frontend.md)
+5. Restart Next.js after any `.env.local` change
+
+## Tests failed (exit 7)
+
+Run `stacksdapp test`. Contract tests use simnet — no Docker.
+
+## Generate failed (exit 10)
+
+- Validate `contracts/Clarinet.toml`
+- Run `npm install` in `contracts/` and `frontend/`
+- `stacksdapp clean --force` then `stacksdapp generate`
+
+## Init conflicts
+
+Merge duplicate `settings/`, `tests/`, or `deployments/` dirs before rerunning `stacksdapp init`.
+
+## Git hook blocked commit
+
+Unstage real mnemonics from Testnet/Mainnet settings. Emergency bypass: `SCAFFOLD_ALLOW_COMMITTED_MNEMONIC=1 git commit`
+
+## Mnemonic security
+
+- Devnet template mnemonics are public — devnet only
+- Pre-commit hook blocks likely seed phrases in Testnet/Mainnet.toml
+
+## Getting help
+
+- Docs: https://scaffoldstacks.mintlify.app/
+- Telegram: https://telegram.me/+CBp6wSIiXNhmMjZk
+- GitHub: https://github.com/scaffold-stack/scaffold-stack

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/workflows.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/workflows.md
@@ -1,0 +1,177 @@
+# Workflows
+
+Step-by-step patterns for common Scaffold Stacks tasks.
+
+## New project → testnet deploy
+
+Recommended first path (no Docker):
+
+```bash
+stacksdapp new my-app && cd my-app
+stacksdapp doctor
+```
+
+1. Fund testnet STX: https://explorer.hiro.so/sandbox/faucet?chain=testnet
+2. Edit `contracts/settings/Testnet.toml` with deployer mnemonic (local only; never commit)
+3. Edit `contracts/contracts/counter.clar` as needed
+4. `stacksdapp check && stacksdapp generate && stacksdapp test`
+5. `stacksdapp deploy --network testnet --yes`
+6. `stacksdapp dev --network testnet` → http://localhost:3000
+
+Connect Leather/Xverse on testnet. Debug UI calls contract functions.
+
+## Full-stack: custom frontend + reusable hooks
+
+End-to-end path when the user wants their own UI (not just the debug panel):
+
+1. **Contracts** — edit `contracts/contracts/*.clar` or `stacksdapp add …`
+2. **Validate** — `stacksdapp check && stacksdapp generate && stacksdapp test`
+3. **Deploy** — `stacksdapp deploy --network testnet --yes` (populates `deployments.json`)
+4. **Custom UI** — create `frontend/src/components/Feature.tsx` with `"use client"`; import hooks from `@/generated/hooks`
+5. **Page** — add component to `app/page.tsx` or a new App Router route
+6. **Run** — `stacksdapp dev --network testnet`; connect wallet for public calls
+
+Hook naming, `Cl.*` args, wallet vs devnet signing, post-conditions: [frontend.md](frontend.md)
+
+Keep `<DebugContracts />` during development to compare behavior with your custom components.
+
+## Contract iteration loop
+
+```bash
+# edit contracts/contracts/*.clar
+stacksdapp check
+stacksdapp generate        # or stacksdapp dev (includes watcher)
+stacksdapp test
+stacksdapp deploy --network testnet --yes
+```
+
+With `stacksdapp dev --network testnet`, run `generate` manually or use `generate --watch` in a second terminal.
+
+## Add SIP-010 token
+
+```bash
+stacksdapp add my-token --template sip010
+```
+
+Customize `contracts/contracts/my-token.clar`, then check → generate → test → deploy. Trait functions, hooks, and spec links: [sip-standards.md](sip-standards.md).
+
+## Add SIP-009 NFT
+
+```bash
+stacksdapp add my-nft --template sip009
+```
+
+Same workflow — see [sip-standards.md](sip-standards.md) for trait table and hook examples.
+
+## Adopt existing Clarinet project
+
+From repo with `Clarinet.toml` (standard or nested layout):
+
+```bash
+stacksdapp init
+```
+
+Init will:
+- Normalize layout to `contracts/Clarinet.toml` + `contracts/contracts/*.clar`
+- Add frontend template (if missing)
+- Install npm deps, generate bindings, git hooks, agent skill
+- Write `stacksdapp.toml` if missing
+
+Then:
+
+```bash
+stacksdapp deploy --network testnet --yes
+stacksdapp dev --network testnet
+```
+
+Guide: https://scaffoldstacks.mintlify.app/adopt-existing.md
+
+## Local devnet
+
+Requires Docker Desktop.
+
+```bash
+stacksdapp doctor
+stacksdapp dev --auto-deploy
+```
+
+- Boots Clarinet devnet + Next.js + file watcher
+- `--auto-deploy` deploys contracts once `:20443` is healthy (recommended)
+- Devnet mnemonics in `settings/Devnet.toml` are public — devnet only
+
+**Deploy separately:**
+
+```bash
+stacksdapp dev                    # terminal 1
+stacksdapp deploy --network devnet --yes   # terminal 2, soon after boot
+```
+
+Guide: https://scaffoldstacks.mintlify.app/local-devnet.md
+
+## Mainnet deploy
+
+1. Audit contracts and test on testnet first
+2. Set `contracts/settings/Mainnet.toml` mnemonic (never commit)
+3. `stacksdapp deploy --network mainnet --dry-run` — review plan and fees
+4. `stacksdapp deploy --network mainnet --yes --wait-confirm`
+5. `stacksdapp dev --network mainnet`
+
+Guide: https://scaffoldstacks.mintlify.app/mainnet.md
+
+## Upgrade project
+
+```bash
+stacksdapp upgrade
+```
+
+Refreshes npm lockfiles, regenerates bindings, updates git hooks and agent skill. Safe to run after updating `stacksdapp` CLI.
+
+Guide: https://scaffoldstacks.mintlify.app/upgrade.md
+
+## CI pipeline
+
+```bash
+stacksdapp doctor --strict
+stacksdapp check
+stacksdapp generate
+stacksdapp test
+stacksdapp deploy --network testnet --yes
+```
+
+Use `--json` for machine-readable output. Rely on exit codes (see cli-reference.md).
+
+Do not run devnet in CI unless Docker is available and stall risk is acceptable.
+
+## Clean slate
+
+```bash
+stacksdapp clean --force
+```
+
+Removes `.cache/`, devnet state, generated bindings. Does not delete `.clar` sources.
+
+After clean: `stacksdapp generate` to restore bindings.
+
+## Redeploy / naming collisions
+
+By default, redeploying auto-versions (`counter` → `counter-v2`). To fail instead:
+
+```bash
+stacksdapp deploy --network testnet --no-auto-version --yes
+```
+
+## Frontend-only against remote network
+
+```bash
+stacksdapp dev --network testnet
+stacksdapp dev --network mainnet
+```
+
+## Subdirectory commands
+
+```bash
+cd frontend
+stacksdapp check    # walks up to project root
+
+stacksdapp --root /path/to/my-app deploy --network testnet --yes
+```

--- a/crates/scaffold/agent-skill-template/AGENTS.md
+++ b/crates/scaffold/agent-skill-template/AGENTS.md
@@ -1,0 +1,45 @@
+# Scaffold Stacks — AI agent guide
+
+This project was scaffolded with [Scaffold Stacks](https://scaffoldstacks.mintlify.app/). Use the bundled agent skill for all Stacks dApp work.
+
+## Skill location
+
+**Cursor:** `.cursor/skills/scaffold-stacks/SKILL.md` (auto-discovered; no setup required)
+
+**Other agents (Claude Code, Codex, etc.):** Read `.cursor/skills/scaffold-stacks/SKILL.md` first, then reference files in that directory as needed.
+
+## Quick commands
+
+Run from project root (or any subdirectory — CLI walks up to `stacksdapp.toml` or `contracts/Clarinet.toml`):
+
+```bash
+stacksdapp doctor          # verify Rust, Node, Clarinet, Docker
+stacksdapp check           # type-check Clarity
+stacksdapp generate        # regenerate TypeScript bindings
+stacksdapp test            # contract + frontend tests
+stacksdapp deploy --network testnet --yes
+stacksdapp dev --network testnet
+```
+
+## Default workflow
+
+1. Edit `contracts/contracts/*.clar`
+2. `stacksdapp check && stacksdapp generate && stacksdapp test`
+3. Deploy to **testnet** first (no Docker): `stacksdapp deploy --network testnet --yes`
+4. `stacksdapp dev --network testnet`
+
+## Documentation
+
+- Guides: https://scaffoldstacks.mintlify.app/
+- Docs index for agents: https://scaffoldstacks.mintlify.app/llms.txt
+- Clarity language: `.cursor/skills/scaffold-stacks/clarity-language.md`
+- SIP-010 / SIP-009: `.cursor/skills/scaffold-stacks/sip-standards.md`
+
+## Frontend
+
+Generated hooks live in `frontend/src/generated/hooks.ts`. See `.cursor/skills/scaffold-stacks/frontend.md` for wallet vs devnet signing, hook usage, and custom UI patterns.
+
+## Never edit by hand
+
+- `frontend/src/generated/*` — run `stacksdapp generate`
+- Do not commit real mnemonics in `contracts/settings/Testnet.toml` or `Mainnet.toml`

--- a/crates/scaffold/contracts-template/package-lock.json
+++ b/crates/scaffold/contracts-template/package-lock.json
@@ -6,46 +6,12 @@
     "": {
       "name": "contracts",
       "devDependencies": {
-        "@stacks/clarinet-sdk": "3.21.0",
-        "@stacks/transactions": "7.4.0",
+        "@stacks/clarinet-sdk": "3.23.1",
+        "@stacks/transactions": "7.6.0",
         "@types/node": "^24",
         "typescript": "^5",
         "vitest": "^4.1.8",
         "vitest-environment-clarinet": "^3.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -54,25 +20,6 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.1.5",
@@ -101,9 +48,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -111,9 +58,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
@@ -128,9 +75,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +92,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
@@ -162,9 +109,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
@@ -179,9 +126,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
@@ -196,9 +143,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +160,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
@@ -230,9 +177,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
@@ -247,9 +194,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
@@ -264,9 +211,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
@@ -281,9 +228,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
@@ -298,9 +245,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
@@ -314,29 +261,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
@@ -351,9 +279,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
@@ -375,13 +303,13 @@
       "license": "MIT"
     },
     "node_modules/@stacks/clarinet-sdk": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.21.0.tgz",
-      "integrity": "sha512-rA8S1j/3n4DcBAmtu8BhKDEPE2qWBOdkEdoz5IgqdRu7qOUvyUyrGEa/JEZJLqkiSYhSrIB/hIQVWgUVK5iiHQ==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.23.1.tgz",
+      "integrity": "sha512-OqGtIf4NSfX0eyIpY9ShxRpdD8HCrupMyRqR3iHqHmlN55d1KqA/lOLql1WGpLv0x9yEt4UP3xiM5Dd9l8HN1w==",
       "dev": true,
       "license": "GPL-3.0",
       "dependencies": {
-        "@stacks/clarinet-sdk-wasm": "3.21.0",
+        "@stacks/clarinet-sdk-wasm": "3.23.1",
         "@stacks/transactions": "7.4.0",
         "kolorist": "1.8.0",
         "prompts": "2.4.2",
@@ -392,31 +320,13 @@
       }
     },
     "node_modules/@stacks/clarinet-sdk-wasm": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.21.0.tgz",
-      "integrity": "sha512-jX/QWkWIhT2S+NSci5QV0882K9nXDt/WV9c+oqlcdGmCMaiEvsSgWIJ9YNuyNyiyPfIcBOnvGrxxqAMtVaVrog==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.23.1.tgz",
+      "integrity": "sha512-XWTKhSdMEM1QsnjQpsU3+zEiwjaGhY/rUf0hCW9cGdxBy+rImxyUacxr6Flq1XdVwZJSO0oidC5wxx4gDGjt0A==",
       "dev": true,
       "license": "GPL-3.0"
     },
-    "node_modules/@stacks/common": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.5.0.tgz",
-      "integrity": "sha512-UkKM3J7VufGEEuHLYRAFZQFbiQeACMpMMzGbBL6qo/6YLXvPPXA8MBffeCsXE65/a0bJSbh+0Q7rfdio9IvZ1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@stacks/network": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.5.0.tgz",
-      "integrity": "sha512-FKfw864+ipj0RBa0kXBCKp+6Bm/8IS1pk+jg5NJhi//NzG8fZsC4MsER1F8qvzVoFrLfZjqxo+3sJDYfvHbVOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stacks/common": "^7.5.0",
-        "cross-fetch": "^3.1.5"
-      }
-    },
-    "node_modules/@stacks/transactions": {
+    "node_modules/@stacks/clarinet-sdk/node_modules/@stacks/transactions": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
       "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
@@ -431,23 +341,45 @@
         "lodash.clonedeep": "^4.5.0"
       }
     },
+    "node_modules/@stacks/common": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.6.0.tgz",
+      "integrity": "sha512-VUW8WDmZP4wXUNWVvpFerV+7LQ0PqIn8YOs8AjSUMA7ZOXIRLxJHoKxjfiHzJqazy7KlyryPW4kSNBCr7tLqhQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stacks/network": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.6.0.tgz",
+      "integrity": "sha512-Blm85nsEbvJoFIFaDp0QE9WMC0Hf+o3Yb0oIDwWu3PPgpVSdndb/bJQUeT6eJTs0ibS26A2E/5d5L0fb4Ff/lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stacks/common": "^7.6.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/transactions": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.6.0.tgz",
+      "integrity": "sha512-s7F7eJtQVnZoB79j8pY9SLKhlvvdYZZD1NSDRWrFjzSJTDmxptL8c50S563WFja6KOhFOgg1jd+p0XWTxFAVyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -475,9 +407,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -485,16 +417,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -503,13 +435,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -530,9 +462,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -543,13 +475,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -557,14 +489,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -573,9 +505,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -583,13 +515,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -714,9 +646,9 @@
       "license": "MIT"
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -824,9 +756,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -840,23 +772,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -875,9 +807,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -896,9 +828,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -917,9 +849,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -938,9 +870,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -959,9 +891,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -980,9 +912,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -1001,9 +933,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -1022,9 +954,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -1043,9 +975,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -1064,9 +996,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -1102,9 +1034,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1142,9 +1074,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -1183,9 +1115,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1203,7 +1135,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1226,13 +1158,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.138.0",
+        "@oxc-project/types": "=0.143.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1242,21 +1174,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/siginfo": {
@@ -1291,9 +1222,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1339,9 +1270,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1366,9 +1297,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1381,14 +1312,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1412,16 +1335,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -1438,7 +1361,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -1490,19 +1413,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1530,12 +1453,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/crates/scaffold/contracts-template/package.json
+++ b/crates/scaffold/contracts-template/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "contracts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:report": "vitest run -- --coverage --costs"
+  },
+  "devDependencies": {
+    "@stacks/clarinet-sdk": "3.23.1",
+    "@stacks/transactions": "7.6.0",
+    "@types/node": "^24",
+    "typescript": "^5",
+    "vitest": "^4.1.8",
+    "vitest-environment-clarinet": "^3.0.0"
+  }
+}

--- a/crates/scaffold/frontend-template/package-lock.json
+++ b/crates/scaffold/frontend-template/package-lock.json
@@ -7,8 +7,8 @@
       "name": "frontend",
       "dependencies": {
         "@stacks/connect": "^8",
-        "@stacks/network": "^7",
-        "@stacks/transactions": "^7",
+        "@stacks/network": "^7.6.0",
+        "@stacks/transactions": "^7.6.0",
         "jotai": "^2.19.0",
         "next": "^15",
         "pino-pretty": "^11",
@@ -1683,10 +1683,25 @@
       "dev": true,
       "license": "GPL-3.0"
     },
+    "node_modules/@stacks/clarinet-sdk/node_modules/@stacks/transactions": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
+      "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^7.3.1",
+        "@stacks/network": "^7.3.1",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
     "node_modules/@stacks/common": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.3.1.tgz",
-      "integrity": "sha512-29ANTFcSSlXnGQlgDVWg7OQ74lgQhu3x8JkeN19Q+UE/1lbQrzcctgPHG74XHjWNp8NPBqskUYA8/HLgIKuKNQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.6.0.tgz",
+      "integrity": "sha512-VUW8WDmZP4wXUNWVvpFerV+7LQ0PqIn8YOs8AjSUMA7ZOXIRLxJHoKxjfiHzJqazy7KlyryPW4kSNBCr7tLqhQ==",
       "license": "MIT"
     },
     "node_modules/@stacks/connect": {
@@ -1721,12 +1736,12 @@
       }
     },
     "node_modules/@stacks/network": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.3.1.tgz",
-      "integrity": "sha512-dQjhcwkz8lihSYSCUMf7OYeEh/Eh0++NebDtXbIB3pHWTvNCYEH7sxhYTB1iyunurv31/QEi0RuWdlfXK/BjeA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.6.0.tgz",
+      "integrity": "sha512-Blm85nsEbvJoFIFaDp0QE9WMC0Hf+o3Yb0oIDwWu3PPgpVSdndb/bJQUeT6eJTs0ibS26A2E/5d5L0fb4Ff/lA==",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^7.3.1",
+        "@stacks/common": "^7.6.0",
         "cross-fetch": "^3.1.5"
       }
     },
@@ -1781,15 +1796,15 @@
       }
     },
     "node_modules/@stacks/transactions": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
-      "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.6.0.tgz",
+      "integrity": "sha512-s7F7eJtQVnZoB79j8pY9SLKhlvvdYZZD1NSDRWrFjzSJTDmxptL8c50S563WFja6KOhFOgg1jd+p0XWTxFAVyA==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@noble/secp256k1": "1.7.1",
-        "@stacks/common": "^7.3.1",
-        "@stacks/network": "^7.3.1",
+        "@stacks/common": "^7.6.0",
+        "@stacks/network": "^7.6.0",
         "c32check": "^2.0.0",
         "lodash.clonedeep": "^4.5.0"
       }

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -17,6 +17,9 @@ use which::which;
 
 static FRONTEND_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-template");
 
+/// Default Clarity language version for newly scaffolded contracts (Clarity 6 / epoch 4.0).
+pub const DEFAULT_CLARITY_VERSION: u8 = 6;
+
 const CONTRACTS_PACKAGE_LOCK: &str = include_str!("../contracts-template/package-lock.json");
 
 const DEFAULT_CONTRACTS_PACKAGE_JSON: &str = r#"{
@@ -28,8 +31,8 @@ const DEFAULT_CONTRACTS_PACKAGE_JSON: &str = r#"{
     "test:report": "vitest run -- --coverage --costs"
   },
   "devDependencies": {
-    "@stacks/clarinet-sdk": "3.21.0",
-    "@stacks/transactions": "7.4.0",
+    "@stacks/clarinet-sdk": "3.23.1",
+    "@stacks/transactions": "7.6.0",
     "@types/node": "^24",
     "typescript": "^5",
     "vitest": "^4.1.8",
@@ -115,26 +118,6 @@ balance = 100_000_000_000_000
 sbtc_balance = 1_000_000_000
 derivation = "m/44'/5757'/0'/0/0"
 
-[devnet]
-# Clarinet 3.2+ snapshot fast-boot: keep this section free of [[devnet.pox_stacking_orders]]
-# and avoid custom images / early-epoch overrides (those force slow genesis mining).
-disable_bitcoin_explorer = true
-disable_stacks_explorer = true
-disable_stacks_api = false
-# 15s keeps Nakamoto + signer able to keep up; 1s races burn height and stalls tips.
-bitcoin_controller_block_time = 15_000
-"#;
-
-const DEFAULT_FULL_DEVNET_SETTINGS_BODY: &str = r#"[network]
-name = "devnet"
-deployment_fee_rate = 10
-
-[accounts.deployer]
-mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
 [accounts.wallet_1]
 mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
 balance = 100_000_000_000_000
@@ -153,50 +136,38 @@ balance = 100_000_000_000_000
 sbtc_balance = 1_000_000_000
 derivation = "m/44'/5757'/0'/0/0"
 
-[accounts.wallet_4]
-mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
-[accounts.wallet_5]
-mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
-[accounts.wallet_6]
-mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
-[accounts.wallet_7]
-mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
-[accounts.wallet_8]
-mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
-[accounts.faucet]
-mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
-balance = 100_000_000_000_000
-sbtc_balance = 1_000_000_000
-derivation = "m/44'/5757'/0'/0/0"
-
 [devnet]
-# Clarinet 3.2+ snapshot fast-boot: no PoX stacking orders (those force slow genesis).
-# Explorers off by default — enable locally if you need http://localhost:8000 / :8001.
+# Clarinet 3.23+ epoch-4.0 snapshot requires default PoX stacking orders (wallet_1–3 below).
+# Do not remove them or override epoch_* heights — that disables the burn-163 snapshot.
 disable_bitcoin_explorer = true
 disable_stacks_explorer = true
-disable_stacks_api = false
-# 15s keeps Nakamoto + signer able to keep up; 1s races burn height and stalls tips.
-bitcoin_controller_block_time = 15_000
+disable_stacks_api = true
+# 45s gives Nakamoto signer time through PoX reward-cycle transitions (30s can stall at ~block 71).
+bitcoin_controller_block_time = 45_000
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_2"
+slots = 2
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_3"
+slots = 2
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
 "#;
 
 fn devnet_settings_with_warning(body: &str) -> String {
@@ -741,8 +712,8 @@ check_checker = {{ trusted_sender = false, trusted_caller = false, callee_filter
 
 [contracts.counter]
 path = "contracts/counter.clar"
-clarity_version = 5
-epoch = "latest"
+clarity_version = {DEFAULT_CLARITY_VERSION}
+epoch = "4.0"
 "#
         ),
     )
@@ -750,7 +721,7 @@ epoch = "latest"
 
     tokio::fs::write(
         contracts_root.join("settings/Devnet.toml"),
-        devnet_settings_with_warning(DEFAULT_FULL_DEVNET_SETTINGS_BODY),
+        devnet_settings_with_warning(DEFAULT_DEVNET_SETTINGS_BODY),
     )
     .await?;
 
@@ -814,21 +785,21 @@ mnemonic = "<YOUR PRIVATE MAINNET MNEMONIC HERE>"
 import { Cl } from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
 
 describe("counter", () => {
   it("increments", () => {
-    const { result } = simnet.callPublicFn("counter", "increment", [], address1);
+    const { result } = simnet.callPublicFn("counter", "increment", [], deployer);
     expect(result).toBeOk(Cl.uint(1));
   });
   it("get-count returns current value", () => {
-    simnet.callPublicFn("counter", "increment", [], address1);
-    const { result } = simnet.callReadOnlyFn("counter", "get-count", [], address1);
+    simnet.callPublicFn("counter", "increment", [], deployer);
+    const { result } = simnet.callReadOnlyFn("counter", "get-count", [], deployer);
     expect(result).toBeOk(Cl.uint(1));
   });
   it("decrement", () => {
-    simnet.callPublicFn("counter", "increment", [], address1);
-    const { result } = simnet.callPublicFn("counter", "decrement", [], address1);
+    simnet.callPublicFn("counter", "increment", [], deployer);
+    const { result } = simnet.callPublicFn("counter", "decrement", [], deployer);
     expect(result).toBeOk(Cl.uint(0));
   });
 });
@@ -1050,9 +1021,28 @@ fn ensure_success(status: std::process::ExitStatus, command: &str) -> Result<()>
     }
 }
 
-pub async fn add_contract(name: &str, template: &str) -> Result<()> {
+fn default_epoch_for_clarity(clarity_version: u8) -> &'static str {
+    match clarity_version {
+        6 => "4.0",
+        // Pin C5/C4 to explicit epochs — Clarinet 3.23+ treats "latest" as 4.0 (burn 163).
+        5 => "3.4",
+        _ => "3.0",
+    }
+}
+
+fn validate_clarity_version(version: u8) -> Result<()> {
+    match version {
+        4 | 5 | 6 => Ok(()),
+        _ => Err(anyhow!(
+            "Unsupported clarity version {version} (supported: 4, 5, 6)"
+        )),
+    }
+}
+
+pub async fn add_contract(name: &str, template: &str, clarity_version: u8) -> Result<()> {
     validate_contract_name(name)?;
     validate_contract_template(template)?;
+    validate_clarity_version(clarity_version)?;
 
     let contracts_dir = Path::new("contracts/contracts");
     if !contracts_dir.exists() {
@@ -1070,6 +1060,10 @@ pub async fn add_contract(name: &str, template: &str) -> Result<()> {
     stacksdapp_shell::kv("Contract", name);
     if template != "blank" {
         stacksdapp_shell::kv("Template", template);
+    }
+    if clarity_version != DEFAULT_CLARITY_VERSION {
+        let version_label = format!("v{clarity_version}");
+        stacksdapp_shell::kv("Clarity", &version_label);
     }
     println!();
 
@@ -1222,11 +1216,11 @@ describe("{name} NFT", () => {{
 import {{ Cl }} from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
 
 describe("{name}", () => {{
   it("returns contract info", () => {{
-    const {{ result }} = simnet.callReadOnlyFn("{name}", "get-info", [], address1);
+    const {{ result }} = simnet.callReadOnlyFn("{name}", "get-info", [], deployer);
     expect(result).toBeOk(Cl.stringAscii("{name} contract"));
   }});
 }});
@@ -1278,8 +1272,9 @@ describe("{name}", () => {{
         }
     }
 
+    let epoch = default_epoch_for_clarity(clarity_version);
     existing.push_str(&format!(
-        "\n[contracts.{name}]\npath = \"contracts/{name}.clar\"\nclarity_version = 5\nepoch = \"latest\"\n"
+        "\n[contracts.{name}]\npath = \"contracts/{name}.clar\"\nclarity_version = {clarity_version}\nepoch = \"{epoch}\"\n"
     ));
 
     if let Err(e) = tokio::fs::write(clarinet_toml_path, existing).await {
@@ -1601,6 +1596,27 @@ mod tests {
         assert!(validate_contract_name("a/b").is_err());
         assert!(validate_contract_name(&"a".repeat(41)).is_err());
         assert!(validate_contract_name("9bad").is_err());
+    }
+
+    #[test]
+    fn clarity_version_defaults_to_six() {
+        assert_eq!(DEFAULT_CLARITY_VERSION, 6);
+    }
+
+    #[test]
+    fn default_epoch_for_clarity_version() {
+        assert_eq!(default_epoch_for_clarity(6), "4.0");
+        assert_eq!(default_epoch_for_clarity(5), "3.4");
+        assert_eq!(default_epoch_for_clarity(4), "3.0");
+    }
+
+    #[test]
+    fn clarity_version_validation() {
+        assert!(validate_clarity_version(4).is_ok());
+        assert!(validate_clarity_version(5).is_ok());
+        assert!(validate_clarity_version(6).is_ok());
+        assert!(validate_clarity_version(3).is_err());
+        assert!(validate_clarity_version(7).is_err());
     }
 
     #[test]

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -226,6 +226,14 @@ mnemonic = "<YOUR PRIVATE MAINNET MNEMONIC HERE>"
 const GIT_HOOK_PRE_COMMIT: &str = r#"#!/bin/sh
 # Installed by scaffold-stacks — block likely seed phrases in Testnet/Mainnet settings.
 if [ -n "${SCAFFOLD_ALLOW_COMMITTED_MNEMONIC}" ]; then
+  echo "" >&2
+  echo "================================================================" >&2
+  echo "  scaffold-stacks git hook: BYPASS ACTIVE" >&2
+  echo "================================================================" >&2
+  echo "  SCAFFOLD_ALLOW_COMMITTED_MNEMONIC is set — mnemonic guard skipped." >&2
+  echo "  Emergency override only; do not use for routine commits." >&2
+  echo "================================================================" >&2
+  echo "" >&2
   exit 0
 fi
 
@@ -1601,6 +1609,15 @@ mod tests {
         assert!(validate_contract_template("sip010").is_ok());
         assert!(validate_contract_template("sip009").is_ok());
         assert!(validate_contract_template("sip10").is_err());
+    }
+
+    #[test]
+    fn pre_commit_hook_logs_loudly_when_bypass_env_set() {
+        assert!(
+            GIT_HOOK_PRE_COMMIT.contains("BYPASS ACTIVE"),
+            "hook must warn loudly when SCAFFOLD_ALLOW_COMMITTED_MNEMONIC is set"
+        );
+        assert!(GIT_HOOK_PRE_COMMIT.contains("SCAFFOLD_ALLOW_COMMITTED_MNEMONIC"));
     }
 
     #[test]

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -1744,36 +1744,26 @@ mod agent_skill_tests {
         let tmp = tempfile::tempdir().unwrap();
         write_agent_skill_files(tmp.path()).await.unwrap();
         assert!(tmp.path().join("AGENTS.md").exists());
-        assert!(
-            tmp
-                .path()
-                .join(".cursor/skills/scaffold-stacks/SKILL.md")
-                .exists()
-        );
-        assert!(
-            tmp
-                .path()
-                .join(".cursor/skills/scaffold-stacks/frontend.md")
-                .exists()
-        );
-        assert!(
-            tmp
-                .path()
-                .join(".cursor/skills/scaffold-stacks/clarity-language.md")
-                .exists()
-        );
-        assert!(
-            tmp
-                .path()
-                .join(".cursor/skills/scaffold-stacks/sip-standards.md")
-                .exists()
-        );
-        assert!(
-            tmp
-                .path()
-                .join(".cursor/skills/scaffold-stacks/cli-reference.md")
-                .exists()
-        );
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/SKILL.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/frontend.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/clarity-language.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/sip-standards.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/cli-reference.md")
+            .exists());
     }
 }
 

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -1056,7 +1056,7 @@ fn default_epoch_for_clarity(clarity_version: u8) -> &'static str {
 
 fn validate_clarity_version(version: u8) -> Result<()> {
     match version {
-        4 | 5 | 6 => Ok(()),
+        4..=6 => Ok(()),
         _ => Err(anyhow!(
             "Unsupported clarity version {version} (supported: 4, 5, 6)"
         )),

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -16,6 +16,7 @@ use tokio::process::Command;
 use which::which;
 
 static FRONTEND_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/frontend-template");
+static AGENT_SKILL_TEMPLATE: Dir = include_dir!("$CARGO_MANIFEST_DIR/agent-skill-template");
 
 /// Default Clarity language version for newly scaffolded contracts (Clarity 6 / epoch 4.0).
 pub const DEFAULT_CLARITY_VERSION: u8 = 6;
@@ -173,6 +174,18 @@ btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
 fn devnet_settings_with_warning(body: &str) -> String {
     format!("{DEVNET_MNEMONIC_WARNING}{body}")
 }
+
+/// Mainnet SIP-010 trait — used as Clarinet requirement for simnet type-checking.
+/// Testnet has no deployed standard trait contract; do not add `(impl-trait …)` until
+/// deploying to mainnet (see agent skill sip-standards.md).
+const SIP010_TRAIT_REQUIREMENT: &str =
+    "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard";
+const SIP010_IMPL_TRAIT_MAINNET: &str =
+    "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait";
+
+/// Mainnet SIP-009 trait requirement.
+const SIP009_TRAIT_REQUIREMENT: &str = "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait";
+const SIP009_IMPL_TRAIT_MAINNET: &str = "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait";
 
 const DEFAULT_TESTNET_SETTINGS: &str = r#"[network]
 name = "testnet"
@@ -543,6 +556,7 @@ pub async fn init_project() -> Result<()> {
         }
 
         write_git_hooks_tracked(root, &mut rollback).await?;
+        write_agent_skill_files(root).await?;
         rollback.generated_touched = true;
         run_generate_after_setup().await?;
 
@@ -631,8 +645,9 @@ pub async fn upgrade_project() -> Result<()> {
         run_npm_install(Path::new("contracts"), "contracts", "[upgrade]").await?;
         stacksdapp_codegen::generate_all().await?;
         write_git_hooks(Path::new(".")).await?;
+        write_agent_skill_files(Path::new(".")).await?;
         let _ = try_set_git_hooks_path(Path::new(".")).await;
-        println!("[upgrade] ✔ Upgrade complete.");
+        println!("[upgrade] ✔ Upgrade complete (bindings, hooks, agent skill).");
         Ok(())
     }
     .await;
@@ -889,7 +904,16 @@ settings/Simnet.toml
     .await?;
 
     write_git_hooks(root).await?;
+    write_agent_skill_files(root).await?;
 
+    Ok(())
+}
+
+/// Install or refresh the bundled AI agent skill (Cursor, Claude Code, etc.).
+async fn write_agent_skill_files(root: &Path) -> Result<()> {
+    AGENT_SKILL_TEMPLATE
+        .extract(root)
+        .map_err(|e| anyhow!("Failed to install agent skill: {e}"))?;
     Ok(())
 }
 
@@ -1072,6 +1096,11 @@ pub async fn add_contract(name: &str, template: &str, clarity_version: u8) -> Re
         "sip010" => (
             format!(
                 r#";; {name}.clar Fungible Token
+;;
+;; SIP-010-compatible functions (get-name, transfer, etc.) are implemented below.
+;; For mainnet wallet listing, add before deploy:
+;;   (impl-trait '{sip010_impl_trait})
+;; See .cursor/skills/scaffold-stacks/sip-standards.md - never use bare 'sip-010-trait.
 
 (define-fungible-token {name})
 
@@ -1114,7 +1143,8 @@ pub async fn add_contract(name: &str, template: &str, clarity_version: u8) -> Re
     (try! (ft-transfer? {name} amount sender recipient))
     (match memo to-print (print to-print) 0x)
     (ok true)))
-"#
+"#,
+                sip010_impl_trait = SIP010_IMPL_TRAIT_MAINNET,
             ),
             format!(
                 r#"import {{ describe, expect, it }} from "vitest";
@@ -1136,12 +1166,17 @@ describe("{name} FT", () => {{
 }});
 "#
             ),
-            Some("SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard"),
+            Some(SIP010_TRAIT_REQUIREMENT),
         ),
 
         "sip009" => (
             format!(
                 r#";; {name}.clar Non-Fungible Token
+;;
+;; SIP-009-compatible functions are implemented below.
+;; For mainnet wallet listing, add before deploy:
+;;   (impl-trait '{sip009_impl_trait})
+;; See .cursor/skills/scaffold-stacks/sip-standards.md - never use bare trait names.
 
 (define-non-fungible-token {name} uint)
 
@@ -1182,7 +1217,8 @@ describe("{name} FT", () => {{
     (try! (nft-mint? {name} token-id recipient))
     (var-set last-token-id token-id)
     (ok token-id)))
-"#
+"#,
+                sip009_impl_trait = SIP009_IMPL_TRAIT_MAINNET,
             ),
             format!(
                 r#"import {{ describe, expect, it }} from "vitest";
@@ -1204,7 +1240,7 @@ describe("{name} NFT", () => {{
 }});
 "#
             ),
-            Some("SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait"),
+            Some(SIP009_TRAIT_REQUIREMENT),
         ),
 
         "blank" => (
@@ -1628,6 +1664,15 @@ mod tests {
     }
 
     #[test]
+    fn sip_trait_constants_use_full_mainnet_contract_paths() {
+        assert!(SIP010_IMPL_TRAIT_MAINNET.starts_with("SP3"));
+        assert!(SIP010_IMPL_TRAIT_MAINNET.ends_with(".sip-010-trait"));
+        assert!(SIP010_TRAIT_REQUIREMENT.contains("sip-010-trait-ft-standard"));
+        assert!(SIP009_IMPL_TRAIT_MAINNET.starts_with("SP2"));
+        assert!(SIP009_TRAIT_REQUIREMENT.ends_with(".nft-trait"));
+    }
+
+    #[test]
     fn pre_commit_hook_logs_loudly_when_bypass_env_set() {
         assert!(
             GIT_HOOK_PRE_COMMIT.contains("BYPASS ACTIVE"),
@@ -1677,6 +1722,58 @@ mod tests {
                 prop_assert!(validate_project_name(&s).is_err());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod agent_skill_tests {
+    use super::{write_agent_skill_files, AGENT_SKILL_TEMPLATE};
+
+    #[test]
+    fn agent_skill_template_contains_skill_md() {
+        let skill = AGENT_SKILL_TEMPLATE
+            .get_file(".cursor/skills/scaffold-stacks/SKILL.md")
+            .expect("SKILL.md in template");
+        let content = skill.contents_utf8().expect("utf8");
+        assert!(content.contains("name: scaffold-stacks"));
+        assert!(content.contains("stacksdapp"));
+    }
+
+    #[tokio::test]
+    async fn write_agent_skill_files_extracts_to_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_agent_skill_files(tmp.path()).await.unwrap();
+        assert!(tmp.path().join("AGENTS.md").exists());
+        assert!(
+            tmp
+                .path()
+                .join(".cursor/skills/scaffold-stacks/SKILL.md")
+                .exists()
+        );
+        assert!(
+            tmp
+                .path()
+                .join(".cursor/skills/scaffold-stacks/frontend.md")
+                .exists()
+        );
+        assert!(
+            tmp
+                .path()
+                .join(".cursor/skills/scaffold-stacks/clarity-language.md")
+                .exists()
+        );
+        assert!(
+            tmp
+                .path()
+                .join(".cursor/skills/scaffold-stacks/sip-standards.md")
+                .exists()
+        );
+        assert!(
+            tmp
+                .path()
+                .join(".cursor/skills/scaffold-stacks/cli-reference.md")
+                .exists()
+        );
     }
 }
 

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -2,9 +2,15 @@
 //! Init once from `main` via [`init`]. Commands and crates then use [`status`],
 //! [`warn`], [`error`], [`debug`], and [`emit_json`].
 
+pub mod mnemonic;
 pub mod project;
 pub mod steps;
 
+pub use mnemonic::{
+    check_deployer_mnemonic, inspect_settings_file, is_mnemonic_placeholder,
+    is_public_devnet_mnemonic, parse_deployer_mnemonic, settings_relative_path,
+    validate_mnemonic_word_format, MnemonicCheck, ParsedDeployerMnemonic, PUBLIC_DEVNET_MNEMONICS,
+};
 pub use project::{
     default_config_toml, enter_scaffold_root, find_init_root, find_scaffold_root, load_config,
     project_root, resolve_scaffold_root, validate_network, StacksdappConfig, CONFIG_FILE,

--- a/crates/shell/src/mnemonic.rs
+++ b/crates/shell/src/mnemonic.rs
@@ -120,7 +120,11 @@ fn capitalize(s: &str) -> String {
 }
 
 /// Inspect a network settings file on disk (for doctor).
-pub fn inspect_settings_file(network: &str, root: &Path, strict_format: bool) -> Option<(String, MnemonicCheck)> {
+pub fn inspect_settings_file(
+    network: &str,
+    root: &Path,
+    strict_format: bool,
+) -> Option<(String, MnemonicCheck)> {
     let path = root.join(settings_relative_path(network));
     let raw = std::fs::read_to_string(&path).ok()?;
     let parsed = parse_deployer_mnemonic(&raw)?;
@@ -134,21 +138,24 @@ mod tests {
 
     #[test]
     fn detects_public_devnet_deployer_seed() {
-        assert!(is_public_devnet_mnemonic(
-            PUBLIC_DEVNET_MNEMONICS[0]
-        ));
+        assert!(is_public_devnet_mnemonic(PUBLIC_DEVNET_MNEMONICS[0]));
     }
 
     #[test]
     fn rejects_placeholder_mnemonic() {
-        assert!(is_mnemonic_placeholder("<YOUR PRIVATE TESTNET MNEMONIC HERE>"));
+        assert!(is_mnemonic_placeholder(
+            "<YOUR PRIVATE TESTNET MNEMONIC HERE>"
+        ));
     }
 
     #[test]
     fn validates_word_count_and_charset() {
         assert!(validate_mnemonic_word_format(PUBLIC_DEVNET_MNEMONICS[0]).is_ok());
         assert!(validate_mnemonic_word_format("one two three").is_err());
-        assert!(validate_mnemonic_word_format("One two three four five six seven eight nine ten eleven twelve").is_err());
+        assert!(validate_mnemonic_word_format(
+            "One two three four five six seven eight nine ten eleven twelve"
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/shell/src/mnemonic.rs
+++ b/crates/shell/src/mnemonic.rs
@@ -1,0 +1,163 @@
+//! Deployer mnemonic inspection for testnet/mainnet safety checks.
+
+use std::path::Path;
+
+/// Public devnet seeds shipped in scaffold templates — must never be used on testnet/mainnet.
+pub const PUBLIC_DEVNET_MNEMONICS: &[&str] = &[
+    "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw",
+    "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild",
+    "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital",
+    "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high",
+    "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin",
+    "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase",
+    "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy",
+    "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow",
+    "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune",
+    "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform",
+];
+
+const VALID_WORD_COUNTS: [usize; 5] = [12, 15, 18, 21, 24];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedDeployerMnemonic {
+    pub mnemonic: String,
+    pub line_number: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MnemonicCheck {
+    /// Placeholder or empty — not configured yet.
+    NotConfigured,
+    Ok,
+    PublicDevnet,
+    InvalidFormat(String),
+}
+
+/// Normalize whitespace for stable comparison.
+pub fn normalize_mnemonic(mnemonic: &str) -> String {
+    mnemonic.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub fn is_mnemonic_placeholder(mnemonic: &str) -> bool {
+    mnemonic.is_empty() || mnemonic.contains('<') || mnemonic.contains('>')
+}
+
+pub fn is_public_devnet_mnemonic(mnemonic: &str) -> bool {
+    let normalized = normalize_mnemonic(mnemonic);
+    PUBLIC_DEVNET_MNEMONICS
+        .iter()
+        .any(|seed| normalize_mnemonic(seed) == normalized)
+}
+
+/// Word-count + lowercase a-z charset (no BIP39 checksum — Clarinet may accept edge cases).
+pub fn validate_mnemonic_word_format(mnemonic: &str) -> Result<(), String> {
+    let words: Vec<&str> = mnemonic.split_whitespace().collect();
+    let count = words.len();
+    if !VALID_WORD_COUNTS.contains(&count) {
+        return Err(format!(
+            "mnemonic has {count} words (expected 12, 15, 18, 21, or 24)"
+        ));
+    }
+    for word in words {
+        if word.is_empty() || !word.chars().all(|c| c.is_ascii_lowercase()) {
+            return Err(format!(
+                "mnemonic words must be lowercase a-z (invalid token: \"{word}\")"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn parse_deployer_mnemonic(toml_raw: &str) -> Option<ParsedDeployerMnemonic> {
+    let mut in_deployer = false;
+    for (idx, line) in toml_raw.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed == "[accounts.deployer]" {
+            in_deployer = true;
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_deployer = false;
+        }
+        if in_deployer && trimmed.starts_with("mnemonic") {
+            if let Some((_, val)) = trimmed.split_once('=') {
+                let mnemonic = val.trim().trim_matches('"').to_string();
+                return Some(ParsedDeployerMnemonic {
+                    mnemonic,
+                    line_number: idx + 1,
+                });
+            }
+        }
+    }
+    None
+}
+
+pub fn check_deployer_mnemonic(mnemonic: &str, strict_format: bool) -> MnemonicCheck {
+    if is_mnemonic_placeholder(mnemonic) {
+        return MnemonicCheck::NotConfigured;
+    }
+    if is_public_devnet_mnemonic(mnemonic) {
+        return MnemonicCheck::PublicDevnet;
+    }
+    if strict_format {
+        if let Err(detail) = validate_mnemonic_word_format(mnemonic) {
+            return MnemonicCheck::InvalidFormat(detail);
+        }
+    }
+    MnemonicCheck::Ok
+}
+
+pub fn settings_relative_path(network: &str) -> String {
+    format!("contracts/settings/{}.toml", capitalize(network))
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+/// Inspect a network settings file on disk (for doctor).
+pub fn inspect_settings_file(network: &str, root: &Path, strict_format: bool) -> Option<(String, MnemonicCheck)> {
+    let path = root.join(settings_relative_path(network));
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let parsed = parse_deployer_mnemonic(&raw)?;
+    let check = check_deployer_mnemonic(&parsed.mnemonic, strict_format);
+    Some((path.display().to_string(), check))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_public_devnet_deployer_seed() {
+        assert!(is_public_devnet_mnemonic(
+            PUBLIC_DEVNET_MNEMONICS[0]
+        ));
+    }
+
+    #[test]
+    fn rejects_placeholder_mnemonic() {
+        assert!(is_mnemonic_placeholder("<YOUR PRIVATE TESTNET MNEMONIC HERE>"));
+    }
+
+    #[test]
+    fn validates_word_count_and_charset() {
+        assert!(validate_mnemonic_word_format(PUBLIC_DEVNET_MNEMONICS[0]).is_ok());
+        assert!(validate_mnemonic_word_format("one two three").is_err());
+        assert!(validate_mnemonic_word_format("One two three four five six seven eight nine ten eleven twelve").is_err());
+    }
+
+    #[test]
+    fn parse_finds_line_number() {
+        let toml = r#"[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+"#;
+        let parsed = parse_deployer_mnemonic(toml).unwrap();
+        assert_eq!(parsed.line_number, 2);
+        assert!(is_public_devnet_mnemonic(&parsed.mnemonic));
+    }
+}

--- a/scripts/ci-smoke.sh
+++ b/scripts/ci-smoke.sh
@@ -19,11 +19,11 @@ fi
 echo "==> binary: $BIN"
 "$BIN" --version
 
-echo "==> clarinet pin check (expect 3.21+)"
+echo "==> clarinet pin check (expect 3.23+)"
 clarinet --version
 clarinet_ver="$(clarinet --version | head -n1)"
-if ! [[ "$clarinet_ver" =~ clarinet[[:space:]]+3\.(2[1-9]|[3-9][0-9]|[0-9]{3,}) ]]; then
-  echo "error: Clarinet 3.21+ required for CI (got: $clarinet_ver)" >&2
+if ! [[ "$clarinet_ver" =~ clarinet[[:space:]]+3\.(2[3-9]|[3-9][0-9]|[0-9]{3,}) ]]; then
+  echo "error: Clarinet 3.23+ required for CI (Clarity 6 devnet; got: $clarinet_ver)" >&2
   exit 1
 fi
 
@@ -59,6 +59,14 @@ test -f contracts/Clarinet.toml
 test -f contracts/contracts/counter.clar
 test -f frontend/package.json
 test -f stacksdapp.toml
+grep -q 'clarity_version = 6' contracts/Clarinet.toml || {
+  echo "error: new projects should default to clarity_version = 6" >&2
+  exit 1
+}
+grep -q 'epoch = "4.0"' contracts/Clarinet.toml || {
+  echo "error: Clarity 6 projects should pin epoch = \"4.0\"" >&2
+  exit 1
+}
 
 echo "==> stacksdapp check"
 "$BIN" check
@@ -91,6 +99,12 @@ test -f contracts/contracts/hello-token.clar
 "$BIN" check
 "$BIN" generate
 grep -q 'hello-token' frontend/src/generated/contracts.ts
+
+echo "==> backward compat: add Clarity 5 contract"
+"$BIN" add legacy-counter --template blank --clarity-version 5
+grep -q 'clarity_version = 5' contracts/Clarinet.toml
+grep -q 'epoch = "3.4"' contracts/Clarinet.toml
+"$BIN" check
 
 echo "==> stacksdapp test"
 "$BIN" test

--- a/scripts/ci-smoke.sh
+++ b/scripts/ci-smoke.sh
@@ -59,6 +59,11 @@ test -f contracts/Clarinet.toml
 test -f contracts/contracts/counter.clar
 test -f frontend/package.json
 test -f stacksdapp.toml
+test -f AGENTS.md
+test -f .cursor/skills/scaffold-stacks/SKILL.md
+test -f .cursor/skills/scaffold-stacks/frontend.md
+test -f .cursor/skills/scaffold-stacks/clarity-language.md
+test -f .cursor/skills/scaffold-stacks/sip-standards.md
 grep -q 'clarity_version = 6' contracts/Clarinet.toml || {
   echo "error: new projects should default to clarity_version = 6" >&2
   exit 1


### PR DESCRIPTION
## Summary

This PR ships **stacksdapp 0.2.0** — a production-hardening release for the full-stack Stacks scaffold CLI. It adds stable exit codes, safer deploy/devnet flows, Clarity 6 defaults, SIP-010/SIP-009 contract templates, and a **bundled AI agent skill** installed automatically on every `stacksdapp new` / `init` / `upgrade`.

### CLI & shell (`stacksdapp-shell`)

- Typed `CliError` with stable exit codes (2–10)
- Global flags: `-v` / `-q`, `--color`, `--json`, `--root` / `STACKSDAPP_ROOT`
- Project root walk-up via `stacksdapp.toml` or `contracts/Clarinet.toml`
- `doctor --strict`, deploy mnemonic guards, git hook checks
- Human-safe logging (`println_human_safe`) so devnet spinners aren’t corrupted by child-process output

### Deploy pipeline

- `--yes` / `-y` for non-interactive deploys; `--dry-run` with snapshot/restore (no silent source mutation)
- `--wait-confirm`, clearer broadcast vs confirmed messaging
- Testnet/mainnet: auto-versioning on name conflicts, dependency ordering, fail-closed tx parsing
- Devnet: epoch-gated publish handling, skip re-broadcast when contract already on chain, direct `@stacks/transactions` broadcast
- Partial failure recovery and `Clarinet.toml` rollback on pipeline errors

### Devnet supervision

- Snapshot-friendly default `Devnet.toml` (Clarinet 3.23+ / epoch 4.0)
- Stall detection, Docker recovery, stale container cleanup on `dev` / `clean`
- Auto-answer Clarinet snapshot prompts; sustained tip advancement before “ready”
- `--auto-deploy`, `--keep-state`; dev `--json` lifecycle payload when frontend is ready

### Clarity 6 & contracts

- New projects default to **Clarity 6** (`clarity_version = 6`, epoch `4.0`)
- `stacksdapp add --clarity-version <4|5|6>`
- **`stacksdapp add --template sip010|sip009`** — SIP-010 fungible token and SIP-009 NFT with generated Vitest tests, Clarinet trait requirements, and frontend hooks
- SIP templates: full trait-compatible function sets; mainnet `impl-trait` guidance in comments (omitted on testnet so deploy succeeds)

### Codegen & frontend template

- Generated `hooks.ts`, `contracts.ts`, `DebugContracts.tsx` via Tera templates
- Devnet burner signing in `lib/devnet.ts`; wallet connect for testnet/mainnet
- `scaffold.config.ts` with Hiro API key support for read-only calls
- `@stacks/connect` v8 + `@stacks/transactions` v7

### Bundled AI agent skill (new)

Every scaffolded project receives:

| Path | Purpose |
|------|---------|
| `AGENTS.md` | Root pointer for non-Cursor agents |
| `.cursor/skills/scaffold-stacks/SKILL.md` | Auto-discovery entry point |
| + 8 reference docs | CLI, Clarity language, SIP standards, frontend hooks, workflows, troubleshooting |

Source of truth: `crates/scaffold/agent-skill-template/`. Installed/refreshed by `new`, `init`, and `upgrade`.

Skill covers common agent failure modes discovered in the wild:

- `use of undeclared trait <sip-010-trait>` — never use bare trait names; testnet vs mainnet `impl-trait` rules
- `Cannot convert [object Object] to a BigInt` — unwrap `cvToValue` / cvToJSON shapes from read-only hooks
- `Failed to fetch` on `fetchCallReadOnlyFunction` — network/env mismatch, devnet node down, unguarded read-only calls

CLI repo mirror: `.cursor/skills/scaffold-stacks/` for contributors.

### CI & release

- GitHub Actions: CI (clippy, `cargo test --all`, smoke, frontend build) + Release workflow on `v*` tags
- `scripts/ci-smoke.sh` — asserts skill files after `stacksdapp new`, C6 defaults, C5 backward compat
- `scripts/verify-e2e.sh`, `scripts/verify-audit-fixes.sh`
- MIT `LICENSE`, expanded `CONTRIBUTING.md`, `CHANGELOG.md`

## Breaking / migration notes

- Default Clarity version is now **6** (epoch `4.0`); C5 projects need explicit `--clarity-version 5` or manual epoch `3.4`
- Devnet requires **Clarinet 3.23+** and Docker
- `frontend/src/generated/*` remains auto-generated — never hand-edit
- SIP tokens on **testnet**: omit `impl-trait`; uncomment mainnet `impl-trait` line before mainnet deploy