### PR TITLE
Extend scaffold-stacks agent skill with official Stacks docs coverage

### DIFF
--- a/.cursor/skills/scaffold-stacks/SKILL.md
+++ b/.cursor/skills/scaffold-stacks/SKILL.md
@@ -22,7 +22,7 @@ Scaffold Stacks = **Rust CLI** (`stacksdapp`) + **monorepo** (Clarity + Next.js)
 - User asks about Clarity + frontend integration on Stacks
 - User asks about SIP-010, SIP-009, or Clarity language syntax
 
-**Deep language / spec detail:** [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md) · [Stacks docs](https://docs.stacks.co/llms.txt)
+**Deep language / spec detail:** [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md) · [stacks-docs-index.md](stacks-docs-index.md) · [Stacks docs llms.txt](https://docs.stacks.co/llms.txt)
 
 ## Project root
 
@@ -103,6 +103,7 @@ Details: [clarity-versions.md](clarity-versions.md)
 - Use `--yes` for non-interactive deploys
 - Prefer **testnet** for deploy CI and first-time verification
 - Warn before committing mnemonics; devnet seeds in template are **public burners**
+- For Stacks topics not in this skill, **fetch** [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) or use `?ask=` on a doc page — see [stacks-docs-index.md](stacks-docs-index.md)
 
 ### Do not
 
@@ -210,6 +211,8 @@ stacksdapp dev --network mainnet
 
 ## Additional resources
 
+### Scaffold Stacks (local)
+
 - [frontend.md](frontend.md) — hooks, wallet, devnet signing, custom UI
 - [clarity-language.md](clarity-language.md) — Clarity cheat sheet + Stacks learning links
 - [sip-standards.md](sip-standards.md) — SIP-010/009 specs + scaffold templates
@@ -218,3 +221,9 @@ stacksdapp dev --network mainnet
 - [clarity-versions.md](clarity-versions.md) — C4/C5/C6 migration
 - [troubleshooting.md](troubleshooting.md) — doctor, Docker, deploy errors
 - [project-layout.md](project-layout.md) — directories and env vars
+
+### Official Stacks docs (fetch when needed)
+
+- [stacks-docs-index.md](stacks-docs-index.md) — **start here** for [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) section map + fetch workflow
+- [stacks-js.md](stacks-js.md) — Connect, transactions, post-conditions, read-only calls
+- [stacks-clarinet-docs.md](stacks-clarinet-docs.md) — Clarinet testing, deployment, Rendezvous

--- a/.cursor/skills/scaffold-stacks/clarity-language.md
+++ b/.cursor/skills/scaffold-stacks/clarity-language.md
@@ -11,11 +11,11 @@ Scaffold Stacks handles deploy, bindings, and frontend — **you still write Cla
 | Interactive course | [Clarity Universe](https://clarity-lang.org/universe) |
 | Browser REPL | [Clarity Playground](https://play.stackslabs.com/) |
 | Function/type reference | [Clarity Reference](https://docs.stacks.co/reference/clarity/functions.md) |
-| Full docs index | [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) |
+| Full docs index | [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) — see [stacks-docs-index.md](stacks-docs-index.md) for section map + fetch workflow |
 | Language spec (SIP-002) | [SIP-002 Smart Contract Language](https://github.com/stacksgov/sips/blob/main/sips/sip-002/sip-002-smart-contract-language.md) |
 | Ask docs a question | `GET https://docs.stacks.co/<page>.md?ask=<question>&goal=<goal>` |
 
-**Agent rule:** For Clarity language questions beyond this cheat sheet, fetch Stacks docs — do not invent syntax.
+**Agent rule:** For Clarity language questions beyond this cheat sheet, read [stacks-docs-index.md](stacks-docs-index.md) then fetch Stacks docs — do not invent syntax.
 
 ## Scaffold project workflow (Clarity side)
 

--- a/.cursor/skills/scaffold-stacks/frontend.md
+++ b/.cursor/skills/scaffold-stacks/frontend.md
@@ -588,6 +588,9 @@ npm test             # vitest (optional frontend tests)
 | Clarity language + learning links | `clarity-language.md` |
 | SIP-010 / SIP-009 specs + templates | `sip-standards.md` |
 | Generated hooks + custom components | `frontend.md` |
+| Stacks.js / Connect / post-conditions | `stacks-js.md` |
+| Clarinet (official docs) | `stacks-clarinet-docs.md` |
+| Full Stacks docs catalog | `stacks-docs-index.md` → [llms.txt](https://docs.stacks.co/llms.txt) |
 | Wallet vs devnet signing | this file |
 | Project directories | `project-layout.md` |
 | Errors / devnet stall | `troubleshooting.md` |

--- a/.cursor/skills/scaffold-stacks/stacks-clarinet-docs.md
+++ b/.cursor/skills/scaffold-stacks/stacks-clarinet-docs.md
@@ -1,0 +1,116 @@
+# Clarinet — official docs map (beyond stacksdapp CLI)
+
+Scaffold wraps Clarinet via **`stacksdapp check`**, **`test`**, **`deploy`**, and **`dev`**. This file maps **Hiro Clarinet documentation** for when agents need Clarinet features not covered in [cli-reference.md](cli-reference.md).
+
+**Index:** [stacks-docs-index.md](stacks-docs-index.md) · [Clarinet overview](https://docs.stacks.co/clarinet/overview.md)
+
+## stacksdapp vs raw Clarinet
+
+| Goal | Prefer | Clarinet doc (if needed) |
+|------|--------|--------------------------|
+| Type-check | `stacksdapp check` | [Validation and Analysis](https://docs.stacks.co/clarinet/validation-and-analysis.md) |
+| Unit tests | `stacksdapp test` | [Unit Testing](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) |
+| Local chain | `stacksdapp dev` | [Local Blockchain Development](https://docs.stacks.co/clarinet/local-blockchain-development.md) |
+| Deploy testnet/mainnet | `stacksdapp deploy --yes` | [Contract Deployment](https://docs.stacks.co/clarinet/contract-deployment.md) |
+| New project layout | `stacksdapp new` | [Project Structure](https://docs.stacks.co/clarinet/project-structure.md) |
+
+**Agent rule:** Do not tell users to run raw `clarinet devnet start` alongside `stacksdapp dev` — port conflicts. See [troubleshooting.md](troubleshooting.md).
+
+## Version requirements (scaffold defaults)
+
+| Tool | Version | Why |
+|------|---------|-----|
+| **Clarinet** | **3.23+** | Clarity 6 devnet / epoch 4.0 snapshot (burn ≥ 163) |
+| `@stacks/clarinet-sdk` | **3.23.1** | Matches Clarinet in `contracts/package.json` |
+| Default contract | Clarity **6**, epoch **4.0** | See [clarity-versions.md](clarity-versions.md) |
+
+`stacksdapp doctor` warns if Clarinet is below 3.23.
+
+## Testing (Vitest + simnet)
+
+| Topic | Doc |
+|-------|-----|
+| Testing guide | [Unit Testing](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) |
+| SDK reference | [SDK Reference](https://docs.stacks.co/reference/clarinet-js-sdk/sdk-reference.md) |
+| Simnet-only code | [Simnet-only code](https://docs.stacks.co/clarinet/simnet-only-code.md) |
+| Mainnet simulation | [Mainnet Execution Simulation](https://docs.stacks.co/clarinet/mainnet-execution-simulation.md) |
+
+Scaffold test layout:
+
+```
+contracts/tests/*.test.ts    # Vitest + simnet (generated for add --template)
+contracts/vitest.config.ts   # clarinet environment
+```
+
+Example pattern (from generated SIP templates):
+
+```typescript
+import { Cl } from '@stacks/transactions';
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get('deployer')!;
+
+const { result } = simnet.callPublicFn(
+  'my-token',
+  'mint',
+  [Cl.uint(100), Cl.standardPrincipal(deployer)],
+  deployer,
+);
+```
+
+## Validation & analysis
+
+| Topic | Doc |
+|-------|-----|
+| check_checker | [Validation and Analysis](https://docs.stacks.co/clarinet/validation-and-analysis.md) |
+| Formatter | [Clarity Formatter](https://docs.stacks.co/clarinet/clarity-formatter.md) |
+| Contract interaction | [Contract Interaction](https://docs.stacks.co/clarinet/contract-interaction.md) |
+
+Scaffold enables check_checker in `Clarinet.toml` by default.
+
+## Deployment
+
+| Topic | Doc |
+|-------|-----|
+| Deployment guide | [Contract Deployment](https://docs.stacks.co/clarinet/contract-deployment.md) |
+| Clarinet CLI deploy commands | [CLI Reference](https://docs.stacks.co/reference/clarinet/cli-reference.md) |
+
+Scaffold **`stacksdapp deploy`** generates plans, handles testnet broadcast, devnet epoch gating, and auto-versioning — prefer it over manual `clarinet deployments apply` in scaffold projects.
+
+## Devnet & integrations
+
+| Topic | Doc |
+|-------|-----|
+| Local devnet | [Local Blockchain Development](https://docs.stacks.co/clarinet/local-blockchain-development.md) |
+| Stacks.js integration | [Stacks.js Integration](https://docs.stacks.co/clarinet/integrations/stacks.js.md) |
+| sBTC integration | [sBTC Integration](https://docs.stacks.co/clarinet/integrations/sbtc.md) |
+| VSCode extension | [Clarity VSCode Extension](https://docs.stacks.co/clarinet/integrations/clarity-vscode-extension.md) |
+| FAQ | [Clarinet FAQ](https://docs.stacks.co/clarinet/faq.md) |
+
+## Rendezvous (fuzz testing)
+
+Optional advanced testing — not run by default in scaffold.
+
+| Topic | Doc |
+|-------|-----|
+| Overview | [Rendezvous Overview](https://docs.stacks.co/rendezvous/overview.md) |
+| Quickstart | [Rendezvous Quickstart](https://docs.stacks.co/rendezvous/quickstart.md) |
+| CLI reference | [Rendezvous Reference](https://docs.stacks.co/reference/rendezvous/reference.md) |
+
+Add to mature projects after `stacksdapp test` passes.
+
+## Clarity language reference (official)
+
+| Topic | Doc |
+|-------|-----|
+| All functions | [Functions](https://docs.stacks.co/reference/clarity/functions.md) |
+| Types | [Types](https://docs.stacks.co/reference/clarity/types.md) |
+| Keywords | [Keywords](https://docs.stacks.co/reference/clarity/keywords.md) |
+
+Shorter cheat sheet: [clarity-language.md](clarity-language.md)
+
+## Agent rules
+
+- Clarinet **3.23+** for Clarity 6 devnet — see [troubleshooting.md](troubleshooting.md) if devnet stalls
+- C5 contracts need epoch **3.4**, not 4.0 — [clarity-versions.md](clarity-versions.md)
+- For doc gaps, fetch [llms.txt](https://docs.stacks.co/llms.txt) → Clarinet section

--- a/.cursor/skills/scaffold-stacks/stacks-docs-index.md
+++ b/.cursor/skills/scaffold-stacks/stacks-docs-index.md
@@ -1,0 +1,127 @@
+# Stacks official docs — index & fetch workflow
+
+Scaffold Stacks skill files cover **CLI, project layout, frontend hooks, SIP templates, and troubleshooting**. For everything else on Stacks, use the **official docs index** — same catalog as [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt).
+
+## Agent workflow (required when docs are not in this skill)
+
+1. **Check local skill first** — [SKILL.md](SKILL.md), [frontend.md](frontend.md), [clarity-language.md](clarity-language.md), [sip-standards.md](sip-standards.md), [stacks-js.md](stacks-js.md), [stacks-clarinet-docs.md](stacks-clarinet-docs.md)
+2. **If not covered** — fetch the index: `https://docs.stacks.co/llms.txt`
+3. **Open the matching `.md` URL** from the index (append `.md` to doc paths)
+4. **Or ask GitBook directly:**
+
+```http
+GET https://docs.stacks.co/<path-to-page>.md?ask=<specific question>&goal=<what you are building>
+```
+
+Example:
+
+```http
+GET https://docs.stacks.co/stacks.js/read-only-calls.md?ask=How do I decode fetchCallReadOnlyFunction results?&goal=Fix frontend balance display in a scaffold project
+```
+
+**Never invent Clarity syntax, SIP trait addresses, or Stacks.js APIs** — fetch or use `?ask=`.
+
+## Two doc indexes (do not confuse)
+
+| Index | URL | Use for |
+|-------|-----|---------|
+| **Scaffold Stacks** | https://scaffoldstacks.mintlify.app/llms.txt | `stacksdapp` CLI, this template, deploy workflows |
+| **Stacks (Hiro)** | https://docs.stacks.co/llms.txt | Clarity, Clarinet, Stacks.js, sBTC, APIs, PoX |
+
+## Section map (docs.stacks.co/llms.txt)
+
+Curated entry points per section. For the full link list, fetch `llms.txt`.
+
+### Learn — concepts & network
+
+| Topic | Doc |
+|-------|-----|
+| What is Stacks / Bitcoin L2 | [Stacks 101](https://docs.stacks.co/learn/stacks-101/what-is-stacks.md) |
+| Mainnet vs testnet | [Mainnet and Testnets](https://docs.stacks.co/learn/network-fundamentals/mainnet-and-testnets.md) |
+| Wallets & accounts | [Wallets & Accounts](https://docs.stacks.co/learn/network-fundamentals/wallets-and-accounts.md) |
+| How transactions work | [How Transactions Work](https://docs.stacks.co/learn/transactions/how-transactions-work.md) |
+| Post-conditions (concept) | [Post Conditions](https://docs.stacks.co/learn/transactions/post-conditions.md) |
+| Clarity overview | [Clarity](https://docs.stacks.co/learn/clarity.md) |
+| SIPs list | [SIPs](https://docs.stacks.co/learn/network-fundamentals/sips.md) |
+| Nakamoto / block production | [What was the Nakamoto Upgrade?](https://docs.stacks.co/learn/block-production/what-was-the-nakamoto-upgrade.md) |
+| sBTC overview | [sBTC](https://docs.stacks.co/learn/sbtc.md) |
+| Bridging / USDCx | [Bridging](https://docs.stacks.co/learn/bridging.md) |
+
+### Build — dApp development (beyond scaffold CLI)
+
+| Topic | Doc | Local skill |
+|-------|-----|-------------|
+| Developer quickstart | [Developer Quickstart](https://docs.stacks.co/get-started/developer-quickstart.md) | [workflows.md](workflows.md) |
+| Clarity crash course | [Clarity Crash Course](https://docs.stacks.co/get-started/clarity-crash-course.md) | [clarity-language.md](clarity-language.md) |
+| Fungible tokens | [Fungible Tokens](https://docs.stacks.co/get-started/create-a-token/fungible-tokens.md) | [sip-standards.md](sip-standards.md) |
+| NFTs | [Non-Fungible Tokens](https://docs.stacks.co/get-started/create-a-token/non-fungible-tokens.md) | [sip-standards.md](sip-standards.md) |
+| Semi-fungible tokens | [Semi-Fungible Tokens](https://docs.stacks.co/get-started/create-a-token/semi-fungible-tokens.md) | — |
+| Frontend / auth / txs | [Build a Frontend](https://docs.stacks.co/get-started/build-a-frontend.md) | [frontend.md](frontend.md) |
+| Wallet authentication | [Authentication](https://docs.stacks.co/get-started/build-a-frontend/authentication.md) | [stacks-js.md](stacks-js.md) |
+| Sending transactions (frontend) | [Sending Transactions](https://docs.stacks.co/get-started/build-a-frontend/sending-transactions.md) | [stacks-js.md](stacks-js.md) |
+| Use cases (DeFi, gaming, etc.) | [Use Cases](https://docs.stacks.co/get-started/use-cases.md) | fetch on demand |
+| Post-conditions (frontend) | [Post-Conditions](https://docs.stacks.co/get-started/build-a-frontend/post-conditions.md) | [stacks-js.md](stacks-js.md) |
+| Path to production | [Path to Production](https://docs.stacks.co/get-started/path-to-production.md) | [troubleshooting.md](troubleshooting.md) |
+| Clarinet overview | [Clarinet Overview](https://docs.stacks.co/clarinet/overview.md) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| Clarinet testing | [Unit Testing](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| Clarinet deploy | [Contract Deployment](https://docs.stacks.co/clarinet/contract-deployment.md) | [cli-reference.md](cli-reference.md) |
+| Rendezvous fuzzing | [Rendezvous Overview](https://docs.stacks.co/rendezvous/overview.md) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| Stacks.js overview | [Stacks.js Overview](https://docs.stacks.co/stacks.js/overview.md) | [stacks-js.md](stacks-js.md) |
+| Stacks Connect | [Connect Wallet](https://docs.stacks.co/stacks-connect/connect-wallet.md) | [frontend.md](frontend.md) |
+| Post-conditions guide | [Post-Conditions Overview](https://docs.stacks.co/post-conditions/overview.md) | [stacks-js.md](stacks-js.md) |
+| sBTC builder guide | [sBTC Builder Quickstart](https://docs.stacks.co/more-guides/sbtc/sbtc-builder-quickstart.md) | fetch on demand |
+| Price oracles (Pyth/DIA) | [Price Oracles](https://docs.stacks.co/more-guides/price-oracles.md) | fetch on demand |
+| Verify BTC txs in Clarity | [Verify Bitcoin Transactions in Clarity](https://docs.stacks.co/more-guides/verify-bitcoin-transactions-clarity.md) | fetch on demand |
+| USDCx bridging | [Bridging USDCx](https://docs.stacks.co/more-guides/bridging-usdcx.md) | fetch on demand |
+| c32 address encoding | [c32check](https://docs.stacks.co/more-guides/c32check.md) | fetch on demand |
+| Embedded wallets (Turnkey) | [Signing with Turnkey](https://docs.stacks.co/more-guides/onboarding/signing-with-turnkey.md) | fetch on demand |
+| Devtools catalog | [Stacks Devtools Catalog](https://docs.stacks.co/stacks-devtools-catalog.md) | — |
+
+### Operate — nodes, signers (usually not scaffold dApp work)
+
+| Topic | Doc |
+|-------|-----|
+| Run a node | [Run a Node](https://docs.stacks.co/operate/run-a-node.md) |
+| Run a signer | [Run a Signer](https://docs.stacks.co/operate/run-a-signer.md) |
+| PoX-5 upgrade | [PoX-5 Upgrade Guide](https://docs.stacks.co/operate/run-a-signer/pox-5-upgrade-guide.md) |
+| Staking STX | [Staking STX](https://docs.stacks.co/operate/staking-stx.md) |
+
+Scaffold **devnet** uses Clarinet Docker — not a production node. Prefer **testnet** for deploy verification.
+
+### Reference — APIs & language spec
+
+| Topic | Doc |
+|-------|-----|
+| Clarity functions | [Functions](https://docs.stacks.co/reference/clarity/functions.md) |
+| Clarity types | [Types](https://docs.stacks.co/reference/clarity/types.md) |
+| Clarity keywords | [Keywords](https://docs.stacks.co/reference/clarity/keywords.md) |
+| Stacks Blockchain API | [Stacks Blockchain API](https://docs.stacks.co/reference/api/stacks-blockchain-api.md) |
+| Node RPC | [Stacks Node RPC](https://docs.stacks.co/reference/api/stacks-node-rpc.md) |
+| `@stacks/transactions` | [Reference](https://docs.stacks.co/reference/stacks.js/stacks-transactions.md) |
+| `@stacks/connect` | [Reference](https://docs.stacks.co/reference/stacks.js/stacks-connect.md) |
+| `cvToValue` / `cvToJSON` | [cvToValue](https://docs.stacks.co/reference/stacks.js/stacks-transactions/utilities/cvtovalue.md) |
+| Clarinet CLI ref | [CLI Reference](https://docs.stacks.co/reference/clarinet/cli-reference.md) |
+| Clarinet SDK ref | [SDK Reference](https://docs.stacks.co/reference/clarinet-js-sdk/sdk-reference.md) |
+
+### Tutorials & Cookbook
+
+| Topic | Doc |
+|-------|-----|
+| Tutorials hub | [Welcome to Tutorials](https://docs.stacks.co/tutorials/readme.md) |
+| Full-stack primer | [Getting Started with Stacks](https://docs.stacks.co/tutorials/bitcoin-primer/getting-started-with-stacks.md) |
+| Cookbook hub | [Welcome to the Cookbook](https://docs.stacks.co/cookbook/readme.md) |
+| SIP-010 transfer (JS) | [Transfer a SIP10 token](https://docs.stacks.co/cookbook/stacks.js/token-transfers/transfer-a-sip10-token.md) |
+| Example Clarity contracts | [Example Contracts](https://docs.stacks.co/cookbook/clarity/example-contracts.md) |
+| Post-condition recipes | [Build an ft pc](https://docs.stacks.co/cookbook/stacks.js/cryptography-and-security/build-an-ft-pc.md) |
+
+## When to fetch vs use local skill
+
+| Question type | Start here |
+|---------------|------------|
+| `stacksdapp` command, exit code, deploy | [SKILL.md](SKILL.md) · [cli-reference.md](cli-reference.md) |
+| Generated hooks, wallet, `Failed to fetch` | [frontend.md](frontend.md) |
+| SIP-010/009 templates, `impl-trait` | [sip-standards.md](sip-standards.md) |
+| Clarity syntax cheat sheet | [clarity-language.md](clarity-language.md) |
+| Stacks.js / Connect / post-conditions code | [stacks-js.md](stacks-js.md) |
+| Clarinet features (not stacksdapp CLI) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| sBTC, oracles, node ops, anything else | **Fetch** [llms.txt](https://docs.stacks.co/llms.txt) → open page → or `?ask=` |

--- a/.cursor/skills/scaffold-stacks/stacks-js.md
+++ b/.cursor/skills/scaffold-stacks/stacks-js.md
@@ -1,0 +1,149 @@
+# Stacks.js — Connect, transactions & post-conditions
+
+Scaffold frontend uses **`@stacks/connect` v8**, **`@stacks/transactions` v7**, **`@stacks/network` v7**. Generated code lives in `frontend/src/generated/contracts.ts` and `hooks.ts`. This file maps official Stacks.js docs to scaffold patterns.
+
+**Full reference index:** [stacks-docs-index.md](stacks-docs-index.md) · [Stacks.js overview](https://docs.stacks.co/stacks.js/overview.md)
+
+## Packages in scaffold projects
+
+| Package | Role in scaffold |
+|---------|------------------|
+| `@stacks/connect` | Wallet connect + `request('stx_callContract', …)` on testnet/mainnet |
+| `@stacks/transactions` | `Cl.*` args, `fetchCallReadOnlyFunction`, `cvToValue`, post-conditions |
+| `@stacks/network` | `createNetwork`, Hiro API key — see `scaffold.config.ts` |
+
+Devnet **does not** use Connect for writes — see [frontend.md](frontend.md) (`lib/devnet.ts` burners).
+
+## Stacks Connect (wallet)
+
+| Task | Doc |
+|------|-----|
+| Connect wallet | [Connect Wallet](https://docs.stacks.co/stacks-connect/connect-wallet.md) |
+| Authentication (SIWE-style) | [Authentication](https://docs.stacks.co/get-started/build-a-frontend/authentication.md) |
+| Call contract via wallet | [Broadcast Transactions](https://docs.stacks.co/stacks-connect/broadcast-transactions.md) |
+| Send transactions (guide) | [Sending Transactions](https://docs.stacks.co/get-started/build-a-frontend/sending-transactions.md) |
+| `stx_callContract` | [stx_callContract](https://docs.stacks.co/reference/stacks.js/stacks-connect/methods/stx_callcontract.md) |
+| Message signing | [Message Signing](https://docs.stacks.co/stacks-connect/message-signing.md) |
+| Wallet support matrix | [Wallet Support](https://docs.stacks.co/stacks-connect/wallet-support.md) |
+| v7 → v8 migration | [Migration Guide](https://docs.stacks.co/stacks-connect/migration-guide.md) |
+
+Scaffold template: `frontend/src/components/WalletConnect.tsx`, `store/wallet.ts`.
+
+Generated public calls (testnet/mainnet):
+
+```typescript
+import { request } from '@stacks/connect';
+
+await request('stx_callContract', {
+  contract: `${address}.${contractName}`,
+  functionName: 'increment',
+  functionArgs: [], // ClarityValue[]
+  postConditions: [],
+  postConditionMode: 'allow',
+  network: scaffoldConfig.targetNetwork,
+});
+```
+
+## Read-only calls
+
+| Task | Doc |
+|------|-----|
+| Read-only calls guide | [Read Only Calls](https://docs.stacks.co/stacks.js/read-only-calls.md) |
+| `fetchCallReadOnlyFunction` | [fetchCallReadOnlyFunction](https://docs.stacks.co/reference/stacks.js/stacks-transactions/network/fetchcallreadonlyfunction.md) |
+| Decode results | [cvToValue](https://docs.stacks.co/reference/stacks.js/stacks-transactions/utilities/cvtovalue.md) · [cvToJSON](https://docs.stacks.co/reference/stacks.js/stacks-transactions/utilities/cvtojson.md) |
+
+Scaffold generated read-only functions use `cvToValue` — hook `data` shapes are documented in [frontend.md](frontend.md) (do not `BigInt(hook.data)` blindly).
+
+## Building Clarity values (`Cl.*`)
+
+| Task | Doc |
+|------|-----|
+| Encoding & decoding | [Encoding & Decoding](https://docs.stacks.co/stacks.js/encoding-and-decoding.md) |
+| Clarity values reference | [Clarity Values](https://docs.stacks.co/reference/stacks.js/stacks-transactions/clarity-values.md) |
+
+Common in scaffold hooks:
+
+```typescript
+import { Cl } from '@stacks/transactions';
+
+Cl.uint(100)
+Cl.int(-1)
+Cl.principal('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM')
+Cl.standardPrincipal(address)
+Cl.contractPrincipal('SP…', 'contract-name')
+Cl.none()
+Cl.some(Cl.uint(1))
+Cl.tuple({ 'field': Cl.uint(1) })
+Cl.list([Cl.uint(1), Cl.uint(2)])
+```
+
+## Post-conditions
+
+Post-conditions protect users from unexpected token/STX transfers during contract calls.
+
+| Task | Doc |
+|------|-----|
+| Concept | [Post-Conditions Overview](https://docs.stacks.co/post-conditions/overview.md) |
+| Implementation | [Implementation](https://docs.stacks.co/post-conditions/implementation.md) |
+| Examples | [Examples](https://docs.stacks.co/post-conditions/examples.md) |
+| Frontend guide | [Post-Conditions (frontend)](https://docs.stacks.co/get-started/build-a-frontend/post-conditions.md) |
+| `Pc` builder API | [Post Conditions](https://docs.stacks.co/reference/stacks.js/stacks-transactions/post-conditions.md) |
+| Cookbook: FT PC | [Build an ft pc](https://docs.stacks.co/cookbook/stacks.js/cryptography-and-security/build-an-ft-pc.md) |
+
+Scaffold **hooks** default to `postConditionMode: 'allow'` with empty post-conditions. For explicit PCs, call **`contracts.ts` directly** — see [frontend.md](frontend.md).
+
+```typescript
+import { Pc, PostConditionMode } from '@stacks/transactions';
+import { myToken_transfer } from '@/generated/contracts';
+
+await myToken_transfer(
+  [Cl.uint(100), Cl.principal(sender), Cl.principal(recipient), Cl.none()],
+  [Pc.principal(sender).willSendLte(100).ft('ST….token', 'my-token')],
+);
+```
+
+## Networks & Hiro API
+
+| Task | Doc |
+|------|-----|
+| Networks | [Networks](https://docs.stacks.co/stacks.js/networks.md) |
+| Network configuration | [Network Configuration](https://docs.stacks.co/stacks.js/network-configuration.md) |
+| `@stacks/network` ref | [stacks-network](https://docs.stacks.co/reference/stacks.js/stacks-network.md) |
+
+Scaffold: `frontend/src/scaffold.config.ts` — `getReadOnlyNetwork()`, optional `NEXT_PUBLIC_HIRO_API_KEY`.
+
+Default node URLs:
+
+| Network | URL |
+|---------|-----|
+| Testnet | `https://api.testnet.hiro.so` |
+| Mainnet | `https://api.hiro.so` |
+| Devnet | `http://localhost:3999` |
+
+## Contract deploy & calls (low-level)
+
+| Task | Doc |
+|------|-----|
+| Build transactions | [Build Transactions](https://docs.stacks.co/stacks.js/build-transactions.md) |
+| Contract calls | [Contract Calls](https://docs.stacks.co/stacks.js/contract-calls.md) |
+| Contract deployment | [Contract Deployment](https://docs.stacks.co/stacks.js/contract-deployment.md) |
+| `broadcastTransaction` | [broadcastTransaction](https://docs.stacks.co/reference/stacks.js/stacks-transactions/network/broadcasttransaction.md) |
+
+Prefer **`stacksdapp deploy`** for contracts; use Stacks.js deploy only for custom tooling.
+
+## SIP-010 / SIP-009 via Connect
+
+| Task | Doc |
+|------|-----|
+| Transfer SIP-010 FT | [stx_transferSip10Ft](https://docs.stacks.co/reference/stacks.js/stacks-connect/methods/stx_transfersip10ft.md) |
+| Transfer SIP-009 NFT | [stx_transferSip9Nft](https://docs.stacks.co/reference/stacks.js/stacks-connect/methods/stx_transfersip9nft.md) |
+| Cookbook: SIP-010 transfer | [Transfer a SIP10 token](https://docs.stacks.co/cookbook/stacks.js/token-transfers/transfer-a-sip10-token.md) |
+
+Scaffold projects usually use **generated hooks** wrapping contract `transfer` — see [sip-standards.md](sip-standards.md).
+
+## Agent rules
+
+- Prefer generated `hooks.ts` / `contracts.ts` over reimplementing Stacks.js in app code
+- Match `scaffoldConfig.network` / wallet network / `deployments.json` chain (ST vs SP)
+- For API details not listed here, fetch [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) or use `?ask=` on the relevant `.md` page
+- Clarity-side work: [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,47 @@
-# Scaffold Stacks — AI agent guide (CLI repo)
+# Scaffold Stacks — AI agent guide
 
-This repository builds the `stacksdapp` CLI. When helping users **build dApps**, read the bundled skill template — the same files installed into every scaffolded project.
+This project was scaffolded with [Scaffold Stacks](https://scaffoldstacks.mintlify.app/). Use the bundled agent skill for all Stacks dApp work.
 
-## Skill source (edit here)
+## Skill location
 
-```
-crates/scaffold/agent-skill-template/
-├── AGENTS.md
-└── .cursor/skills/scaffold-stacks/
-    ├── SKILL.md
-    ├── frontend.md
-    ├── clarity-language.md
-    ├── sip-standards.md
-    ├── cli-reference.md
-    ├── project-layout.md
-    ├── clarity-versions.md
-    ├── workflows.md
-    └── troubleshooting.md
-```
+**Cursor:** `.cursor/skills/scaffold-stacks/SKILL.md` (auto-discovered; no setup required)
 
-Changes here are copied into projects by `stacksdapp new`, `stacksdapp init`, and `stacksdapp upgrade`.
+**Other agents (Claude Code, Codex, etc.):** Read `.cursor/skills/scaffold-stacks/SKILL.md` first, then reference files in that directory as needed.
 
-After editing, sync the CLI repo Cursor copy:
+## Quick commands
+
+Run from project root (or any subdirectory — CLI walks up to `stacksdapp.toml` or `contracts/Clarinet.toml`):
 
 ```bash
-cp crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/*.md .cursor/skills/scaffold-stacks/
+stacksdapp doctor          # verify Rust, Node, Clarinet, Docker
+stacksdapp check           # type-check Clarity
+stacksdapp generate        # regenerate TypeScript bindings
+stacksdapp test            # contract + frontend tests
+stacksdapp deploy --network testnet --yes
+stacksdapp dev --network testnet
 ```
 
-## Working on this repo
+## Default workflow
 
-```bash
-cargo build -p stacksdapp
-cargo test --all
-bash scripts/ci-smoke.sh
-```
+1. Edit `contracts/contracts/*.clar`
+2. `stacksdapp check && stacksdapp generate && stacksdapp test`
+3. Deploy to **testnet** first (no Docker): `stacksdapp deploy --network testnet --yes`
+4. `stacksdapp dev --network testnet`
 
-## Working on a scaffolded dApp
+## Documentation
 
-Read `.cursor/skills/scaffold-stacks/SKILL.md` (or the template above). For React/hooks/wallet work, see `frontend.md`.
+- **Scaffold guides:** https://scaffoldstacks.mintlify.app/
+- **Scaffold docs index:** https://scaffoldstacks.mintlify.app/llms.txt
+- **Stacks official docs index:** https://docs.stacks.co/llms.txt — section map in `.cursor/skills/scaffold-stacks/stacks-docs-index.md`
+- Clarity language: `.cursor/skills/scaffold-stacks/clarity-language.md`
+- SIP-010 / SIP-009: `.cursor/skills/scaffold-stacks/sip-standards.md`
+- Stacks.js / Connect: `.cursor/skills/scaffold-stacks/stacks-js.md`
 
-Docs: https://scaffoldstacks.mintlify.app/ · Index: https://scaffoldstacks.mintlify.app/llms.txt
+## Frontend
+
+Generated hooks live in `frontend/src/generated/hooks.ts`. See `.cursor/skills/scaffold-stacks/frontend.md` for wallet vs devnet signing, hook usage, and custom UI patterns.
+
+## Never edit by hand
+
+- `frontend/src/generated/*` — run `stacksdapp generate`
+- Do not commit real mnemonics in `contracts/settings/Testnet.toml` or `Mainnet.toml`

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,4 +1,4 @@
-//! Stable CLI exit codes for scripting (Foundry-style distinguishability).
+//! Stable CLI exit codes for scripting ( -style distinguishability).
 //!
 //! | Code | Meaning |
 //! |------|---------|

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -363,7 +363,7 @@ fn print_completions(shell: Shell) -> Result<()> {
     }
 }
 
-/// Foundry-style root discovery: chdir into the project before path-relative commands.
+///  -style root discovery: chdir into the project before path-relative commands.
 fn enter_project_context(cli: &Cli) -> Result<()> {
     use std::env;
 

--- a/crates/deployer/src/ui.rs
+++ b/crates/deployer/src/ui.rs
@@ -1,4 +1,4 @@
-//! Clean Foundry-style deploy terminal UI.
+//! Clean  -style deploy terminal UI.
 
 use colored::Colorize;
 use std::io::{self, Write};

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/SKILL.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/SKILL.md
@@ -22,7 +22,7 @@ Scaffold Stacks = **Rust CLI** (`stacksdapp`) + **monorepo** (Clarity + Next.js)
 - User asks about Clarity + frontend integration on Stacks
 - User asks about SIP-010, SIP-009, or Clarity language syntax
 
-**Deep language / spec detail:** [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md) · [Stacks docs](https://docs.stacks.co/llms.txt)
+**Deep language / spec detail:** [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md) · [stacks-docs-index.md](stacks-docs-index.md) · [Stacks docs llms.txt](https://docs.stacks.co/llms.txt)
 
 ## Project root
 
@@ -103,6 +103,7 @@ Details: [clarity-versions.md](clarity-versions.md)
 - Use `--yes` for non-interactive deploys
 - Prefer **testnet** for deploy CI and first-time verification
 - Warn before committing mnemonics; devnet seeds in template are **public burners**
+- For Stacks topics not in this skill, **fetch** [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) or use `?ask=` on a doc page — see [stacks-docs-index.md](stacks-docs-index.md)
 
 ### Do not
 
@@ -210,6 +211,8 @@ stacksdapp dev --network mainnet
 
 ## Additional resources
 
+### Scaffold Stacks (local)
+
 - [frontend.md](frontend.md) — hooks, wallet, devnet signing, custom UI
 - [clarity-language.md](clarity-language.md) — Clarity cheat sheet + Stacks learning links
 - [sip-standards.md](sip-standards.md) — SIP-010/009 specs + scaffold templates
@@ -218,3 +221,9 @@ stacksdapp dev --network mainnet
 - [clarity-versions.md](clarity-versions.md) — C4/C5/C6 migration
 - [troubleshooting.md](troubleshooting.md) — doctor, Docker, deploy errors
 - [project-layout.md](project-layout.md) — directories and env vars
+
+### Official Stacks docs (fetch when needed)
+
+- [stacks-docs-index.md](stacks-docs-index.md) — **start here** for [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) section map + fetch workflow
+- [stacks-js.md](stacks-js.md) — Connect, transactions, post-conditions, read-only calls
+- [stacks-clarinet-docs.md](stacks-clarinet-docs.md) — Clarinet testing, deployment, Rendezvous

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/clarity-language.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/clarity-language.md
@@ -11,11 +11,11 @@ Scaffold Stacks handles deploy, bindings, and frontend — **you still write Cla
 | Interactive course | [Clarity Universe](https://clarity-lang.org/universe) |
 | Browser REPL | [Clarity Playground](https://play.stackslabs.com/) |
 | Function/type reference | [Clarity Reference](https://docs.stacks.co/reference/clarity/functions.md) |
-| Full docs index | [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) |
+| Full docs index | [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) — see [stacks-docs-index.md](stacks-docs-index.md) for section map + fetch workflow |
 | Language spec (SIP-002) | [SIP-002 Smart Contract Language](https://github.com/stacksgov/sips/blob/main/sips/sip-002/sip-002-smart-contract-language.md) |
 | Ask docs a question | `GET https://docs.stacks.co/<page>.md?ask=<question>&goal=<goal>` |
 
-**Agent rule:** For Clarity language questions beyond this cheat sheet, fetch Stacks docs — do not invent syntax.
+**Agent rule:** For Clarity language questions beyond this cheat sheet, read [stacks-docs-index.md](stacks-docs-index.md) then fetch Stacks docs — do not invent syntax.
 
 ## Scaffold project workflow (Clarity side)
 

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/frontend.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/frontend.md
@@ -588,6 +588,9 @@ npm test             # vitest (optional frontend tests)
 | Clarity language + learning links | `clarity-language.md` |
 | SIP-010 / SIP-009 specs + templates | `sip-standards.md` |
 | Generated hooks + custom components | `frontend.md` |
+| Stacks.js / Connect / post-conditions | `stacks-js.md` |
+| Clarinet (official docs) | `stacks-clarinet-docs.md` |
+| Full Stacks docs catalog | `stacks-docs-index.md` → [llms.txt](https://docs.stacks.co/llms.txt) |
 | Wallet vs devnet signing | this file |
 | Project directories | `project-layout.md` |
 | Errors / devnet stall | `troubleshooting.md` |

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/stacks-clarinet-docs.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/stacks-clarinet-docs.md
@@ -1,0 +1,116 @@
+# Clarinet — official docs map (beyond stacksdapp CLI)
+
+Scaffold wraps Clarinet via **`stacksdapp check`**, **`test`**, **`deploy`**, and **`dev`**. This file maps **Hiro Clarinet documentation** for when agents need Clarinet features not covered in [cli-reference.md](cli-reference.md).
+
+**Index:** [stacks-docs-index.md](stacks-docs-index.md) · [Clarinet overview](https://docs.stacks.co/clarinet/overview.md)
+
+## stacksdapp vs raw Clarinet
+
+| Goal | Prefer | Clarinet doc (if needed) |
+|------|--------|--------------------------|
+| Type-check | `stacksdapp check` | [Validation and Analysis](https://docs.stacks.co/clarinet/validation-and-analysis.md) |
+| Unit tests | `stacksdapp test` | [Unit Testing](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) |
+| Local chain | `stacksdapp dev` | [Local Blockchain Development](https://docs.stacks.co/clarinet/local-blockchain-development.md) |
+| Deploy testnet/mainnet | `stacksdapp deploy --yes` | [Contract Deployment](https://docs.stacks.co/clarinet/contract-deployment.md) |
+| New project layout | `stacksdapp new` | [Project Structure](https://docs.stacks.co/clarinet/project-structure.md) |
+
+**Agent rule:** Do not tell users to run raw `clarinet devnet start` alongside `stacksdapp dev` — port conflicts. See [troubleshooting.md](troubleshooting.md).
+
+## Version requirements (scaffold defaults)
+
+| Tool | Version | Why |
+|------|---------|-----|
+| **Clarinet** | **3.23+** | Clarity 6 devnet / epoch 4.0 snapshot (burn ≥ 163) |
+| `@stacks/clarinet-sdk` | **3.23.1** | Matches Clarinet in `contracts/package.json` |
+| Default contract | Clarity **6**, epoch **4.0** | See [clarity-versions.md](clarity-versions.md) |
+
+`stacksdapp doctor` warns if Clarinet is below 3.23.
+
+## Testing (Vitest + simnet)
+
+| Topic | Doc |
+|-------|-----|
+| Testing guide | [Unit Testing](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) |
+| SDK reference | [SDK Reference](https://docs.stacks.co/reference/clarinet-js-sdk/sdk-reference.md) |
+| Simnet-only code | [Simnet-only code](https://docs.stacks.co/clarinet/simnet-only-code.md) |
+| Mainnet simulation | [Mainnet Execution Simulation](https://docs.stacks.co/clarinet/mainnet-execution-simulation.md) |
+
+Scaffold test layout:
+
+```
+contracts/tests/*.test.ts    # Vitest + simnet (generated for add --template)
+contracts/vitest.config.ts   # clarinet environment
+```
+
+Example pattern (from generated SIP templates):
+
+```typescript
+import { Cl } from '@stacks/transactions';
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get('deployer')!;
+
+const { result } = simnet.callPublicFn(
+  'my-token',
+  'mint',
+  [Cl.uint(100), Cl.standardPrincipal(deployer)],
+  deployer,
+);
+```
+
+## Validation & analysis
+
+| Topic | Doc |
+|-------|-----|
+| check_checker | [Validation and Analysis](https://docs.stacks.co/clarinet/validation-and-analysis.md) |
+| Formatter | [Clarity Formatter](https://docs.stacks.co/clarinet/clarity-formatter.md) |
+| Contract interaction | [Contract Interaction](https://docs.stacks.co/clarinet/contract-interaction.md) |
+
+Scaffold enables check_checker in `Clarinet.toml` by default.
+
+## Deployment
+
+| Topic | Doc |
+|-------|-----|
+| Deployment guide | [Contract Deployment](https://docs.stacks.co/clarinet/contract-deployment.md) |
+| Clarinet CLI deploy commands | [CLI Reference](https://docs.stacks.co/reference/clarinet/cli-reference.md) |
+
+Scaffold **`stacksdapp deploy`** generates plans, handles testnet broadcast, devnet epoch gating, and auto-versioning — prefer it over manual `clarinet deployments apply` in scaffold projects.
+
+## Devnet & integrations
+
+| Topic | Doc |
+|-------|-----|
+| Local devnet | [Local Blockchain Development](https://docs.stacks.co/clarinet/local-blockchain-development.md) |
+| Stacks.js integration | [Stacks.js Integration](https://docs.stacks.co/clarinet/integrations/stacks.js.md) |
+| sBTC integration | [sBTC Integration](https://docs.stacks.co/clarinet/integrations/sbtc.md) |
+| VSCode extension | [Clarity VSCode Extension](https://docs.stacks.co/clarinet/integrations/clarity-vscode-extension.md) |
+| FAQ | [Clarinet FAQ](https://docs.stacks.co/clarinet/faq.md) |
+
+## Rendezvous (fuzz testing)
+
+Optional advanced testing — not run by default in scaffold.
+
+| Topic | Doc |
+|-------|-----|
+| Overview | [Rendezvous Overview](https://docs.stacks.co/rendezvous/overview.md) |
+| Quickstart | [Rendezvous Quickstart](https://docs.stacks.co/rendezvous/quickstart.md) |
+| CLI reference | [Rendezvous Reference](https://docs.stacks.co/reference/rendezvous/reference.md) |
+
+Add to mature projects after `stacksdapp test` passes.
+
+## Clarity language reference (official)
+
+| Topic | Doc |
+|-------|-----|
+| All functions | [Functions](https://docs.stacks.co/reference/clarity/functions.md) |
+| Types | [Types](https://docs.stacks.co/reference/clarity/types.md) |
+| Keywords | [Keywords](https://docs.stacks.co/reference/clarity/keywords.md) |
+
+Shorter cheat sheet: [clarity-language.md](clarity-language.md)
+
+## Agent rules
+
+- Clarinet **3.23+** for Clarity 6 devnet — see [troubleshooting.md](troubleshooting.md) if devnet stalls
+- C5 contracts need epoch **3.4**, not 4.0 — [clarity-versions.md](clarity-versions.md)
+- For doc gaps, fetch [llms.txt](https://docs.stacks.co/llms.txt) → Clarinet section

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/stacks-docs-index.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/stacks-docs-index.md
@@ -1,0 +1,127 @@
+# Stacks official docs — index & fetch workflow
+
+Scaffold Stacks skill files cover **CLI, project layout, frontend hooks, SIP templates, and troubleshooting**. For everything else on Stacks, use the **official docs index** — same catalog as [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt).
+
+## Agent workflow (required when docs are not in this skill)
+
+1. **Check local skill first** — [SKILL.md](SKILL.md), [frontend.md](frontend.md), [clarity-language.md](clarity-language.md), [sip-standards.md](sip-standards.md), [stacks-js.md](stacks-js.md), [stacks-clarinet-docs.md](stacks-clarinet-docs.md)
+2. **If not covered** — fetch the index: `https://docs.stacks.co/llms.txt`
+3. **Open the matching `.md` URL** from the index (append `.md` to doc paths)
+4. **Or ask GitBook directly:**
+
+```http
+GET https://docs.stacks.co/<path-to-page>.md?ask=<specific question>&goal=<what you are building>
+```
+
+Example:
+
+```http
+GET https://docs.stacks.co/stacks.js/read-only-calls.md?ask=How do I decode fetchCallReadOnlyFunction results?&goal=Fix frontend balance display in a scaffold project
+```
+
+**Never invent Clarity syntax, SIP trait addresses, or Stacks.js APIs** — fetch or use `?ask=`.
+
+## Two doc indexes (do not confuse)
+
+| Index | URL | Use for |
+|-------|-----|---------|
+| **Scaffold Stacks** | https://scaffoldstacks.mintlify.app/llms.txt | `stacksdapp` CLI, this template, deploy workflows |
+| **Stacks (Hiro)** | https://docs.stacks.co/llms.txt | Clarity, Clarinet, Stacks.js, sBTC, APIs, PoX |
+
+## Section map (docs.stacks.co/llms.txt)
+
+Curated entry points per section. For the full link list, fetch `llms.txt`.
+
+### Learn — concepts & network
+
+| Topic | Doc |
+|-------|-----|
+| What is Stacks / Bitcoin L2 | [Stacks 101](https://docs.stacks.co/learn/stacks-101/what-is-stacks.md) |
+| Mainnet vs testnet | [Mainnet and Testnets](https://docs.stacks.co/learn/network-fundamentals/mainnet-and-testnets.md) |
+| Wallets & accounts | [Wallets & Accounts](https://docs.stacks.co/learn/network-fundamentals/wallets-and-accounts.md) |
+| How transactions work | [How Transactions Work](https://docs.stacks.co/learn/transactions/how-transactions-work.md) |
+| Post-conditions (concept) | [Post Conditions](https://docs.stacks.co/learn/transactions/post-conditions.md) |
+| Clarity overview | [Clarity](https://docs.stacks.co/learn/clarity.md) |
+| SIPs list | [SIPs](https://docs.stacks.co/learn/network-fundamentals/sips.md) |
+| Nakamoto / block production | [What was the Nakamoto Upgrade?](https://docs.stacks.co/learn/block-production/what-was-the-nakamoto-upgrade.md) |
+| sBTC overview | [sBTC](https://docs.stacks.co/learn/sbtc.md) |
+| Bridging / USDCx | [Bridging](https://docs.stacks.co/learn/bridging.md) |
+
+### Build — dApp development (beyond scaffold CLI)
+
+| Topic | Doc | Local skill |
+|-------|-----|-------------|
+| Developer quickstart | [Developer Quickstart](https://docs.stacks.co/get-started/developer-quickstart.md) | [workflows.md](workflows.md) |
+| Clarity crash course | [Clarity Crash Course](https://docs.stacks.co/get-started/clarity-crash-course.md) | [clarity-language.md](clarity-language.md) |
+| Fungible tokens | [Fungible Tokens](https://docs.stacks.co/get-started/create-a-token/fungible-tokens.md) | [sip-standards.md](sip-standards.md) |
+| NFTs | [Non-Fungible Tokens](https://docs.stacks.co/get-started/create-a-token/non-fungible-tokens.md) | [sip-standards.md](sip-standards.md) |
+| Semi-fungible tokens | [Semi-Fungible Tokens](https://docs.stacks.co/get-started/create-a-token/semi-fungible-tokens.md) | — |
+| Frontend / auth / txs | [Build a Frontend](https://docs.stacks.co/get-started/build-a-frontend.md) | [frontend.md](frontend.md) |
+| Wallet authentication | [Authentication](https://docs.stacks.co/get-started/build-a-frontend/authentication.md) | [stacks-js.md](stacks-js.md) |
+| Sending transactions (frontend) | [Sending Transactions](https://docs.stacks.co/get-started/build-a-frontend/sending-transactions.md) | [stacks-js.md](stacks-js.md) |
+| Use cases (DeFi, gaming, etc.) | [Use Cases](https://docs.stacks.co/get-started/use-cases.md) | fetch on demand |
+| Post-conditions (frontend) | [Post-Conditions](https://docs.stacks.co/get-started/build-a-frontend/post-conditions.md) | [stacks-js.md](stacks-js.md) |
+| Path to production | [Path to Production](https://docs.stacks.co/get-started/path-to-production.md) | [troubleshooting.md](troubleshooting.md) |
+| Clarinet overview | [Clarinet Overview](https://docs.stacks.co/clarinet/overview.md) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| Clarinet testing | [Unit Testing](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk.md) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| Clarinet deploy | [Contract Deployment](https://docs.stacks.co/clarinet/contract-deployment.md) | [cli-reference.md](cli-reference.md) |
+| Rendezvous fuzzing | [Rendezvous Overview](https://docs.stacks.co/rendezvous/overview.md) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| Stacks.js overview | [Stacks.js Overview](https://docs.stacks.co/stacks.js/overview.md) | [stacks-js.md](stacks-js.md) |
+| Stacks Connect | [Connect Wallet](https://docs.stacks.co/stacks-connect/connect-wallet.md) | [frontend.md](frontend.md) |
+| Post-conditions guide | [Post-Conditions Overview](https://docs.stacks.co/post-conditions/overview.md) | [stacks-js.md](stacks-js.md) |
+| sBTC builder guide | [sBTC Builder Quickstart](https://docs.stacks.co/more-guides/sbtc/sbtc-builder-quickstart.md) | fetch on demand |
+| Price oracles (Pyth/DIA) | [Price Oracles](https://docs.stacks.co/more-guides/price-oracles.md) | fetch on demand |
+| Verify BTC txs in Clarity | [Verify Bitcoin Transactions in Clarity](https://docs.stacks.co/more-guides/verify-bitcoin-transactions-clarity.md) | fetch on demand |
+| USDCx bridging | [Bridging USDCx](https://docs.stacks.co/more-guides/bridging-usdcx.md) | fetch on demand |
+| c32 address encoding | [c32check](https://docs.stacks.co/more-guides/c32check.md) | fetch on demand |
+| Embedded wallets (Turnkey) | [Signing with Turnkey](https://docs.stacks.co/more-guides/onboarding/signing-with-turnkey.md) | fetch on demand |
+| Devtools catalog | [Stacks Devtools Catalog](https://docs.stacks.co/stacks-devtools-catalog.md) | — |
+
+### Operate — nodes, signers (usually not scaffold dApp work)
+
+| Topic | Doc |
+|-------|-----|
+| Run a node | [Run a Node](https://docs.stacks.co/operate/run-a-node.md) |
+| Run a signer | [Run a Signer](https://docs.stacks.co/operate/run-a-signer.md) |
+| PoX-5 upgrade | [PoX-5 Upgrade Guide](https://docs.stacks.co/operate/run-a-signer/pox-5-upgrade-guide.md) |
+| Staking STX | [Staking STX](https://docs.stacks.co/operate/staking-stx.md) |
+
+Scaffold **devnet** uses Clarinet Docker — not a production node. Prefer **testnet** for deploy verification.
+
+### Reference — APIs & language spec
+
+| Topic | Doc |
+|-------|-----|
+| Clarity functions | [Functions](https://docs.stacks.co/reference/clarity/functions.md) |
+| Clarity types | [Types](https://docs.stacks.co/reference/clarity/types.md) |
+| Clarity keywords | [Keywords](https://docs.stacks.co/reference/clarity/keywords.md) |
+| Stacks Blockchain API | [Stacks Blockchain API](https://docs.stacks.co/reference/api/stacks-blockchain-api.md) |
+| Node RPC | [Stacks Node RPC](https://docs.stacks.co/reference/api/stacks-node-rpc.md) |
+| `@stacks/transactions` | [Reference](https://docs.stacks.co/reference/stacks.js/stacks-transactions.md) |
+| `@stacks/connect` | [Reference](https://docs.stacks.co/reference/stacks.js/stacks-connect.md) |
+| `cvToValue` / `cvToJSON` | [cvToValue](https://docs.stacks.co/reference/stacks.js/stacks-transactions/utilities/cvtovalue.md) |
+| Clarinet CLI ref | [CLI Reference](https://docs.stacks.co/reference/clarinet/cli-reference.md) |
+| Clarinet SDK ref | [SDK Reference](https://docs.stacks.co/reference/clarinet-js-sdk/sdk-reference.md) |
+
+### Tutorials & Cookbook
+
+| Topic | Doc |
+|-------|-----|
+| Tutorials hub | [Welcome to Tutorials](https://docs.stacks.co/tutorials/readme.md) |
+| Full-stack primer | [Getting Started with Stacks](https://docs.stacks.co/tutorials/bitcoin-primer/getting-started-with-stacks.md) |
+| Cookbook hub | [Welcome to the Cookbook](https://docs.stacks.co/cookbook/readme.md) |
+| SIP-010 transfer (JS) | [Transfer a SIP10 token](https://docs.stacks.co/cookbook/stacks.js/token-transfers/transfer-a-sip10-token.md) |
+| Example Clarity contracts | [Example Contracts](https://docs.stacks.co/cookbook/clarity/example-contracts.md) |
+| Post-condition recipes | [Build an ft pc](https://docs.stacks.co/cookbook/stacks.js/cryptography-and-security/build-an-ft-pc.md) |
+
+## When to fetch vs use local skill
+
+| Question type | Start here |
+|---------------|------------|
+| `stacksdapp` command, exit code, deploy | [SKILL.md](SKILL.md) · [cli-reference.md](cli-reference.md) |
+| Generated hooks, wallet, `Failed to fetch` | [frontend.md](frontend.md) |
+| SIP-010/009 templates, `impl-trait` | [sip-standards.md](sip-standards.md) |
+| Clarity syntax cheat sheet | [clarity-language.md](clarity-language.md) |
+| Stacks.js / Connect / post-conditions code | [stacks-js.md](stacks-js.md) |
+| Clarinet features (not stacksdapp CLI) | [stacks-clarinet-docs.md](stacks-clarinet-docs.md) |
+| sBTC, oracles, node ops, anything else | **Fetch** [llms.txt](https://docs.stacks.co/llms.txt) → open page → or `?ask=` |

--- a/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/stacks-js.md
+++ b/crates/scaffold/agent-skill-template/.cursor/skills/scaffold-stacks/stacks-js.md
@@ -1,0 +1,149 @@
+# Stacks.js — Connect, transactions & post-conditions
+
+Scaffold frontend uses **`@stacks/connect` v8**, **`@stacks/transactions` v7**, **`@stacks/network` v7**. Generated code lives in `frontend/src/generated/contracts.ts` and `hooks.ts`. This file maps official Stacks.js docs to scaffold patterns.
+
+**Full reference index:** [stacks-docs-index.md](stacks-docs-index.md) · [Stacks.js overview](https://docs.stacks.co/stacks.js/overview.md)
+
+## Packages in scaffold projects
+
+| Package | Role in scaffold |
+|---------|------------------|
+| `@stacks/connect` | Wallet connect + `request('stx_callContract', …)` on testnet/mainnet |
+| `@stacks/transactions` | `Cl.*` args, `fetchCallReadOnlyFunction`, `cvToValue`, post-conditions |
+| `@stacks/network` | `createNetwork`, Hiro API key — see `scaffold.config.ts` |
+
+Devnet **does not** use Connect for writes — see [frontend.md](frontend.md) (`lib/devnet.ts` burners).
+
+## Stacks Connect (wallet)
+
+| Task | Doc |
+|------|-----|
+| Connect wallet | [Connect Wallet](https://docs.stacks.co/stacks-connect/connect-wallet.md) |
+| Authentication (SIWE-style) | [Authentication](https://docs.stacks.co/get-started/build-a-frontend/authentication.md) |
+| Call contract via wallet | [Broadcast Transactions](https://docs.stacks.co/stacks-connect/broadcast-transactions.md) |
+| Send transactions (guide) | [Sending Transactions](https://docs.stacks.co/get-started/build-a-frontend/sending-transactions.md) |
+| `stx_callContract` | [stx_callContract](https://docs.stacks.co/reference/stacks.js/stacks-connect/methods/stx_callcontract.md) |
+| Message signing | [Message Signing](https://docs.stacks.co/stacks-connect/message-signing.md) |
+| Wallet support matrix | [Wallet Support](https://docs.stacks.co/stacks-connect/wallet-support.md) |
+| v7 → v8 migration | [Migration Guide](https://docs.stacks.co/stacks-connect/migration-guide.md) |
+
+Scaffold template: `frontend/src/components/WalletConnect.tsx`, `store/wallet.ts`.
+
+Generated public calls (testnet/mainnet):
+
+```typescript
+import { request } from '@stacks/connect';
+
+await request('stx_callContract', {
+  contract: `${address}.${contractName}`,
+  functionName: 'increment',
+  functionArgs: [], // ClarityValue[]
+  postConditions: [],
+  postConditionMode: 'allow',
+  network: scaffoldConfig.targetNetwork,
+});
+```
+
+## Read-only calls
+
+| Task | Doc |
+|------|-----|
+| Read-only calls guide | [Read Only Calls](https://docs.stacks.co/stacks.js/read-only-calls.md) |
+| `fetchCallReadOnlyFunction` | [fetchCallReadOnlyFunction](https://docs.stacks.co/reference/stacks.js/stacks-transactions/network/fetchcallreadonlyfunction.md) |
+| Decode results | [cvToValue](https://docs.stacks.co/reference/stacks.js/stacks-transactions/utilities/cvtovalue.md) · [cvToJSON](https://docs.stacks.co/reference/stacks.js/stacks-transactions/utilities/cvtojson.md) |
+
+Scaffold generated read-only functions use `cvToValue` — hook `data` shapes are documented in [frontend.md](frontend.md) (do not `BigInt(hook.data)` blindly).
+
+## Building Clarity values (`Cl.*`)
+
+| Task | Doc |
+|------|-----|
+| Encoding & decoding | [Encoding & Decoding](https://docs.stacks.co/stacks.js/encoding-and-decoding.md) |
+| Clarity values reference | [Clarity Values](https://docs.stacks.co/reference/stacks.js/stacks-transactions/clarity-values.md) |
+
+Common in scaffold hooks:
+
+```typescript
+import { Cl } from '@stacks/transactions';
+
+Cl.uint(100)
+Cl.int(-1)
+Cl.principal('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM')
+Cl.standardPrincipal(address)
+Cl.contractPrincipal('SP…', 'contract-name')
+Cl.none()
+Cl.some(Cl.uint(1))
+Cl.tuple({ 'field': Cl.uint(1) })
+Cl.list([Cl.uint(1), Cl.uint(2)])
+```
+
+## Post-conditions
+
+Post-conditions protect users from unexpected token/STX transfers during contract calls.
+
+| Task | Doc |
+|------|-----|
+| Concept | [Post-Conditions Overview](https://docs.stacks.co/post-conditions/overview.md) |
+| Implementation | [Implementation](https://docs.stacks.co/post-conditions/implementation.md) |
+| Examples | [Examples](https://docs.stacks.co/post-conditions/examples.md) |
+| Frontend guide | [Post-Conditions (frontend)](https://docs.stacks.co/get-started/build-a-frontend/post-conditions.md) |
+| `Pc` builder API | [Post Conditions](https://docs.stacks.co/reference/stacks.js/stacks-transactions/post-conditions.md) |
+| Cookbook: FT PC | [Build an ft pc](https://docs.stacks.co/cookbook/stacks.js/cryptography-and-security/build-an-ft-pc.md) |
+
+Scaffold **hooks** default to `postConditionMode: 'allow'` with empty post-conditions. For explicit PCs, call **`contracts.ts` directly** — see [frontend.md](frontend.md).
+
+```typescript
+import { Pc, PostConditionMode } from '@stacks/transactions';
+import { myToken_transfer } from '@/generated/contracts';
+
+await myToken_transfer(
+  [Cl.uint(100), Cl.principal(sender), Cl.principal(recipient), Cl.none()],
+  [Pc.principal(sender).willSendLte(100).ft('ST….token', 'my-token')],
+);
+```
+
+## Networks & Hiro API
+
+| Task | Doc |
+|------|-----|
+| Networks | [Networks](https://docs.stacks.co/stacks.js/networks.md) |
+| Network configuration | [Network Configuration](https://docs.stacks.co/stacks.js/network-configuration.md) |
+| `@stacks/network` ref | [stacks-network](https://docs.stacks.co/reference/stacks.js/stacks-network.md) |
+
+Scaffold: `frontend/src/scaffold.config.ts` — `getReadOnlyNetwork()`, optional `NEXT_PUBLIC_HIRO_API_KEY`.
+
+Default node URLs:
+
+| Network | URL |
+|---------|-----|
+| Testnet | `https://api.testnet.hiro.so` |
+| Mainnet | `https://api.hiro.so` |
+| Devnet | `http://localhost:3999` |
+
+## Contract deploy & calls (low-level)
+
+| Task | Doc |
+|------|-----|
+| Build transactions | [Build Transactions](https://docs.stacks.co/stacks.js/build-transactions.md) |
+| Contract calls | [Contract Calls](https://docs.stacks.co/stacks.js/contract-calls.md) |
+| Contract deployment | [Contract Deployment](https://docs.stacks.co/stacks.js/contract-deployment.md) |
+| `broadcastTransaction` | [broadcastTransaction](https://docs.stacks.co/reference/stacks.js/stacks-transactions/network/broadcasttransaction.md) |
+
+Prefer **`stacksdapp deploy`** for contracts; use Stacks.js deploy only for custom tooling.
+
+## SIP-010 / SIP-009 via Connect
+
+| Task | Doc |
+|------|-----|
+| Transfer SIP-010 FT | [stx_transferSip10Ft](https://docs.stacks.co/reference/stacks.js/stacks-connect/methods/stx_transfersip10ft.md) |
+| Transfer SIP-009 NFT | [stx_transferSip9Nft](https://docs.stacks.co/reference/stacks.js/stacks-connect/methods/stx_transfersip9nft.md) |
+| Cookbook: SIP-010 transfer | [Transfer a SIP10 token](https://docs.stacks.co/cookbook/stacks.js/token-transfers/transfer-a-sip10-token.md) |
+
+Scaffold projects usually use **generated hooks** wrapping contract `transfer` — see [sip-standards.md](sip-standards.md).
+
+## Agent rules
+
+- Prefer generated `hooks.ts` / `contracts.ts` over reimplementing Stacks.js in app code
+- Match `scaffoldConfig.network` / wallet network / `deployments.json` chain (ST vs SP)
+- For API details not listed here, fetch [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt) or use `?ask=` on the relevant `.md` page
+- Clarity-side work: [clarity-language.md](clarity-language.md) · [sip-standards.md](sip-standards.md)

--- a/crates/scaffold/agent-skill-template/AGENTS.md
+++ b/crates/scaffold/agent-skill-template/AGENTS.md
@@ -30,10 +30,12 @@ stacksdapp dev --network testnet
 
 ## Documentation
 
-- Guides: https://scaffoldstacks.mintlify.app/
-- Docs index for agents: https://scaffoldstacks.mintlify.app/llms.txt
+- **Scaffold guides:** https://scaffoldstacks.mintlify.app/
+- **Scaffold docs index:** https://scaffoldstacks.mintlify.app/llms.txt
+- **Stacks official docs index:** https://docs.stacks.co/llms.txt — section map in `.cursor/skills/scaffold-stacks/stacks-docs-index.md`
 - Clarity language: `.cursor/skills/scaffold-stacks/clarity-language.md`
 - SIP-010 / SIP-009: `.cursor/skills/scaffold-stacks/sip-standards.md`
+- Stacks.js / Connect: `.cursor/skills/scaffold-stacks/stacks-js.md`
 
 ## Frontend
 

--- a/crates/scaffold/src/lib.rs
+++ b/crates/scaffold/src/lib.rs
@@ -1737,6 +1737,7 @@ mod agent_skill_tests {
         let content = skill.contents_utf8().expect("utf8");
         assert!(content.contains("name: scaffold-stacks"));
         assert!(content.contains("stacksdapp"));
+        assert!(content.contains("stacks-docs-index.md"));
     }
 
     #[tokio::test]
@@ -1763,6 +1764,18 @@ mod agent_skill_tests {
         assert!(tmp
             .path()
             .join(".cursor/skills/scaffold-stacks/cli-reference.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/stacks-docs-index.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/stacks-js.md")
+            .exists());
+        assert!(tmp
+            .path()
+            .join(".cursor/skills/scaffold-stacks/stacks-clarinet-docs.md")
             .exists());
     }
 }

--- a/crates/shell/src/steps.rs
+++ b/crates/shell/src/steps.rs
@@ -1,4 +1,4 @@
-//! Shared spinner steps and banner chrome for Foundry-style CLI output.
+//! Shared spinner steps and banner chrome for  -style CLI output.
 
 use colored::Colorize;
 use std::io::{self, Write};


### PR DESCRIPTION
## Summary

- Adds three new bundled agent skill reference files sourced from [docs.stacks.co/llms.txt](https://docs.stacks.co/llms.txt): `stacks-docs-index.md` (section map + fetch/`?ask=` workflow), `stacks-js.md` (Connect, transactions, post-conditions), and `stacks-clarinet-docs.md` (official Clarinet/Rendezvous docs beyond `stacksdapp` CLI).
- Wires the new docs into existing skill files (`SKILL.md`, `clarity-language.md`, `frontend.md`, `AGENTS.md`) so agents use local scaffold guidance first and fetch official Stacks docs when a topic isn’t covered.
- Extends `agent_skill_tests` to assert the new files extract correctly on `stacksdapp new` / `upgrade`.
- Minor comment cleanup in CLI/deployer/shell (remove third-party tool name references in module docs).

## Motivation

The bundled `scaffold-stacks` skill covers CLI workflows, frontend hooks, SIP templates, and troubleshooting well, but agents were missing a structured path to official Hiro/Stacks documentation (Clarity reference, Stacks.js API, Clarinet features, sBTC, oracles, etc.). This PR closes that gap without embedding the full 560-line llms.txt — instead using a hub file, curated links, and the GitBook `?ask=` fetch pattern.

## What changed

### New skill files (template + `.cursor/skills/` mirror)

| File | Purpose |
|------|---------|
| `stacks-docs-index.md` | Catalog of docs.stacks.co sections; when to use local skill vs fetch |
| `stacks-js.md` | Connect, read-only calls, `Cl.*`, post-conditions, networks |
| `stacks-clarinet-docs.md` | Clarinet testing, deployment, Rendezvous fuzzing |

### Updated skill files

- **`SKILL.md`** — links new references; rule to fetch llms.txt when not covered locally
- **`clarity-language.md`** — points agents at `stacks-docs-index.md` for full Clarity reference
- **`frontend.md`** — coverage map extended with `stacks-js.md` and docs index
- **`AGENTS.md`** — documents both Scaffold Mintlify index and Stacks official index

### Tests

- `crates/scaffold/src/lib.rs` — `write_agent_skill_files_extracts_to_root` asserts new files exist after install

### Other

- Comment wording cleanup in `cli/src/error.rs`, `cli/src/main.rs`, `crates/deployer/src/ui.rs`, `crates/shell/src/steps.rs`

## Non-breaking

- No changes to `ci-smoke.sh` required-file list (still checks original 4 skill files)
- New files ship via existing `include_dir!` agent-skill-template bundle
- Additive cross-links only — existing skill behavior unchanged